### PR TITLE
Added audio accuracy test

### DIFF
--- a/audio-accuracy-test/audio_accuracy_test.py
+++ b/audio-accuracy-test/audio_accuracy_test.py
@@ -14,7 +14,7 @@ __author__ = 'wolfgange3311999'
 logger = getLogger('audio_test_runner')
 
 
-class MockStream(object):
+class FileStream(object):
     def __init__(self, file_name):
         self.file = wave.open(file_name, 'rb')
         self.size = self.file.getnframes()
@@ -30,9 +30,9 @@ class MockStream(object):
         self.file.close()
 
 
-class MockMicrophone(AudioSource):
+class FileMockMicrophone(AudioSource):
     def __init__(self, file_name):
-        self.stream = MockStream(file_name)
+        self.stream = FileStream(file_name)
         self.SAMPLE_RATE = self.stream.sample_rate
         self.SAMPLE_WIDTH = self.stream.sample_width
         self.CHUNK = 1024
@@ -48,7 +48,7 @@ class AudioTester(object):
         speech_logger.setLevel(100)  # Disables logging to clean output
 
     def test_audio(self, file_name):
-        source = MockMicrophone(file_name)
+        source = FileMockMicrophone(file_name)
         ee = pyee.EventEmitter()
 
         class SharedData:
@@ -81,32 +81,44 @@ def get_root_dir():
     return dirname(dirname(__file__))
 
 if __name__ == "__main__":
-    path = join('audio-test', 'data', 'query_after', '*.wav')
+    directory = join('audio-accuracy-test', 'data', 'query_after')
+    query = join(directory, '*.wav')
     root_dir = get_root_dir()
-    full_path = join(root_dir, path)
+    full_path = join(root_dir, query)
     file_names = sorted(glob(full_path))
-
-    # Grab audio format info from first file
-    ex_file = wave.open(file_names[0], 'rb')
-    tester = AudioTester(ex_file.getframerate())
 
     num_found = 0
     total = len(file_names)
 
+    if total < 1:
+        print(bold_str(RED+"Error: No wav files found in " + directory))
+        exit(1)
+
+    # Grab audio format info from first file
+    ex_file = wave.open(file_names[0], 'rb')
+
+    print
+    tester = AudioTester(ex_file.getframerate())
+    print
+
     for file_name in file_names:
         short_name = os.path.basename(file_name)
         was_found = tester.test_audio(file_name)
+
         if was_found:
-            print(bold_str(GREEN + "Detected ") + " - " + short_name)
+            result_str = GREEN + "Detected "
             num_found += 1
         else:
-            print(bold_str(RED + "Not found") + " - " + short_name)
+            result_str = RED + "Not found"
+
+        print(bold_str(result_str) + " - " + short_name)
 
 
     def to_percent(numerator, denominator):
         return "{0:.2f}".format((100.0 * numerator) / denominator) + "%"
 
 
+    print
     print("Found " + bold_str(num_found) + " out of " + bold_str(total))
     print(bold_str(to_percent(num_found, total)) + " accuracy.")
     print

--- a/audio-accuracy-test/audio_accuracy_test.py
+++ b/audio-accuracy-test/audio_accuracy_test.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
         else:
             result_str = RED + "Not found"
 
-        print(bold_str(result_str) + " - " + short_name)
+        print("Wake word " + bold_str(result_str) + " - " + short_name)
 
 
     def to_percent(numerator, denominator):

--- a/audio-test/audio_test_runner.py
+++ b/audio-test/audio_test_runner.py
@@ -1,0 +1,114 @@
+import os
+import wave
+from glob import glob
+
+import pyaudio
+import pyee
+from os.path import dirname, join
+from speech_recognition import Microphone, AudioSource
+
+from mycroft.client.speech.listener import AudioConsumer
+from mycroft.client.speech.local_recognizer import LocalRecognizer
+from mycroft.client.speech.mic import MutableStream, ResponsiveRecognizer
+from mycroft.util.log import getLogger
+from mycroft.client.speech.mic import logger as speech_logger
+
+__author__ = 'wolfgange3311999'
+logger = getLogger('audio_test_runner')
+
+
+class MockStream(object):
+    def __init__(self, file_name):
+        self.file = wave.open(file_name, 'rb')
+        self.size = self.file.getnframes()
+        self.sample_rate = self.file.getframerate()
+        self.sample_width = self.file.getsampwidth()
+
+    def read(self, chunk_size):
+        if abs(self.file.tell() - self.size) < 10:
+            raise EOFError
+        return self.file.readframes(chunk_size)
+
+    def close(self):
+        self.file.close()
+
+
+class MockMicrophone(AudioSource):
+    def __init__(self, file_name):
+        self.stream = MockStream(file_name)
+        self.SAMPLE_RATE = self.stream.sample_rate
+        self.SAMPLE_WIDTH = self.stream.sample_width
+        self.CHUNK = 1024
+
+    def close(self):
+        self.stream.close()
+
+
+class AudioTester(object):
+    def __init__(self, samp_rate):
+        self.ww_recognizer = LocalRecognizer(samp_rate, 'en-us')
+        self.listener = ResponsiveRecognizer(self.ww_recognizer)
+        speech_logger.setLevel(100)  # Disables logging to clean output
+
+    @staticmethod
+    def absolute_path(name):
+        root_dir = dirname(dirname(__file__))
+        return join(root_dir, 'audio-test', 'data', name)
+
+    def test_audio(self, file_name):
+        source = MockMicrophone(file_name)
+        ee = pyee.EventEmitter()
+
+        class SharedData:
+            found = False
+
+        def on_found_wake_word():
+            SharedData.found = True
+
+        ee.on('recognizer_loop:record_begin', on_found_wake_word)
+
+        try:
+            self.listener.listen(source, ee)
+        except EOFError:
+            pass
+
+        return SharedData.found
+
+
+BOLD = '\033[1m'
+NORMAL = '\033[0m'
+GREEN = '\033[92m'
+RED = '\033[91m'
+
+def bold_str(val):
+    return BOLD + str(val) + NORMAL
+
+if __name__ == "__main__":
+    file_names = glob(AudioTester.absolute_path('*.wav'))
+
+    # Grab audio format info from first file
+    ex_file = wave.open(file_names[0], 'rb')
+    tester = AudioTester(ex_file.getframerate())
+
+    num_found = 0
+    total = len(file_names)
+
+    for file_name in file_names:
+        short_name = os.path.basename(file_name)
+        was_found = tester.test_audio(file_name)
+        print(BOLD)
+        if was_found:
+            print(GREEN + "Detected " + NORMAL + " - " + short_name)
+            num_found += 1
+        else:
+            print(RED + "Not found" + NORMAL + " - " + short_name)
+        print(NORMAL)
+
+
+    def to_percent(numerator, denominator):
+        return "{0:.2f}".format((100.0 * numerator) / denominator) + "%"
+
+
+    print("Found " + bold_str(num_found) + " out of " + bold_str(total))
+    print(bold_str(to_percent(num_found, total)) + " accuracy.")
+    print

--- a/audio-test/audio_test_runner.py
+++ b/audio-test/audio_test_runner.py
@@ -53,7 +53,7 @@ class AudioTester(object):
     @staticmethod
     def absolute_path(name):
         root_dir = dirname(dirname(__file__))
-        return join(root_dir, 'audio-test', 'data', name)
+        return join(root_dir, 'audio-test', 'data', 'query_after', name)
 
     def test_audio(self, file_name):
         source = MockMicrophone(file_name)

--- a/audio-test/audio_test_runner.py
+++ b/audio-test/audio_test_runner.py
@@ -2,14 +2,11 @@ import os
 import wave
 from glob import glob
 
-import pyaudio
 import pyee
 from os.path import dirname, join
-from speech_recognition import Microphone, AudioSource
-
-from mycroft.client.speech.listener import AudioConsumer
+from speech_recognition import AudioSource
 from mycroft.client.speech.local_recognizer import LocalRecognizer
-from mycroft.client.speech.mic import MutableStream, ResponsiveRecognizer
+from mycroft.client.speech.mic import ResponsiveRecognizer
 from mycroft.util.log import getLogger
 from mycroft.client.speech.mic import logger as speech_logger
 
@@ -50,11 +47,6 @@ class AudioTester(object):
         self.listener = ResponsiveRecognizer(self.ww_recognizer)
         speech_logger.setLevel(100)  # Disables logging to clean output
 
-    @staticmethod
-    def absolute_path(name):
-        root_dir = dirname(dirname(__file__))
-        return join(root_dir, 'audio-test', 'data', 'query_after', name)
-
     def test_audio(self, file_name):
         source = MockMicrophone(file_name)
         ee = pyee.EventEmitter()
@@ -80,11 +72,19 @@ NORMAL = '\033[0m'
 GREEN = '\033[92m'
 RED = '\033[91m'
 
+
 def bold_str(val):
     return BOLD + str(val) + NORMAL
 
+
+def get_root_dir():
+    return dirname(dirname(__file__))
+
 if __name__ == "__main__":
-    file_names = glob(AudioTester.absolute_path('*.wav'))
+    path = join('audio-test', 'data', 'query_after', '*.wav')
+    root_dir = get_root_dir()
+    full_path = join(root_dir, path)
+    file_names = sorted(glob(full_path))
 
     # Grab audio format info from first file
     ex_file = wave.open(file_names[0], 'rb')
@@ -96,13 +96,11 @@ if __name__ == "__main__":
     for file_name in file_names:
         short_name = os.path.basename(file_name)
         was_found = tester.test_audio(file_name)
-        print(BOLD)
         if was_found:
-            print(GREEN + "Detected " + NORMAL + " - " + short_name)
+            print(bold_str(GREEN + "Detected ") + " - " + short_name)
             num_found += 1
         else:
-            print(RED + "Not found" + NORMAL + " - " + short_name)
-        print(NORMAL)
+            print(bold_str(RED + "Not found") + " - " + short_name)
 
 
     def to_percent(numerator, denominator):

--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,7 @@ case $1 in
 	"audiotest") SCRIPT=${TOP}/mycroft/util/audio_test.py ;;
 	"collector") SCRIPT=${TOP}/mycroft_data_collection/cli.py ;;
 	"unittest") SCRIPT=${TOP}/test/test_runner.py ;;
-	"audiounittest") SCRIPT=${TOP}/audio-test/audio_test_runner.py ;;
+	"audioaccuracytest") SCRIPT=${TOP}/audio-accuracy-test/audio_accuracy_test.py ;;
 	"sdkdoc") SCRIPT=${TOP}/doc/generate_sdk_docs.py ;;
         "enclosure") SCRIPT=${TOP}/mycroft/client/enclosure/enclosure.py ;;
         "pairing") SCRIPT=${TOP}/mycroft/pairing/client.py ;;

--- a/start.sh
+++ b/start.sh
@@ -11,6 +11,7 @@ case $1 in
 	"audiotest") SCRIPT=${TOP}/mycroft/util/audio_test.py ;;
 	"collector") SCRIPT=${TOP}/mycroft_data_collection/cli.py ;;
 	"unittest") SCRIPT=${TOP}/test/test_runner.py ;;
+	"audiounittest") SCRIPT=${TOP}/audio-test/audio_test_runner.py ;;
 	"sdkdoc") SCRIPT=${TOP}/doc/generate_sdk_docs.py ;;
         "enclosure") SCRIPT=${TOP}/mycroft/client/enclosure/enclosure.py ;;
         "pairing") SCRIPT=${TOP}/mycroft/pairing/client.py ;;


### PR DESCRIPTION
This adds a new command, `./start.sh audioaccuracytest` that will run the listener through a set of audio files and verify that it can find the wake word.

To run it, place some audio files with the wake word in `audio-test/data/query-after/`. The folder is under query-after since audio files are also being collected with the query before even though they are not currently being tested since the listener isn't setup to work like that.