### PR TITLE
Make Mimic interface send phonemes on message bus

### DIFF
--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -62,7 +62,7 @@ def mute_and_speak(utterance):
     try:
         logger.info("Speak: " + utterance)
         loop.mute()
-        tts.execute(utterance)
+        tts.execute(utterance, client)
     finally:
         loop.unmute()
         mutex.release()

--- a/mycroft/client/text/cli.py
+++ b/mycroft/client/text/cli.py
@@ -36,10 +36,11 @@ def handle_speak(event):
     try:
         utterance = event.metadata.get('utterance')
         logger.info("Speak: " + utterance)
-        tts.execute(utterance)
+        tts.execute(utterance, client)
     finally:
         mutex.release()
         client.emit(Message("recognizer_loop:audio_output_end"))
+        logger.info("Speak complete")
 
 
 def connect():

--- a/mycroft/configuration/mycroft.ini
+++ b/mycroft/configuration/mycroft.ini
@@ -60,6 +60,7 @@ session_ttl_seconds = 180
 [tts]
 module = "mimic"
 mimic.voice = "ap"
+mimic.phonemes = "startstop"
 espeak.lang = "english-us"
 espeak.voice = "m1"
 

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -31,7 +31,7 @@ class TTS(object):
     TTS abstract class to be implemented by all TTS engines.
 
     It aggregates the minimum required parameters and exposes
-    ``execute(sentence)`` function.
+    ``execute(sentence, client)`` function.
     """
 
     def __init__(self, lang, voice, filename='/tmp/tts.wav'):
@@ -41,7 +41,7 @@ class TTS(object):
         self.filename = filename
 
     @abc.abstractmethod
-    def execute(self, sentence):
+    def execute(self, sentence, client):
         pass
 
 

--- a/mycroft/tts/espeak_tts.py
+++ b/mycroft/tts/espeak_tts.py
@@ -29,7 +29,7 @@ class ESpeak(TTS):
     def __init__(self, lang, voice):
         super(ESpeak, self).__init__(lang, voice)
 
-    def execute(self, sentence):
+    def execute(self, sentence, client):
         subprocess.call(
             ['espeak', '-v', self.lang + '+' + self.voice, sentence])
 

--- a/mycroft/tts/google_tts.py
+++ b/mycroft/tts/google_tts.py
@@ -30,7 +30,7 @@ class GoogleTTS(TTS):
     def __init__(self, lang, voice):
         super(GoogleTTS, self).__init__(lang, voice)
 
-    def execute(self, sentence):
+    def execute(self, sentence, client):
         tts = gTTS(text=sentence, lang=self.lang)
         tts.save(self.filename)
         play_wav(self.filename)

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -33,9 +33,50 @@ BIN = config.get(
     "mimic.path", join(MYCROFT_ROOT_PATH, 'mimic', 'bin', 'mimic'))
 
 
+def phonemes_start_stop(phonemes):
+    """ Reduces phonemes to a start speaking and a stop speaking value. """
+    if len(phonemes) > 1:
+        return [('start', phonemes[0][1]), ('stop', phonemes[-1][1])]
+    else:
+        return []
+
+
+def phonemes_speaking(phonemes):
+    """ Reduces phonemes to pauses and speaking intervals """
+    binary = []
+    for e in phonemes:
+        if e[0] != 'pau':
+            new = ('speaking', e[1])
+        else:
+            new = e
+        if len(binary) == 0 or binary[-1][0] != new[0]:
+            binary.append(new)
+        else:
+            binary[-1] = new
+    return binary
+
+
+def phonemes_all(phonemes):
+    """ Keeps all phoneme data """
+    return phonemes
+
+
+def phonemes_none(phonemes):
+    """ Removes all phoneme data """
+    return []
+
+phoneme_set = {'all': phonemes_all,
+               'startstop': phonemes_start_stop,
+               'speaking': phonemes_speaking,
+               'none': phonemes_none
+               }
+
+
 class Mimic(TTS):
     def __init__(self, lang, voice):
         super(Mimic, self).__init__(lang, voice)
+        pf = config.get('mimic.phonemes', 'none')
+        self.representation = phoneme_set.get(pf, phonemes_none)
 
     def execute(self, sentence, client):
         process = subprocess.Popen(['stdbuf', '-oL', BIN,
@@ -49,8 +90,10 @@ class Mimic(TTS):
                 phonemes = output.strip().split(' ')
                 phonemes = [(e.split(':')[0], e.split(':')[1])
                             for e in phonemes]
-                client.emit(Message('mycroft.tts',
-                                    metadata={'phonemes': phonemes}))
+                phonemes = self.representation(phonemes)
+                if len(phonemes) > 0:
+                    client.emit(Message('mycroft.tts',
+                                        metadata={'phonemes': phonemes}))
 
 
 class MimicValidator(TTSValidator):

--- a/mycroft/tts/remote_tts.py
+++ b/mycroft/tts/remote_tts.py
@@ -44,7 +44,7 @@ class RemoteTTS(TTS):
         self.url = remove_last_slash(url)
         self.session = FuturesSession()
 
-    def execute(self, sentence):
+    def execute(self, sentence, client):
         phrases = self.__get_phrases(sentence)
 
         if len(phrases) > 0:

--- a/mycroft/tts/spdsay_tts.py
+++ b/mycroft/tts/spdsay_tts.py
@@ -29,7 +29,7 @@ class SpdSay(TTS):
     def __init__(self, lang, voice):
         super(SpdSay, self).__init__(lang, voice)
 
-    def execute(self, sentence):
+    def execute(self, sentence, client):
         subprocess.call(
             ['spd-say', '-l', self.lang, '-t', self.voice, sentence])
 


### PR DESCRIPTION
This is a take on providing information to allow mycroft to "lip-sync" as requested by "Matthew" on slack. It's mainly for his testing.

Using the -psdur flag mimic will write phonemes and their duration to
standard out. These are captured and sent over the message bus as a list
of phoneme-duration pairs.

It'll look like this:
```
2016-07-14 13:37:16,174 - Skills - DEBUG - {"message_type": "mycroft.tts", "context": null, "metadata": {"phonemes": [["pau", "0.152"], ["w", "0.244"], ["ay", "0.389"], ["l", "0.496"], ["d", "0.554"], ["ih", "0.593"], ["b", "0.670"], ["iy", "0.822"], ["s", "0.950"], ["t", "0.975"], ["s", "1.077"], ["ae", "1.289"], ["n", "1.349"], ["ax", "1.383"], ["m", "1.475"], ["ax", "1.521"], ["l", "1.656"], ["z", "1.743"], ["pau", "1.925"], ["ih", "2.003"], ["z", "2.087"], ["k", "2.214"], ["aa", "2.330"], ["n", "2.376"], ["ow", "2.519"], ["k", "2.624"], ["aa", "2.747"], ["iy", "2.895"], ["t", "2.977"], ["s", "3.170"], ["pau", "3.336"]]}}
```
"duration" is the mimic term for it but it's not really a duration, more like stop time for the phoneme.

Currently this uses a workaround to force mimic to linebuffer the stdout stream. Mimic is called via `stdbuf -oL` so please verify that the `stdbuf` command exists on the test system. I'll fix the buffering in mimic so next version won't require this hack.

Also, this is using simple pipes to communicate with mimic. It might be too slow and in that case I have to think of something new or get *pymimic* ready.