### PR TITLE
Issues 76 - Fix changes to wikipedia skill so that tests pass

### DIFF
--- a/mycroft/skills/wiki/__init__.py
+++ b/mycroft/skills/wiki/__init__.py
@@ -49,7 +49,7 @@ class WikipediaSkill(MycroftSkill):
         self.load_vocab_files(join(dirname(__file__), 'vocab', 'en-us'))
 
         prefixes = ['wiki', 'wikipedia', 'tell me about', 'tell us about',
-                    'who is', 'who was']  # TODO - i10n
+                    'what does wikipedia say about']  # TODO - i10n
         self.__register_prefixed_regex(prefixes, "(?P<ArticleTitle>.*)")
 
         intent = IntentBuilder("WikipediaIntent").require(

--- a/mycroft/skills/wiki/vocab/en-us/WikipediaKeyword.voc
+++ b/mycroft/skills/wiki/vocab/en-us/WikipediaKeyword.voc
@@ -2,5 +2,4 @@ wiki
 wikipedia
 tell me about
 tell us about
-who is
-who was
+what does wikipedia say about


### PR DESCRIPTION
I changed the wikipedia skill so that it triggers on 'what does wikipedia say about'. I also removed 'who is' and 'who was' in the vocab, as those will be handled by Wolfram. This is a new pull request to be handled by Travis.