### PR TITLE
Removed  -j$CORES from install-mimic.sh

### DIFF
--- a/install-mimic.sh
+++ b/install-mimic.sh
@@ -10,12 +10,12 @@ if [ ! -d ${MIMIC_DIR} ]; then
     git clone https://github.com/MycroftAI/mimic.git
     cd ${MIMIC_DIR}
     ./configure --with-audio=alsa
-    make -j$CORES
+    make #-j$CORES
 else
     # ensure mimic is up to date
     cd ${MIMIC_DIR}
     git pull
     make clean
     ./configure --with-audio=alsa
-    make -j$CORES
+    make #-j$CORES
 fi


### PR DESCRIPTION
This is temporary relief for those with mimic builds failing.