### PR TITLE
Issues 209 - Keep user configuration by default

### DIFF
--- a/mycroft/configuration/__init__.py
+++ b/mycroft/configuration/__init__.py
@@ -46,9 +46,11 @@ class ConfigurationLoader(object):
         return config
 
     @staticmethod
-    def init_locations(locations=None):
+    def init_locations(locations=None, keep_user_config=True):
         if not locations:
-            return [DEFAULT_CONFIG, SYSTEM_CONFIG, USER_CONFIG]
+            locations = [DEFAULT_CONFIG, SYSTEM_CONFIG, USER_CONFIG]
+        elif keep_user_config:
+            locations += [USER_CONFIG]
         return locations
 
     @staticmethod
@@ -60,12 +62,13 @@ class ConfigurationLoader(object):
             raise TypeError
 
     @staticmethod
-    def load(config=None, locations=None):
+    def load(config=None, locations=None, keep_user_config=True):
         """
         Loads default or specified configuration files
         """
         config = ConfigurationLoader.init_config(config)
-        locations = ConfigurationLoader.init_locations(locations)
+        locations = ConfigurationLoader.init_locations(locations,
+                                                       keep_user_config)
         ConfigurationLoader.validate_data(config, locations)
 
         for location in locations:
@@ -165,8 +168,9 @@ class ConfigurationManager(object):
         return RemoteConfiguration.load(ConfigurationManager.__config)
 
     @staticmethod
-    def load_local(locations=None):
-        return ConfigurationLoader.load(ConfigurationManager.get(), locations)
+    def load_local(locations=None, keep_user_config=True):
+        return ConfigurationLoader.load(ConfigurationManager.get(), locations,
+                                        keep_user_config)
 
     @staticmethod
     def load_remote():

--- a/test/configuration/__init__.py
+++ b/test/configuration/__init__.py
@@ -34,15 +34,18 @@ class AbstractConfigurationTest(unittest.TestCase):
 
 
 class ConfigurationLoaderTest(AbstractConfigurationTest):
-    def test_init_config(self):
-        config = {'a': 'b'}
+    def test_init_config_with_defaults(self):
         self.assertEquals(ConfigurationLoader.init_config(), {})
+
+    def test_init_config_with_new_config(self):
+        config = {'a': 'b'}
         self.assertEquals(ConfigurationLoader.init_config(config), config)
 
-    def test_init_locations(self):
+    def test_init_locations_with_defaults(self):
         locations = [DEFAULT_CONFIG, SYSTEM_CONFIG, USER_CONFIG]
         self.assertEquals(ConfigurationLoader.init_locations(), locations)
 
+    def test_init_locations_with_new_location(self):
         locations = [self.config_path]
         self.assertEquals(ConfigurationLoader.init_locations(locations),
                           locations)
@@ -87,7 +90,7 @@ class ConfigurationLoaderTest(AbstractConfigurationTest):
 
     def test_load_with_invalid_locations_path(self):
         locations = ['./invalid/mycroft.ini', './invalid_mycroft.ini']
-        config = ConfigurationLoader.load(None, locations)
+        config = ConfigurationLoader.load(None, locations, False)
         self.assertEquals(config, {})
 
 


### PR DESCRIPTION
Issues #209 
- Preserving user configuration during new configuration load
- It's possible to override this behaviour by changing the `keep_user_config` flag to `False`
