### PR TITLE
Install mimic in dev_setup.sh

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -36,7 +36,8 @@ cd ${TOP}/pocketsphinx-python
 python setup.py install
 
 #build and install mimic
-#./install-mimic.sh
+cd ${TOP}
+${TOP}/install-mimic.sh
 
 # install pygtk for desktop_launcher skill
 ${TOP}/install-pygtk.sh


### PR DESCRIPTION
mimic is currently not installed when running ```dev_setup.sh```, resulting in #21. This PR uncomments the line running ```install-mimic.sh```.

Question is if the line was commented out for a reason or if it should be installed by default.