### PR TITLE
Issues 187 - Make Wolfram default to pod 2

### DIFF
--- a/mycroft/skills/wolfram_alpha/__init__.py
+++ b/mycroft/skills/wolfram_alpha/__init__.py
@@ -165,7 +165,7 @@ class WolframAlphaSkill(MycroftSkill):
             return
 
         if result:
-            input_interpretation = self.__find_value(res.pods, 'Input')
+            input_interpretation = self.__find_pod_id(res.pods, 'Input')
             verb = "is"
             structured_syntax_regex = re.compile(".*(\||\[|\\\\|\]).*")
             if parsed_question:

--- a/mycroft/skills/wolfram_alpha/__init__.py
+++ b/mycroft/skills/wolfram_alpha/__init__.py
@@ -125,7 +125,8 @@ class WolframAlphaSkill(MycroftSkill):
                         if not result:
                             result = self.__find_value(res.pods, 'Definition')
                             if not result:
-                                result = self.__find_value(res.pods, 'DecimalApproximation')
+                                result = self.__find_value(
+                                    res.pods, 'DecimalApproximation')
                                 if not result:
                                     result = self.__find_num(
                                         res.pods, '200')

--- a/mycroft/skills/wolfram_alpha/__init__.py
+++ b/mycroft/skills/wolfram_alpha/__init__.py
@@ -115,17 +115,17 @@ class WolframAlphaSkill(MycroftSkill):
             return result
         except:
             try:
-                result = self.__find_value(res.pods, 'Value')
+                result = self.__find_pod_id(res.pods, 'Value')
                 if not result:
-                    result = self.__find_value(
+                    result = self.__find_pod_id(
                         res.pods, 'NotableFacts:PeopleData')
                     if not result:
-                        result = self.__find_value(
+                        result = self.__find_pod_id(
                             res.pods, 'BasicInformation:PeopleData')
                         if not result:
-                            result = self.__find_value(res.pods, 'Definition')
+                            result = self.__find_pod_id(res.pods, 'Definition')
                             if not result:
-                                result = self.__find_value(
+                                result = self.__find_pod_id(
                                     res.pods, 'DecimalApproximation')
                                 if result:
                                     result = result[:5]
@@ -187,7 +187,7 @@ class WolframAlphaSkill(MycroftSkill):
             self.speak("Sorry, I don't understand your request.")
 
     @staticmethod
-    def __find_value(pods, pod_id):
+    def __find_pod_id(pods, pod_id):
         for pod in pods:
             if pod_id in pod.id:
                 return pod.text

--- a/mycroft/skills/wolfram_alpha/__init__.py
+++ b/mycroft/skills/wolfram_alpha/__init__.py
@@ -127,7 +127,9 @@ class WolframAlphaSkill(MycroftSkill):
                             if not result:
                                 result = self.__find_value(
                                     res.pods, 'DecimalApproximation')
-                                if not result:
+                                if result:
+                                    result = result[:5]
+                                else:
                                     result = self.__find_num(
                                         res.pods, '200')
                 return result

--- a/mycroft/skills/wolfram_alpha/__init__.py
+++ b/mycroft/skills/wolfram_alpha/__init__.py
@@ -123,9 +123,12 @@ class WolframAlphaSkill(MycroftSkill):
                         result = self.__find_value(
                             res.pods, 'BasicInformation:PeopleData')
                         if not result:
-                            result = self.__find_value(
-                                res.pods, 'DecimalApproximation')
-                            result = result[:5]
+                            result = self.__find_value(res.pods, 'Definition')
+                            if not result:
+                                result = self.__find_value(res.pods, 'DecimalApproximation')
+                                if not result:
+                                    result = self.__find_num(
+                                        res.pods, '200')
                 return result
             except:
                 return result
@@ -183,7 +186,7 @@ class WolframAlphaSkill(MycroftSkill):
     @staticmethod
     def __find_value(pods, pod_id):
         for pod in pods:
-            if pod.id == pod_id:
+            if pod_id in pod.id:
                 return pod.text
         return None
 
@@ -201,6 +204,13 @@ class WolframAlphaSkill(MycroftSkill):
         # Convert !s to factorial
         text = re.sub(r"!", r",factorial", text)
         return text
+
+    @staticmethod
+    def __find_num(pods, pod_num):
+        for pod in pods:
+            if pod.node.attrib['position'] == pod_num:
+                return pod.text
+        return None
 
     def stop(self):
         pass

--- a/test/skills/wolfram_alpha/__init__.py
+++ b/test/skills/wolfram_alpha/__init__.py
@@ -43,7 +43,7 @@ class WolframAlphaTest(unittest.TestCase):
 
     def test_decimal_approximation_pod(self):
         res = self.create_result("DecimalApproximation", "5.6666666666")
-        self.assertEquals(WolframAlphaSkill().get_result(res), "5.666")
+        self.assertEquals(WolframAlphaSkill().get_result(res), "5.6666666666")
 
     def test_invalid_pod(self):
         res = self.create_result("InvalidTitle", "Test")

--- a/test/skills/wolfram_alpha/__init__.py
+++ b/test/skills/wolfram_alpha/__init__.py
@@ -15,38 +15,51 @@ logger = getLogger(__name__)
 
 
 class WolframAlphaTest(unittest.TestCase):
-    def format_result(self, pod_id, text):
+    def format_result(self, pod_id, text, pod_num):
         return "<queryresult>\
-        <pod id='" + pod_id + "' title = '" + pod_id + "'><subpod>\
+        <pod id='" + pod_id + "' title = '" + pod_id + \
+               "' position='" + pod_num + "'><subpod>\
         <plaintext>" + text + "</plaintext></subpod></pod></queryresult>"
 
-    def create_result(self, pod_id, value):
-        result = self.format_result(pod_id, value)
+    def create_result(self, pod_id, value, pod_num):
+        result = self.format_result(pod_id, value, pod_num)
         return wolframalpha.Result(StringIO(result))
 
     def test_result_pod(self):
-        res = self.create_result("Result", "7")
+        res = self.create_result("Result", "7", '300')
         self.assertEquals(WolframAlphaSkill().get_result(res), "7")
 
     def test_value_pod(self):
-        res = self.create_result("Value", "2^3")
+        res = self.create_result("Value", "2^3", '300')
         self.assertEquals(WolframAlphaSkill().get_result(res), "2^3")
 
     def test_notable_facts_pod(self):
-        res = self.create_result("NotableFacts:PeopleData", "PeopleData")
+        res = self.create_result("NotableFacts:PeopleData",
+                                 "PeopleData", '300')
         self.assertEquals(WolframAlphaSkill().get_result(res), "PeopleData")
 
     def test_basic_information_pod(self):
         res = self.create_result("BasicInformation:PeopleData",
-                                 "Born in 1997")
+                                 "Born in 1997", '300')
         self.assertEquals(WolframAlphaSkill().get_result(res), "Born in 1997")
 
     def test_decimal_approximation_pod(self):
-        res = self.create_result("DecimalApproximation", "5.6666666666")
+        res = self.create_result("DecimalApproximation", "5.6666666666", '300')
         self.assertEquals(WolframAlphaSkill().get_result(res), "5.6666666666")
 
+    def test_definition_pod(self):
+        res = self.create_result("Definition:WordData",
+                                 "a cat is a feline", '300')
+        self.assertEquals(WolframAlphaSkill().get_result(res),
+                          "a cat is a feline")
+
+    def test_numbered_pod(self):
+        res = self.create_result("MathConcept", "tangrams are objects", '200')
+        self.assertEqual(WolframAlphaSkill().get_result(res),
+                         "tangrams are objects")
+
     def test_invalid_pod(self):
-        res = self.create_result("InvalidTitle", "Test")
+        res = self.create_result("InvalidTitle", "Test", '300')
         self.assertEquals(WolframAlphaSkill().get_result(res), None)
 
     def test_whitespace_process(self):

--- a/test/skills/wolfram_alpha/__init__.py
+++ b/test/skills/wolfram_alpha/__init__.py
@@ -45,7 +45,7 @@ class WolframAlphaTest(unittest.TestCase):
 
     def test_decimal_approximation_pod(self):
         res = self.create_result("DecimalApproximation", "5.6666666666", '300')
-        self.assertEquals(WolframAlphaSkill().get_result(res), "5.6666666666")
+        self.assertEquals(WolframAlphaSkill().get_result(res), "5.666")
 
     def test_definition_pod(self):
         res = self.create_result("Definition:WordData",


### PR DESCRIPTION
First, this refactors the `__find_value` method to search for a string in the pod id, not find an exact match. This allows for more flexible searching.

It also changes the `get_result` method, which is how the skill finds what text from the result to speak out. It now will search for a pod with `Definition` in the name, which will handle several cases. If none of the pod ids have been matched, it will return the text of the second pod received. 

This means that Mycroft should speak some information for every query that actually gets a result back from WA. This is a very big change in functionality, and may require some testing, as it will also increase false positives or useless information that it gets from WA.