### PR TITLE
Suggestion: default config for skills running in skill container

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -33,7 +33,11 @@ DEFAULTS_FILE = os.path.join(
 ETC_CONFIG_FILE = '/etc/mycroft/mycroft.ini'
 USER_CONFIG_FILE = os.path.join(
     os.path.expanduser('~'), '.mycroft/mycroft.ini')
-DEFAULT_LOCATIONS = [DEFAULTS_FILE, ETC_CONFIG_FILE, USER_CONFIG_FILE]
+
+DEFAULT_LOCATIONS = [DEFAULTS_FILE]
+SYSTEM_LOCATIONS = [ETC_CONFIG_FILE]
+USER_LOCATIONS = [USER_CONFIG_FILE]
+CONFIG_LOCATIONS = DEFAULT_LOCATIONS + SYSTEM_LOCATIONS + USER_LOCATIONS
 
 
 class ConfigurationLoader(object):
@@ -56,7 +60,7 @@ class ConfigurationLoader(object):
     def load(self):
         """
         Loads configuration files from disk, in the locations defined by
-        DEFAULT_LOCATIONS
+        class member config_locations
         """
         config = {}
         for config_file in self.config_locations:
@@ -128,17 +132,20 @@ class ConfigurationManager(object):
     _config = None
 
     @staticmethod
-    def load(*config_files):
+    def load(defaults=CONFIG_LOCATIONS, *config_files):
         """
         Load default config files as well as any additionally specified files.
         Now also loads configuration from Cerberus (if device is paired)
 
+        :param defaults: A list of default files to load, if not included
+                         CONFIG_LOCATIONS will be used.
         :param config_files: An array of config file paths in addition to
-        DEFAULT_LOCATIONS
+                             defaults.
 
         :return: None
         """
-        loader = ConfigurationLoader(DEFAULT_LOCATIONS + list(config_files))
+        loader = ConfigurationLoader(defaults + list(config_files))
+
         ConfigurationManager._config = loader.load()
         RemoteConfiguration().update()
 

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -132,7 +132,7 @@ class ConfigurationManager(object):
     _config = None
 
     @staticmethod
-    def load(defaults=CONFIG_LOCATIONS, *config_files):
+    def load(*config_files, **kwargs):
         """
         Load default config files as well as any additionally specified files.
         Now also loads configuration from Cerberus (if device is paired)
@@ -144,6 +144,13 @@ class ConfigurationManager(object):
 
         :return: None
         """
+        if len(kwargs) > 0 and "defaults" not in kwargs:
+            raise TypeError("load() got an unexpected keyword argument '%s'" %
+                (kwargs.keys()[0]))
+
+        kwargs["defaults"] = kwargs.get("defaults", CONFIG_LOCATIONS)
+        defaults = kwargs["defaults"]
+
         loader = ConfigurationLoader(defaults + list(config_files))
 
         ConfigurationManager._config = loader.load()

--- a/mycroft/skills/container.py
+++ b/mycroft/skills/container.py
@@ -55,7 +55,7 @@ class SkillContainer(object):
         if os.path.exists(parsed_args.default_config):
             configs = DEFAULT_LOCATIONS + [parsed_args.default_config] \
                 + SYSTEM_LOCATIONS + USER_LOCATIONS
-            ConfigurationManager.load(configs)
+            ConfigurationManager.load(defaults=configs)
 
         if os.path.exists(parsed_args.dependency_dir):
             sys.path.append(parsed_args.dependency_dir)

--- a/mycroft/skills/container.py
+++ b/mycroft/skills/container.py
@@ -23,11 +23,8 @@ from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.skills.core import create_skill_descriptor, load_skill
 from mycroft.util.log import getLogger
 from mycroft.configuration.config import ConfigurationManager
+from mycroft.configuration.config import ConfigBuilder
 from mycroft.skills.intent import create_skill as create_intent_skill
-
-from mycroft.configuration.config import DEFAULT_LOCATIONS
-from mycroft.configuration.config import SYSTEM_LOCATIONS
-from mycroft.configuration.config import USER_LOCATIONS
 
 __author__ = 'seanfitz'
 
@@ -53,9 +50,10 @@ class SkillContainer(object):
 
         parsed_args = parser.parse_args(args)
         if os.path.exists(parsed_args.default_config):
-            configs = DEFAULT_LOCATIONS + [parsed_args.default_config] \
-                + SYSTEM_LOCATIONS + USER_LOCATIONS
-            ConfigurationManager.load(defaults=configs)
+            configs = ConfigBuilder() \
+                .base() \
+                .with_default(parsed_args.default_config)
+            ConfigurationManager.load(configs)
 
         if os.path.exists(parsed_args.dependency_dir):
             sys.path.append(parsed_args.dependency_dir)

--- a/mycroft/skills/container.py
+++ b/mycroft/skills/container.py
@@ -25,6 +25,10 @@ from mycroft.util.log import getLogger
 from mycroft.configuration.config import ConfigurationManager
 from mycroft.skills.intent import create_skill as create_intent_skill
 
+from mycroft.configuration.config import DEFAULT_LOCATIONS
+from mycroft.configuration.config import SYSTEM_LOCATIONS
+from mycroft.configuration.config import USER_LOCATIONS
+
 __author__ = 'seanfitz'
 
 logger = getLogger("SkillContainer")
@@ -35,6 +39,7 @@ class SkillContainer(object):
     def __init__(self, args):
         parser = argparse.ArgumentParser()
         parser.add_argument("--dependency-dir", default="./lib")
+        parser.add_argument("--default-config", default="./config/mycroft.ini")
         parser.add_argument(
             "--messagebus-host", default=messagebus_config.get("host"))
         parser.add_argument(
@@ -47,6 +52,11 @@ class SkillContainer(object):
             "skill_directory", default=os.path.dirname(__file__))
 
         parsed_args = parser.parse_args(args)
+        if os.path.exists(parsed_args.default_config):
+            configs = DEFAULT_LOCATIONS + [parsed_args.default_config] \
+                + SYSTEM_LOCATIONS + USER_LOCATIONS
+            ConfigurationManager.load(configs)
+
         if os.path.exists(parsed_args.dependency_dir):
             sys.path.append(parsed_args.dependency_dir)
         sys.path.append(parsed_args.skill_directory)

--- a/test/test_runner.py
+++ b/test/test_runner.py
@@ -1,4 +1,5 @@
 from mycroft.configuration.config import ConfigurationManager
+from mycroft.configuration.config import ConfigBuilder
 
 import unittest
 
@@ -15,7 +16,9 @@ OUTPUT_DIR = os.path.dirname(os.path.dirname(__file__))
 
 loader = unittest.TestLoader()
 fail_on_error = "--fail-on-error" in sys.argv
-ConfigurationManager.load(os.path.join(TEST_DIR, 'config.ini'))
+ConfigurationManager.load(ConfigBuilder()
+                          .base()
+                          .append(os.path.join(TEST_DIR, 'config.ini')))
 tests = loader.discover(TEST_DIR, pattern="*_test*.py")
 runner = XMLTestRunner(output="./build/report/tests")
 result = runner.run(tests)


### PR DESCRIPTION
This is a suggestion for allowing the skills running in the ```mycroft-skill-container``` to use a default.ini file in the same way as the built-in skills. I believe this would be useful for many third-party skills. 

By default the file ```./config/mycroft.ini```will be used but this can be altered by using the command line argument ```--default-config```.