### PR TITLE
MathSkill

### DIFF
--- a/mycroft/skills/math/__init__.py
+++ b/mycroft/skills/math/__init__.py
@@ -25,7 +25,8 @@ class MathSkill(MycroftSkill):
         self.register_regex('(?P<Value1>\d+)')
         self.register_regex('(?P<Value2>\d+)')
 
-        intent = IntentBuilder("MathIntent").require("Value1").require("MathKeyword").require("Value2").build()
+        intent = IntentBuilder("MathIntent").require(
+            "Value1").require("MathKeyword").require("Value2").build()
         self.register_intent(intent, self.handle_intent)
 
     @staticmethod
@@ -45,9 +46,11 @@ class MathSkill(MycroftSkill):
         operator_func = self.operators[operator_char]
         result = operator_func(first_val, second_val)
 
-        equation_string = self.__to_string(first_val) + ' ' + operator_char + ' ' + self.__to_string(second_val)
+        equation_string = self.__to_string(first_val) + ' ' + operator_char + \
+            ' ' + self.__to_string(second_val)
         answer_string = self.__to_string(result)
-        self.speak_dialog('read.answer', data={'equation':equation_string,'answer':answer_string})
+        self.speak_dialog('read.answer', data={'equation': equation_string,
+                                               'answer': answer_string})
 
     def stop(self):
         pass

--- a/mycroft/skills/math/__init__.py
+++ b/mycroft/skills/math/__init__.py
@@ -1,0 +1,57 @@
+from os.path import dirname
+
+from adapt.intent import IntentBuilder
+from mycroft.skills.core import MycroftSkill
+from mycroft.util.log import getLogger
+import operator
+
+__author__ = 'wolfgange3311999'
+
+LOGGER = getLogger(__name__)
+
+
+class MathSkill(MycroftSkill):
+    def __init__(self):
+        super(MathSkill, self).__init__(name="MathSkill")
+        self.operators = {
+            '+': operator.add,
+            '-': operator.sub,
+            '*': operator.mul,
+            '/': operator.div
+        }
+
+    def initialize(self):
+        self.load_data_files(dirname(__file__))
+        self.register_regex('(?P<Value1>\d+)')
+        self.register_regex('(?P<Value2>\d+)')
+
+        intent = IntentBuilder("MathIntent").require("Value1").require("MathKeyword").require("Value2").build()
+        self.register_intent(intent, self.handle_intent)
+
+    @staticmethod
+    def __to_string(num):
+        """
+        :rtype: string
+        :param num: any float
+        :return: a string representation of num without the trailing .0
+        """
+        return '{0:g}'.format(num)
+
+    def handle_intent(self, message):
+        first_val = float(message.metadata.get('Value1', 0))
+        second_val = float(message.metadata.get('Value2', 0))
+
+        operator_char = message.metadata.get('MathKeyword', 0)
+        operator_func = self.operators[operator_char]
+        result = operator_func(first_val, second_val)
+
+        equation_string = self.__to_string(first_val) + ' ' + operator_char + ' ' + self.__to_string(second_val)
+        answer_string = self.__to_string(result)
+        self.speak_dialog('read.answer', data={'equation':equation_string,'answer':answer_string})
+
+    def stop(self):
+        pass
+
+
+def create_skill():
+    return MathSkill()

--- a/mycroft/skills/math/dialog/en-us/read.answer.dialog
+++ b/mycroft/skills/math/dialog/en-us/read.answer.dialog
@@ -1,0 +1,2 @@
+{{equation}} is {{answer}}
+The answer is {{answer}}

--- a/mycroft/skills/math/test/intent/sample1.intent.json
+++ b/mycroft/skills/math/test/intent/sample1.intent.json
@@ -1,0 +1,9 @@
+{
+  "utterance": "what is 2 plus 3",
+  "intent_type": "MathIntent",
+  "intent": {
+    "Value1": "2",
+    "MathKeyword": "+",
+    "Value2": "3"
+  }
+}

--- a/mycroft/skills/math/test/intent/sample2.intent.json
+++ b/mycroft/skills/math/test/intent/sample2.intent.json
@@ -1,0 +1,9 @@
+{
+  "utterance": "what is 25 minus 7",
+  "intent_type": "MathIntent",
+  "intent": {
+    "Value1": "25",
+    "MathKeyword": "-",
+    "Value2": "7"
+  }
+}

--- a/mycroft/skills/math/test/intent/sample3.intent.json
+++ b/mycroft/skills/math/test/intent/sample3.intent.json
@@ -1,0 +1,9 @@
+{
+  "utterance": "what is 15 times 23",
+  "intent_type": "MathIntent",
+  "intent": {
+    "Value1": "15",
+    "MathKeyword": "*",
+    "Value2": "23"
+  }
+}

--- a/mycroft/skills/math/test/intent/sample4.intent.json
+++ b/mycroft/skills/math/test/intent/sample4.intent.json
@@ -1,0 +1,9 @@
+{
+  "utterance": "what is 32 divided by 24",
+  "intent_type": "MathIntent",
+  "intent": {
+    "Value1": "32",
+    "MathKeyword": "/",
+    "Value2": "24"
+  }
+}

--- a/mycroft/skills/math/test/intent/sample5.intent.json
+++ b/mycroft/skills/math/test/intent/sample5.intent.json
@@ -1,0 +1,9 @@
+{
+  "utterance": "what is 13 + 11",
+  "intent_type": "MathIntent",
+  "intent": {
+    "Value1": "13",
+    "MathKeyword": "+",
+    "Value2": "11"
+  }
+}

--- a/mycroft/skills/math/test/intent/sample6.intent.json
+++ b/mycroft/skills/math/test/intent/sample6.intent.json
@@ -1,0 +1,9 @@
+{
+  "utterance": "what is 17 - 3",
+  "intent_type": "MathIntent",
+  "intent": {
+    "Value1": "17",
+    "MathKeyword": "-",
+    "Value2": "3"
+  }
+}

--- a/mycroft/skills/math/test/intent/sample7.intent.json
+++ b/mycroft/skills/math/test/intent/sample7.intent.json
@@ -1,0 +1,9 @@
+{
+  "utterance": "what is 2 * 3",
+  "intent_type": "MathIntent",
+  "intent": {
+    "Value1": "2",
+    "MathKeyword": "*",
+    "Value2": "3"
+  }
+}

--- a/mycroft/skills/math/test/intent/sample8.intent.json
+++ b/mycroft/skills/math/test/intent/sample8.intent.json
@@ -1,0 +1,9 @@
+{
+  "utterance": "what is 2 / 3",
+  "intent_type": "MathIntent",
+  "intent": {
+    "Value1": "2",
+    "MathKeyword": "/",
+    "Value2": "3"
+  }
+}

--- a/mycroft/skills/math/vocab/en-us/MathKeyword.voc
+++ b/mycroft/skills/math/vocab/en-us/MathKeyword.voc
@@ -1,0 +1,4 @@
++|plus
+-|minus
+*|times|x
+/|divided by|÷


### PR DESCRIPTION
Oops, sorry for this new issue created by the PR.
This resolves issue #92 and adds a very basic math skill. However, I don't think this is ready yet. I couldn't find a way to either support decimal numbers or limit adapt so that something like `what is 2 + 3 * 5` won't trigger this intent.

For some reason the following does not work to allow decimals:
`self.register_regex('(?P<Value1>[\d.]+)')`

Nor does something more specific such as the following:
`self.register_regex('(?P<Value1>\d+(\.\d+)?)')`