### PR TITLE
Issues 73 - Add 'what does wikipedia say about' to wiki skill vocab

### DIFF
--- a/mycroft/skills/wiki/__init__.py
+++ b/mycroft/skills/wiki/__init__.py
@@ -49,8 +49,7 @@ class WikipediaSkill(MycroftSkill):
         self.load_vocab_files(join(dirname(__file__), 'vocab', 'en-us'))
 
         prefixes = ['wiki', 'wikipedia', 'tell me about', 'tell us about',
-                    'who is', 'who was',
-                    'what does wikipedia say about']  # TODO - i10n
+                   'who is', 'who was']  # TODO - i10n
         self.__register_prefixed_regex(prefixes, "(?P<ArticleTitle>.*)")
 
         intent = IntentBuilder("WikipediaIntent").require(

--- a/mycroft/skills/wiki/__init__.py
+++ b/mycroft/skills/wiki/__init__.py
@@ -49,7 +49,8 @@ class WikipediaSkill(MycroftSkill):
         self.load_vocab_files(join(dirname(__file__), 'vocab', 'en-us'))
 
         prefixes = ['wiki', 'wikipedia', 'tell me about', 'tell us about',
-                    'who is', 'who was', 'what does wikipedia say about']  # TODO - i10n
+                    'who is', 'who was',
+                    'what does wikipedia say about']  # TODO - i10n
         self.__register_prefixed_regex(prefixes, "(?P<ArticleTitle>.*)")
 
         intent = IntentBuilder("WikipediaIntent").require(

--- a/mycroft/skills/wiki/__init__.py
+++ b/mycroft/skills/wiki/__init__.py
@@ -49,7 +49,7 @@ class WikipediaSkill(MycroftSkill):
         self.load_vocab_files(join(dirname(__file__), 'vocab', 'en-us'))
 
         prefixes = ['wiki', 'wikipedia', 'tell me about', 'tell us about',
-                    'who is', 'who was']  # TODO - i10n
+                    'who is', 'who was', 'what does wikipedia say about']  # TODO - i10n
         self.__register_prefixed_regex(prefixes, "(?P<ArticleTitle>.*)")
 
         intent = IntentBuilder("WikipediaIntent").require(

--- a/mycroft/skills/wiki/vocab/en-us/WikipediaKeyword.voc
+++ b/mycroft/skills/wiki/vocab/en-us/WikipediaKeyword.voc
@@ -4,4 +4,3 @@ tell me about
 tell us about
 who is
 who was
-what does wikipedia say about

--- a/mycroft/skills/wiki/vocab/en-us/WikipediaKeyword.voc
+++ b/mycroft/skills/wiki/vocab/en-us/WikipediaKeyword.voc
@@ -4,3 +4,4 @@ tell me about
 tell us about
 who is
 who was
+what does wikipedia say about


### PR DESCRIPTION
I added 'what does wikipedia say about' to both the vocab file for the wiki skill and to prefixes in the __init__.py file for the wiki skill so that it can be used to trigger a wikipedia search.