### PR TITLE
Issues 180 - Add stock skill

### DIFF
--- a/mycroft/skills/stock/__init__.py
+++ b/mycroft/skills/stock/__init__.py
@@ -1,0 +1,76 @@
+# Copyright 2016 Mycroft AI, Inc.
+#
+# This file is part of Mycroft Core.
+#
+# Mycroft Core is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Mycroft Core is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Mycroft Core.  If not, see <http://www.gnu.org/licenses/>.
+
+from os.path import dirname
+import requests
+import xml.etree.ElementTree as ET
+
+from mycroft.skills.core import MycroftSkill
+from mycroft.util.log import getLogger
+from adapt.intent import IntentBuilder
+
+__author__ = 'eward'
+logger = getLogger(__name__)
+
+
+class StockSkill(MycroftSkill):
+    def __init__(self):
+        super(StockSkill, self).__init__(name="StockSkill")
+
+    def initialize(self):
+        self.load_data_files(dirname(__file__))
+
+        self.register_regex("price of (?P<Company>.*)")
+        self.register_regex("is (?P<Company>.*) trading at")
+
+        stock_price_intent = IntentBuilder("StockPriceIntent")\
+            .require("StockPriceKeyword")\
+            .require("Company")\
+            .build()
+        self.register_intent(stock_price_intent,
+                             self.handle_stock_price_intent)
+
+    def handle_stock_price_intent(self, message):
+        company = message.metadata.get("Company")
+        try:
+            response = self.find_and_query(company)
+            self.speak_dialog("stock.price", data=response)
+        except:
+            self.speak_dialog("not.found", data={'company': company})
+
+    def _query(self, url, param_name, query):
+        payload = {param_name: query}
+        response = requests.get(url, params=payload)
+        return(ET.fromstring(response.content))
+
+    def find_and_query(self, query):
+        root = self._query(
+            "http://dev.markitondemand.com/MODApis/Api/v2/Lookup?",
+            'input', query)
+        root = self._query(
+            "http://dev.markitondemand.com/Api/v2/Quote?", 'symbol',
+            root.iter('Symbol').next().text)
+        return {'symbol': root.iter('Symbol').next().text,
+                'company': root.iter('Name').next().text,
+                'price': root.iter('LastPrice').next().text}
+
+    def stop(self):
+        pass
+
+
+def create_skill():
+    return StockSkill()

--- a/mycroft/skills/stock/dialog/en-us/not.found.dialog
+++ b/mycroft/skills/stock/dialog/en-us/not.found.dialog
@@ -1,0 +1,2 @@
+Sorry, I couldn't find a stock price for {{company}}.
+{{company}} doesn't exist or has no stock price.

--- a/mycroft/skills/stock/dialog/en-us/stock.price.dialog
+++ b/mycroft/skills/stock/dialog/en-us/stock.price.dialog
@@ -1,0 +1,2 @@
+{{company}}, with ticker symbol {{symbol}} is currently trading at {{price}} dollars per share.
+With ticker symbol {{symbol}}, the current price of {{company}} is {{price}} dollars per share.

--- a/mycroft/skills/stock/test/intent/stock.price1.intent.json
+++ b/mycroft/skills/stock/test/intent/stock.price1.intent.json
@@ -1,0 +1,8 @@
+{
+  "utterance": "what is the stock price of microsoft",
+  "intent_type": "StockPriceIntent",
+  "intent": {
+      "StockPriceKeyword": "stock price",
+      "Company": "microsoft"
+  }
+}

--- a/mycroft/skills/stock/test/intent/stock.price2.intent.json
+++ b/mycroft/skills/stock/test/intent/stock.price2.intent.json
@@ -1,0 +1,8 @@
+{
+  "utterance": "what price is microsoft trading at",
+  "intent_type": "StockPriceIntent",
+  "intent": {
+    "Company": "microsoft",
+    "StockPriceKeyword": "trading at"
+  }
+}

--- a/mycroft/skills/stock/vocab/en-us/StockPriceKeyword.voc
+++ b/mycroft/skills/stock/vocab/en-us/StockPriceKeyword.voc
@@ -1,0 +1,2 @@
+stock price
+trading at


### PR DESCRIPTION
I've added a stock skill that will give you the stock price of a company when you ask for it. For example, `Hey Mycroft, what is the stock price of alphabet` will give you `With ticker symbol GOOGL, the current price of Alphabet Inc is 706.37 dollars per share.

Since we currently don't have dialog functionality for having conversations with Mycroft, this just grabs the first company match for what you give it, or if it can't find a company matching that name, it'll throw an exception and tell you.
