### PR TITLE
Updated to include curl

### DIFF
--- a/build_host_setup.sh
+++ b/build_host_setup.sh
@@ -17,7 +17,8 @@ sudo apt-get install -y \
     libglib2.0-dev \
     s3cmd \
     portaudio19-dev \
-    mpg123
+    mpg123 \
+    curl
 
 # upgrade virtualenv to latest from pypi
 sudo easy_install --upgrade virtualenv


### PR DESCRIPTION
Tried on vanilla ubuntu-gnome, curl is not installed by default so dev_setup.sh does not work.