### PR TITLE
Issues 198 - fix pairing skill

### DIFF
--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -46,13 +46,13 @@ class WebsocketClient(object):
     def __init__(self, host=client_config.get("host"),
                  port=client_config.get("port"),
                  path=client_config.get("route"),
-                 ssl=client_config.get("ssl")):
+                 ssl=str2bool(client_config.get("ssl"))):
 
         validate_param(host, "host")
         validate_param(port, "port")
         validate_param(path, "route")
-        validate_param(ssl, "ssl")
-        ssl = str2bool(ssl)
+        # validate_param(ssl, "ssl")
+        # ssl = str2bool(ssl)
 
         self.emitter = EventEmitter()
         self.scheme = "wss" if ssl else "ws"


### PR DESCRIPTION
This changes the syntax of the messagebus client, there appears to be a big difference between calling str2bool in the parameters of `__init__` and calling it in the actual function.