### PR TITLE
WA skill will now search again if there is one `didyoumean` in the results

### DIFF
--- a/mycroft/skills/wolfram_alpha/__init__.py
+++ b/mycroft/skills/wolfram_alpha/__init__.py
@@ -116,22 +116,22 @@ class WolframAlphaSkill(MycroftSkill):
             return result
         except:
             try:
-                result = self.find_pod_id(res.pods, 'Value')
+                result = self.__find_pod_id(res.pods, 'Value')
                 if not result:
-                    result = self.find_pod_id(
+                    result = self.__find_pod_id(
                         res.pods, 'NotableFacts:PeopleData')
                     if not result:
-                        result = self.find_pod_id(
+                        result = self.__find_pod_id(
                             res.pods, 'BasicInformation:PeopleData')
                         if not result:
-                            result = self.find_pod_id(res.pods, 'Definition')
+                            result = self.__find_pod_id(res.pods, 'Definition')
                             if not result:
-                                result = self.find_pod_id(
+                                result = self.__find_pod_id(
                                     res.pods, 'DecimalApproximation')
                                 if result:
                                     result = result[:5]
                                 else:
-                                    result = self.find_num(
+                                    result = self.__find_num(
                                         res.pods, '200')
                 return result
             except:
@@ -157,17 +157,17 @@ class WolframAlphaSkill(MycroftSkill):
         try:
             res = self.client.query(query)
             result = self.get_result(res)
-            others = self.find_did_you_mean(res)
+            others = self._find_did_you_mean(res)
         except CerberusAccessDenied as e:
             self.speak_dialog('not.paired')
             return
         except Exception as e:
             logger.exception(e)
-            self.speak("Sorry, I don't understand your request.")
+            self.speak_dialog("not.understood")
             return
 
         if result:
-            input_interpretation = self.find_pod_id(res.pods, 'Input')
+            input_interpretation = self.__find_pod_id(res.pods, 'Input')
             verb = "is"
             structured_syntax_regex = re.compile(".*(\||\[|\\\\|\]).*")
             if parsed_question:
@@ -187,31 +187,31 @@ class WolframAlphaSkill(MycroftSkill):
             self.speak(response)
         else:
             if len(others) == 1:
-                self.speak("Sorry, I didn't understand " +
-                           utterance + ". Searching for " +
-                           others[0] + " instead")
+                self.speak_dialog('search.again',
+                                  data={'utterance': utterance, 'alternative':
+                                        others[0]})
                 self.handle_fallback(Message('intent_failure',
                                              metadata={'utterance':
                                                        others[0]}))
             else:
-                self.speak("Sorry, I don't understand your request.")
+                self.speak_dialog("not.understood")
 
     @staticmethod
-    def find_pod_id(pods, pod_id):
+    def __find_pod_id(pods, pod_id):
         for pod in pods:
             if pod_id in pod.id:
                 return pod.text
         return None
 
     @staticmethod
-    def find_num(pods, pod_num):
+    def __find_num(pods, pod_num):
         for pod in pods:
             if pod.node.attrib['position'] == pod_num:
                 return pod.text
         return None
 
     @staticmethod
-    def find_did_you_mean(res):
+    def _find_did_you_mean(res):
         value = []
         root = res.tree.find('didyoumeans')
         if root:

--- a/mycroft/skills/wolfram_alpha/__init__.py
+++ b/mycroft/skills/wolfram_alpha/__init__.py
@@ -187,8 +187,12 @@ class WolframAlphaSkill(MycroftSkill):
             self.speak(response)
         else:
             if len(others) == 1:
-                self.speak("Sorry, I didn't understand " + utterance + ". Searching for " + others[0] + " instead")
-                self.handle_fallback(Message('intent_failure', metadata={'utterance': others[0]}))
+                self.speak("Sorry, I didn't understand " +
+                           utterance + ". Searching for " +
+                           others[0] + " instead")
+                self.handle_fallback(Message('intent_failure',
+                                             metadata={'utterance':
+                                                       others[0]}))
             else:
                 self.speak("Sorry, I don't understand your request.")
 

--- a/mycroft/skills/wolfram_alpha/__init__.py
+++ b/mycroft/skills/wolfram_alpha/__init__.py
@@ -186,7 +186,7 @@ class WolframAlphaSkill(MycroftSkill):
 
             self.speak(response)
         else:
-            if len(others) == 1:
+            if len(others) > 0:
                 self.speak_dialog('search.again',
                                   data={'utterance': utterance, 'alternative':
                                         others[0]})
@@ -214,7 +214,7 @@ class WolframAlphaSkill(MycroftSkill):
     def _find_did_you_mean(res):
         value = []
         root = res.tree.find('didyoumeans')
-        if root:
+        if root is not None:
             for result in root:
                 value.append(result.text)
         return value

--- a/mycroft/skills/wolfram_alpha/__init__.py
+++ b/mycroft/skills/wolfram_alpha/__init__.py
@@ -116,22 +116,22 @@ class WolframAlphaSkill(MycroftSkill):
             return result
         except:
             try:
-                result = self.__find_pod_id(res.pods, 'Value')
+                result = self.find_pod_id(res.pods, 'Value')
                 if not result:
-                    result = self.__find_pod_id(
+                    result = self.find_pod_id(
                         res.pods, 'NotableFacts:PeopleData')
                     if not result:
-                        result = self.__find_pod_id(
+                        result = self.find_pod_id(
                             res.pods, 'BasicInformation:PeopleData')
                         if not result:
-                            result = self.__find_pod_id(res.pods, 'Definition')
+                            result = self.find_pod_id(res.pods, 'Definition')
                             if not result:
-                                result = self.__find_pod_id(
+                                result = self.find_pod_id(
                                     res.pods, 'DecimalApproximation')
                                 if result:
                                     result = result[:5]
                                 else:
-                                    result = self.__find_num(
+                                    result = self.find_num(
                                         res.pods, '200')
                 return result
             except:
@@ -157,7 +157,7 @@ class WolframAlphaSkill(MycroftSkill):
         try:
             res = self.client.query(query)
             result = self.get_result(res)
-            others = self.__find_did_you_mean(res)
+            others = self.find_did_you_mean(res)
         except CerberusAccessDenied as e:
             self.speak_dialog('not.paired')
             return
@@ -167,7 +167,7 @@ class WolframAlphaSkill(MycroftSkill):
             return
 
         if result:
-            input_interpretation = self.__find_pod_id(res.pods, 'Input')
+            input_interpretation = self.find_pod_id(res.pods, 'Input')
             verb = "is"
             structured_syntax_regex = re.compile(".*(\||\[|\\\\|\]).*")
             if parsed_question:
@@ -186,34 +186,33 @@ class WolframAlphaSkill(MycroftSkill):
 
             self.speak(response)
         else:
-            if others:
+            if len(others) == 1:
                 self.speak("Sorry, I didn't understand " + utterance + ". Searching for " + others[0] + " instead")
                 self.handle_fallback(Message('intent_failure', metadata={'utterance': others[0]}))
             else:
                 self.speak("Sorry, I don't understand your request.")
 
     @staticmethod
-    def __find_pod_id(pods, pod_id):
+    def find_pod_id(pods, pod_id):
         for pod in pods:
             if pod_id in pod.id:
                 return pod.text
         return None
 
     @staticmethod
-    def __find_num(pods, pod_num):
+    def find_num(pods, pod_num):
         for pod in pods:
             if pod.node.attrib['position'] == pod_num:
                 return pod.text
         return None
 
     @staticmethod
-    def __find_did_you_mean(res):
+    def find_did_you_mean(res):
         value = []
         root = res.tree.find('didyoumeans')
         if root:
             for result in root:
                 value.append(result.text)
-                logger.debug(result.text)
         return value
 
     @staticmethod

--- a/mycroft/skills/wolfram_alpha/dialog/en-us/not.understood.dialog
+++ b/mycroft/skills/wolfram_alpha/dialog/en-us/not.understood.dialog
@@ -1,0 +1,2 @@
+Sorry, I didn't understand your request
+I'm sorry, I don't understand your request.

--- a/mycroft/skills/wolfram_alpha/dialog/en-us/search.again.dialog
+++ b/mycroft/skills/wolfram_alpha/dialog/en-us/search.again.dialog
@@ -1,0 +1,2 @@
+Sorry, I couldn't find an answer for {{utterance}}. I'm searching for {{alternative}} instead.
+I couldn't get a response for {{utterance}}. I'm instead searching for {{alternative}}.

--- a/test/skills/wolfram_alpha/__init__.py
+++ b/test/skills/wolfram_alpha/__init__.py
@@ -92,7 +92,8 @@ class WolframAlphaTest(unittest.TestCase):
 
     def test_find_did_you_mean_exists(self):
         res = self.create_did_you_mean(['search for power', 'power'])
-        self.assertEquals(self.skill.find_did_you_mean(res), ['search for power', 'power'])
+        self.assertEquals(self.skill.find_did_you_mean(res),
+                          ['search for power', 'power'])
 
     def test_find_did_you_mean_none(self):
         res = self.create_did_you_mean([])

--- a/test/skills/wolfram_alpha/__init__.py
+++ b/test/skills/wolfram_alpha/__init__.py
@@ -91,10 +91,11 @@ class WolframAlphaTest(unittest.TestCase):
                           ("Test!"), "Test,factorial")
 
     def test_find_did_you_mean_exists(self):
-        res = self.create_did_you_mean(['search for power', 'power'])
-        self.assertEquals(self.skill.find_did_you_mean(res),
-                          ['search for power', 'power'])
+        values = ['search for power', 'power']
+        res = self.create_did_you_mean(values)
+        self.assertEquals(self.skill._find_did_you_mean(res),
+                          values)
 
     def test_find_did_you_mean_none(self):
         res = self.create_did_you_mean([])
-        self.assertEquals(self.skill.find_did_you_mean(res), [])
+        self.assertEquals(self.skill._find_did_you_mean(res), [])

--- a/test/skills/wolfram_alpha/__init__.py
+++ b/test/skills/wolfram_alpha/__init__.py
@@ -1,6 +1,7 @@
 import unittest
 import wolframalpha
 from StringIO import StringIO
+from xml.etree import ElementTree as etree
 
 from mycroft.skills.wolfram_alpha import WolframAlphaSkill
 from mycroft.util.log import getLogger
@@ -9,71 +10,90 @@ __author__ = 'eward'
 
 logger = getLogger(__name__)
 
-# necessary amount of text for testing: "<queryresult>\
-# <pod id='NotableFacts:PeopleData'><subpod>\
-# <plaintext>Test</plaintext></subpod></pod></queryresult>"
-
 
 class WolframAlphaTest(unittest.TestCase):
-    def format_result(self, pod_id, text, pod_num):
+    skill = WolframAlphaSkill()
+
+    @staticmethod
+    def format_result(pod_id, text, pod_num):
         return "<queryresult>\
         <pod id='" + pod_id + "' title = '" + pod_id + \
-               "' position='" + pod_num + "'><subpod>\
+               "' position='" + pod_num + "'><subpod> \
         <plaintext>" + text + "</plaintext></subpod></pod></queryresult>"
+
+    @staticmethod
+    def format_did_you_mean(text):
+        tree = "<queryresult><didyoumeans>"
+        for result in text:
+            tree += "<didyoumean>" + result + "</didyoumean>"
+        tree += "</didyoumeans></queryresult>"
+        return tree
 
     def create_result(self, pod_id, value, pod_num):
         result = self.format_result(pod_id, value, pod_num)
         return wolframalpha.Result(StringIO(result))
 
+    def create_did_you_mean(self, text):
+        test = self.format_did_you_mean(text)
+        return wolframalpha.Result(StringIO(test))
+
     def test_result_pod(self):
         res = self.create_result("Result", "7", '300')
-        self.assertEquals(WolframAlphaSkill().get_result(res), "7")
+        self.assertEquals(self.skill.get_result(res), "7")
 
     def test_value_pod(self):
         res = self.create_result("Value", "2^3", '300')
-        self.assertEquals(WolframAlphaSkill().get_result(res), "2^3")
+        self.assertEquals(self.skill.get_result(res), "2^3")
 
     def test_notable_facts_pod(self):
         res = self.create_result("NotableFacts:PeopleData",
                                  "PeopleData", '300')
-        self.assertEquals(WolframAlphaSkill().get_result(res), "PeopleData")
+        self.assertEquals(self.skill.get_result(res), "PeopleData")
 
     def test_basic_information_pod(self):
         res = self.create_result("BasicInformation:PeopleData",
                                  "Born in 1997", '300')
-        self.assertEquals(WolframAlphaSkill().get_result(res), "Born in 1997")
+        self.assertEquals(self.skill.get_result(res), "Born in 1997")
 
     def test_decimal_approximation_pod(self):
         res = self.create_result("DecimalApproximation", "5.6666666666", '300')
-        self.assertEquals(WolframAlphaSkill().get_result(res), "5.666")
+        self.assertEquals(self.skill.get_result(res), "5.666")
 
     def test_definition_pod(self):
         res = self.create_result("Definition:WordData",
                                  "a cat is a feline", '300')
-        self.assertEquals(WolframAlphaSkill().get_result(res),
+        self.assertEquals(self.skill.get_result(res),
                           "a cat is a feline")
 
     def test_numbered_pod(self):
         res = self.create_result("MathConcept", "tangrams are objects", '200')
-        self.assertEqual(WolframAlphaSkill().get_result(res),
+        self.assertEqual(self.skill.get_result(res),
                          "tangrams are objects")
 
     def test_invalid_pod(self):
         res = self.create_result("InvalidTitle", "Test", '300')
-        self.assertEquals(WolframAlphaSkill().get_result(res), None)
+        self.assertEquals(self.skill.get_result(res), None)
 
     def test_whitespace_process(self):
-        self.assertEquals(WolframAlphaSkill().process_wolfram_string
+        self.assertEquals(self.skill.process_wolfram_string
                           ("Test     string"), "Test string")
 
     def test_pipe_process(self):
-        self.assertEquals(WolframAlphaSkill().process_wolfram_string
+        self.assertEquals(self.skill.process_wolfram_string
                           ("Test | string"), "Test, string")
 
     def test_newline_process(self):
-        self.assertEquals(WolframAlphaSkill().process_wolfram_string
+        self.assertEquals(self.skill.process_wolfram_string
                           ("Test\nstring"), "Test, string")
 
     def test_factorial_process(self):
-        self.assertEquals(WolframAlphaSkill().process_wolfram_string
+        self.assertEquals(self.skill.process_wolfram_string
                           ("Test!"), "Test,factorial")
+
+    def test_find_did_you_mean_exists(self):
+        res = self.create_did_you_mean(['search for power', 'power'])
+        self.assertEquals(self.skill.find_did_you_mean(res), ['search for power', 'power'])
+
+    def test_find_did_you_mean_none(self):
+        res = self.create_did_you_mean([])
+        self.assertEquals(self.skill.find_did_you_mean(res), [])


### PR DESCRIPTION
I changed the WA skill so that it will find alternative queries, represented by `didyoumean` elements in the results. If there is exactly one of these, it will automatically search a second time for the alternative query, and tell the user that it is doing so.

This partially addresses #192.