### PR TITLE
Added back session manager behavior from old listener

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -119,6 +119,12 @@ class AudioConsumer(threading.Thread):
             self.metrics.increment("mycroft.wakeup")
 
     def process_audio(self, audio):
+        SessionManager.touch()
+        payload = {
+            'utterance': self.mycroft_recognizer.key_phrase,
+            'session': SessionManager.get().session_id,
+        }
+        self.emitter.emit("recognizer_loop:wakeword", payload)
         try:
             self.transcribe([audio])
         except sr.UnknownValueError:  # TODO: Localization

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -45,6 +45,11 @@ def handle_record_end():
     client.emit(Message('recognizer_loop:record_end'))
 
 
+def handle_wakeword(event):
+    logger.info("Wakeword Detected: " + event['utterance'])
+    client.emit(Message('recognizer_loop:wakeword', event))
+
+
 def handle_utterance(event):
     logger.info("Utterance: " + str(event['utterances']))
     client.emit(Message('recognizer_loop:utterance', event))
@@ -95,6 +100,7 @@ def main():
     loop = RecognizerLoop(device_index=device_index)
     loop.on('recognizer_loop:utterance', handle_utterance)
     loop.on('recognizer_loop:record_begin', handle_record_begin)
+    loop.on('recognizer_loop:wakeword', handle_wakeword)
     loop.on('recognizer_loop:record_end', handle_record_end)
     loop.on('speak', handle_speak)
     client.on('speak', handle_speak)

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -137,8 +137,6 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
     def __init__(self, wake_word_recognizer):
         speech_recognition.Recognizer.__init__(self)
-        self.daemon = True
-
         self.wake_word_recognizer = wake_word_recognizer
         self.audio = pyaudio.PyAudio()
 


### PR DESCRIPTION
 - Removed random extra variable from when I was experimenting with multithreading
 - Added back some SessionManager lines to replicate old behavior more precisely
I'm not quiet sure where the session_id was ever used when emitted in the payload however just to be safe I kept it in there. This is to be sure there are no differences between the old and new listener that could be causing Cerberus problems.