### PR TITLE
Add base media skill to blacklist  (Fixes #274)

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -35,7 +35,7 @@ from mycroft.util.log import getLogger
 __author__ = 'seanfitz'
 
 PRIMARY_SKILLS = ['intent', 'wake']
-BLACKLISTED_SKILLS = ["send_sms"]
+BLACKLISTED_SKILLS = ["send_sms", "media"]
 SKILLS_BASEDIR = dirname(__file__)
 THIRD_PARTY_SKILLS_DIR = "/opt/mycroft/third_party"
 


### PR DESCRIPTION
This adds the base media skill to the blacklisted list in `core.py` so that it won't be loaded.