### PR TITLE
Explicitly install python-setuptools

### DIFF
--- a/build_host_setup.sh
+++ b/build_host_setup.sh
@@ -4,6 +4,7 @@ sudo apt-get install -y \
     git \
     python \
     python-dev \
+    python-setuptools \
     python-virtualenv \
     python-gobject-dev \
     virtualenvwrapper \


### PR DESCRIPTION
Brings in easy_install. Thought this was a dependency of python-virtualenv, but it may not be (virtualenv may vendor this in)

verified this requirement when trying to run build_host_setup.sh on a clean 16.04 vm.