### PR TITLE
Fixed bug causing enclosure weather to occasionally not display

### DIFF
--- a/mycroft/client/enclosure/weather.py
+++ b/mycroft/client/enclosure/weather.py
@@ -42,6 +42,6 @@ class EnclosureWeather:
         if event and event.metadata:
             img_code = event.metadata.get("img_code", None)
             temp = event.metadata.get("temp", None)
-            if img_code and temp:
+            if img_code is not None and temp is not None:
                 msg = "weather.display=" + str(img_code) + str(temp)
                 self.writer.write(msg)


### PR DESCRIPTION
This PR fixes an issue where if the weather's image code was 0, it would be understood as "false", causing it not to properly enter an if statement and display.