### PR TITLE
Add #! to mycroft.sh

### DIFF
--- a/mycroft.sh
+++ b/mycroft.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 function usage {
   echo
   echo "Quickly start, stop or restart Mycroft's esential services in detached screens"


### PR DESCRIPTION
The pull request simply adds a crunch bang to the `mycroft.sh` shell script to prevent the follow error:

    Failed to execute process './mycroft.sh'. Reason:
    exec: Exec format error
    The file './mycroft.sh' is marked as an executable but could not be run by the operating system.