### PR TITLE
Issues 54 - Pairing code is not displayed when device is unpaired

### DIFF
--- a/mycroft/client/enclosure/enclosure.py
+++ b/mycroft/client/enclosure/enclosure.py
@@ -16,10 +16,11 @@
 # along with Mycroft Core.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import serial
 import sys
 from Queue import Queue
 from threading import Thread
+
+import serial
 
 from mycroft.client.enclosure.arduino import EnclosureArduino
 from mycroft.client.enclosure.eyes import EnclosureEyes
@@ -143,7 +144,7 @@ class Enclosure:
         self.eyes = EnclosureEyes(self.client, self.writer)
         self.mouth = EnclosureMouth(self.client, self.writer)
         self.system = EnclosureArduino(self.client, self.writer)
-        self.__init_events()
+        self.__register_events()
 
     def __init_serial(self):
         try:
@@ -152,20 +153,36 @@ class Enclosure:
             self.rate = int(self.config.get("rate"))
             self.timeout = int(self.config.get("timeout"))
             self.serial = serial.serial_for_url(
-                url=self.port, baudrate=self.rate, timeout=self.timeout)
+                    url=self.port, baudrate=self.rate, timeout=self.timeout)
             LOGGER.info(
-                "Connected to: " + self.port + " rate: " + str(self.rate) +
-                " timeout: " + str(self.timeout))
+                    "Connected to: " + self.port + " rate: " + str(self.rate) +
+                    " timeout: " + str(self.timeout))
         except:
             LOGGER.error(
-                "It is not possible to connect to serial port: " + self.port)
+                    "It is not possible to connect to serial port: " + self.port)
             raise
 
-    def __init_events(self):
+    def __register_events(self):
+        self.client.on('mycroft.paired', self.__update_events)
         self.client.on('recognizer_loop:listening', self.mouth.listen)
         self.client.on('recognizer_loop:audio_output_start', self.mouth.talk)
         self.client.on('recognizer_loop:audio_output_end', self.mouth.reset)
         self.client.on('recognizer_loop:wakeword', self.eyes.blink)
+
+    def __remove_events(self):
+        self.client.remove('recognizer_loop:listening', self.mouth.listen)
+        self.client.remove('recognizer_loop:audio_output_start',
+                           self.mouth.talk)
+        self.client.remove('recognizer_loop:audio_output_end',
+                           self.mouth.reset)
+        self.mouth.reset()
+
+    def __update_events(self, event=None):
+        if event and event.metadata:
+            if event.metadata.get('paired', False):
+                self.__register_events()
+            else:
+                self.__remove_events()
 
     def run(self):
         try:

--- a/mycroft/client/enclosure/enclosure.py
+++ b/mycroft/client/enclosure/enclosure.py
@@ -164,12 +164,15 @@ class Enclosure:
 
     def __register_events(self):
         self.client.on('mycroft.paired', self.__update_events)
+        self.client.on('recognizer_loop:wakeword', self.eyes.blink)
+        self.__register_mouth_events()
+
+    def __register_mouth_events(self):
         self.client.on('recognizer_loop:listening', self.mouth.listen)
         self.client.on('recognizer_loop:audio_output_start', self.mouth.talk)
         self.client.on('recognizer_loop:audio_output_end', self.mouth.reset)
-        self.client.on('recognizer_loop:wakeword', self.eyes.blink)
 
-    def __remove_events(self):
+    def __remove_mouth_events(self):
         self.client.remove('recognizer_loop:listening', self.mouth.listen)
         self.client.remove('recognizer_loop:audio_output_start',
                            self.mouth.talk)
@@ -180,9 +183,9 @@ class Enclosure:
     def __update_events(self, event=None):
         if event and event.metadata:
             if event.metadata.get('paired', False):
-                self.__register_events()
+                self.__register_mouth_events()
             else:
-                self.__remove_events()
+                self.__remove_mouth_events()
 
     def run(self):
         try:

--- a/mycroft/client/enclosure/enclosure.py
+++ b/mycroft/client/enclosure/enclosure.py
@@ -153,13 +153,13 @@ class Enclosure:
             self.rate = int(self.config.get("rate"))
             self.timeout = int(self.config.get("timeout"))
             self.serial = serial.serial_for_url(
-                    url=self.port, baudrate=self.rate, timeout=self.timeout)
+                url=self.port, baudrate=self.rate, timeout=self.timeout)
             LOGGER.info(
-                    "Connected to: " + self.port + " rate: " + str(self.rate) +
-                    " timeout: " + str(self.timeout))
+                "Connected to: " + self.port + " rate: " + str(self.rate) +
+                " timeout: " + str(self.timeout))
         except:
             LOGGER.error(
-                    "It is not possible to connect to serial port: " + self.port)
+                "It is not possible to connect to serial port: " + self.port)
             raise
 
     def __register_events(self):

--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -17,14 +17,15 @@
 
 
 import json
-from multiprocessing.pool import ThreadPool
 import time
-from mycroft.configuration.config import ConfigurationManager
-from mycroft.messagebus.message import Message
-import mycroft.util.log
+from multiprocessing.pool import ThreadPool
+
 from pyee import EventEmitter
 from websocket import WebSocketApp
 
+import mycroft.util.log
+from mycroft.configuration.config import ConfigurationManager
+from mycroft.messagebus.message import Message
 from mycroft.util import str2bool
 
 __author__ = 'seanfitz'
@@ -98,6 +99,9 @@ class WebsocketClient(object):
 
     def once(self, event_name, func):
         self.emitter.once(event_name, func)
+
+    def remove(self, event_name, func):
+        self.emitter.remove_listener(event_name, func)
 
     def run_forever(self):
         self.client.run_forever()

--- a/mycroft/pairing/client.py
+++ b/mycroft/pairing/client.py
@@ -17,6 +17,7 @@
 
 
 import shortuuid
+
 from mycroft.configuration.config import ConfigurationManager
 from mycroft.identity import IdentityManager
 from mycroft.messagebus.client.ws import WebsocketClient
@@ -34,6 +35,7 @@ def generate_pairing_code():
 class DevicePairingClient(object):
     def __init__(self, config=_config, pairing_code=None):
         self.config = config
+        self.paired = False
         self.ws_client = WebsocketClient(host=config.get("host"),
                                          port=config.get("port"),
                                          path=config.get("route"),
@@ -53,6 +55,7 @@ class DevicePairingClient(object):
             identity.owner = register_payload.get('user')
             self.identity_manager.update(identity)
             self.ws_client.close()
+            self.paired = True
 
     def send_device_info(self):
         msg = Message("device_info",
@@ -63,7 +66,8 @@ class DevicePairingClient(object):
 
         self.ws_client.emit(msg)
 
-    def print_error(self, message):
+    @staticmethod
+    def print_error(message):
         print(repr(message))
 
     def run(self):
@@ -75,6 +79,7 @@ class DevicePairingClient(object):
 
 def main():
     DevicePairingClient().run()
+
 
 if __name__ == "__main__":
     main()

--- a/mycroft/skills/pairing/__init__.py
+++ b/mycroft/skills/pairing/__init__.py
@@ -39,6 +39,7 @@ class PairingSkill(MycroftSkill):
 
     def handle_pairing_request(self, message):
         if not self.client:
+            self.displaying = False
             self.__emit_paired(False)
             self.client = DevicePairingClient()
             Thread(target=self.client.run).start()

--- a/mycroft/skills/pairing/__init__.py
+++ b/mycroft/skills/pairing/__init__.py
@@ -30,7 +30,7 @@ class PairingSkill(MycroftSkill):
 
     def initialize(self):
         intent = IntentBuilder("PairingIntent").require(
-            "DevicePairingPhrase").build()
+                "DevicePairingPhrase").build()
         self.load_data_files(dirname(__file__))
         self.register_intent(intent, handler=self.handle_pairing_request)
 
@@ -38,10 +38,10 @@ class PairingSkill(MycroftSkill):
         pairing_client = DevicePairingClient()
         pairing_code = pairing_client.pairing_code
         threading.Thread(target=pairing_client.run).start()
-        self.enclosure.mouth_text("Pairing code is: " + pairing_code)
         self.speak_dialog(
-            "pairing.instructions",
-            data={"pairing_code": ', ,'.join(pairing_code)})
+                "pairing.instructions",
+                data={"pairing_code": ', ,'.join(pairing_code)})
+        self.enclosure.mouth_text("Pairing code is: " + pairing_code)
 
     def stop(self):
         pass

--- a/mycroft/skills/pairing/__init__.py
+++ b/mycroft/skills/pairing/__init__.py
@@ -29,6 +29,7 @@ class PairingSkill(MycroftSkill):
     def __init__(self):
         super(PairingSkill, self).__init__(name="PairingSkill")
         self.client = None
+        self.displaying = False
 
     def initialize(self):
         intent = IntentBuilder("PairingIntent").require(
@@ -54,7 +55,8 @@ class PairingSkill(MycroftSkill):
             self.__emit_paired(True)
             self.emitter.remove("recognizer_loop:audio_output_start",
                                 self.__display_pairing_code)
-        else:
+        elif not self.displaying:
+            self.displaying = True
             self.enclosure.mouth_text(
                     "Pairing code: " + self.client.pairing_code)
 

--- a/mycroft/skills/pairing/__init__.py
+++ b/mycroft/skills/pairing/__init__.py
@@ -58,8 +58,7 @@ class PairingSkill(MycroftSkill):
                                 self.__display_pairing_code)
         elif not self.displaying:
             self.displaying = True
-            self.enclosure.mouth_text(
-                    "Pairing code: " + self.client.pairing_code)
+            self.enclosure.mouth_text(self.client.pairing_code)
 
     def __emit_paired(self, paired):
         msg = Message('mycroft.paired', metadata={'paired': paired})


### PR DESCRIPTION
Issue description: #54 

Test Cases:

1. Unit is not paired and user interact with Mycroft for the first time after starting the services
 - Device must display the pairing code after any user query, except when user says "Mycroft" only. In that case, we'll have a "Go ahead" feedback

2. Unit is not paired and user interact with Mycroft for the second time and on
 - Device must keep the pairing code displayed preventing any other mouth animation

3. Unit is already paired
 - No pairing code must be shown and device perform any other action as expected 