### PR TITLE
Added timeout override to listener - fixes #224

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -192,7 +192,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         num_chunks = 0
 
         # Will return if exceeded this even if there's not enough loud chunks
-        max_chunks_of_silence = int(self.RECORDING_TIMEOUT_WITH_SILENCE/sec_per_buffer)
+        max_chunks_of_silence = int(self.RECORDING_TIMEOUT_WITH_SILENCE /
+                                    sec_per_buffer)
 
         # bytearray to store audio in
         byte_data = '\0' * source.SAMPLE_WIDTH


### PR DESCRIPTION
Previously Mycroft would wait a long time for noise if what the user said was too short (Or if you said nothing). It has been changed so that there is a maximum of 3 seconds before it gives up.

Another change is that previously the listener's behavior would be influenced by the buffer size. Now, however, it is not since the noise is increased by an amount relative to the buffer size.