### PR TITLE
Update scheduled skill formatting (Fixed #158)

### DIFF
--- a/mycroft/skills/scheduled_skills.py
+++ b/mycroft/skills/scheduled_skills.py
@@ -43,6 +43,9 @@ class ScheduledSkill(MycroftSkill):
     """
 
     DELTA_TIME = int((datetime.now() - datetime.utcnow()).total_seconds())
+    SECONDS_PER_DAY = 86400
+    SECONDS_PER_HOUR = 3600
+    SECONDS_PER_MINUTE = 60
 
     def __init__(self, name, emitter=None):
         super(ScheduledSkill, self).__init__(name, emitter)
@@ -78,9 +81,10 @@ class ScheduledSkill(MycroftSkill):
     def get_formatted_time(self, timestamp):
         date = datetime.fromtimestamp(timestamp)
         now = datetime.now()
-        if date.date() == now.date():
-            hours, remainder = divmod((date - now).total_seconds(), 3600)
-            minutes, seconds = divmod(remainder, 60)
+        diff = (date - now).total_seconds()
+        if diff <= self.SECONDS_PER_DAY:
+            hours, remainder = divmod(diff, self.SECONDS_PER_HOUR)
+            minutes, seconds = divmod(remainder, self.SECONDS_PER_MINUTE)
             if hours:
                 return "%s hours and %s minutes from now" % \
                        (int(hours), int(minutes))

--- a/mycroft/skills/scheduled_skills.py
+++ b/mycroft/skills/scheduled_skills.py
@@ -26,8 +26,11 @@ import parsedatetime as pdt
 from adapt.intent import IntentBuilder
 from mycroft.skills import time_rules
 from mycroft.skills.core import MycroftSkill
+from mycroft.util.log import getLogger
 
 __author__ = 'jdorleans'
+
+logger = getLogger(__name__)
 
 
 class ScheduledSkill(MycroftSkill):
@@ -73,7 +76,18 @@ class ScheduledSkill(MycroftSkill):
         return mktime(self.calendar.parse(sentence)[0]) - self.DELTA_TIME
 
     def get_formatted_time(self, timestamp):
-        return datetime.fromtimestamp(timestamp).strftime(
+        date = datetime.fromtimestamp(timestamp)
+        now = datetime.now()
+        if date.date() == now.date():
+            hours, remainder = divmod((date - now).total_seconds(), 3600)
+            minutes, seconds = divmod(remainder, 60)
+            if hours:
+                return "%s hours and %s minutes from now" % \
+                       (int(hours), int(minutes))
+            else:
+                return "%s minutes and %s seconds from now" % \
+                       (int(minutes), int(seconds))
+        return date.strftime(
             self.config_core.get('time.format'))
 
     @abc.abstractmethod

--- a/test/scheduled_skills.py
+++ b/test/scheduled_skills.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta
+import unittest
+
+from mycroft.skills.scheduled_skills import ScheduledSkill
+from mycroft.util.log import getLogger
+
+__author__ = 'eward'
+
+logger = getLogger(__name__)
+
+
+class ScheduledSkillTest(unittest.TestCase):
+    def test_formatted_time_today_hours(self):
+        date = datetime.now() + timedelta(hours=2)
+        self.assertEquals(ScheduledSkill(name='test').
+                          get_formatted_time(float(date.strftime('%s'))),
+                          "1 hours and 59 minutes from now")
+
+    def test_formatted_time_today_min(self):
+        date = datetime.now() + timedelta(minutes=2)
+        self.assertEquals(ScheduledSkill(name='test').
+                          get_formatted_time(float(date.strftime('%s'))),
+                          "1 minutes and 59 seconds from now")
+
+    def test_formatted_time_days(self):
+        date = datetime.now() + timedelta(days=2)
+        self.assertEquals(ScheduledSkill(name='test').
+                          get_formatted_time(float(date.strftime('%s'))),
+                          date.strftime("%A, %B %d, %Y at %H:%M"))

--- a/test/skills/scheduled_skills.py
+++ b/test/skills/scheduled_skills.py
@@ -10,20 +10,22 @@ logger = getLogger(__name__)
 
 
 class ScheduledSkillTest(unittest.TestCase):
+    skill = ScheduledSkill(name='ScheduledSkillTest')
+
     def test_formatted_time_today_hours(self):
         date = datetime.now() + timedelta(hours=2)
-        self.assertEquals(ScheduledSkill(name='test').
+        self.assertEquals(self.skill.
                           get_formatted_time(float(date.strftime('%s'))),
                           "1 hours and 59 minutes from now")
 
     def test_formatted_time_today_min(self):
         date = datetime.now() + timedelta(minutes=2)
-        self.assertEquals(ScheduledSkill(name='test').
+        self.assertEquals(self.skill.
                           get_formatted_time(float(date.strftime('%s'))),
                           "1 minutes and 59 seconds from now")
 
     def test_formatted_time_days(self):
         date = datetime.now() + timedelta(days=2)
-        self.assertEquals(ScheduledSkill(name='test').
+        self.assertEquals(self.skill.
                           get_formatted_time(float(date.strftime('%s'))),
                           date.strftime("%A, %B %d, %Y at %H:%M"))


### PR DESCRIPTION
This change makes it so that when a user creates something scheduled on that day, the dialog will be more natural - `Alarm set for 1 hours and 59 minutes from now` rather than `Alarm set for Thursday, June 23 at 7:37 PM`. 

One possible concern with this change is that it makes it harder to internationalize.