### PR TITLE
Temp dict files now have generated names in /tmp/

### DIFF
--- a/mycroft/client/speech/local_recognizer.py
+++ b/mycroft/client/speech/local_recognizer.py
@@ -39,13 +39,10 @@ class LocalRecognizer(object):
         self.decoder = Decoder(self.create_config(dict_name))
 
     def create_dict(self, key_phrase, phonemes):
-        folder = os.path.join(tempfile.gettempdir(), 'mycroft')
-        if not os.path.exists(folder):
-            os.makedirs(folder)
-        file_name = os.path.join(folder, key_phrase + ".dict")
+        (fd, file_name) = tempfile.mkstemp()
         words = key_phrase.split()
         phoneme_groups = phonemes.split('.')
-        with open(file_name, 'w') as f:
+        with os.fdopen(fd, 'w') as f:
             for word, phoneme in zip(words, phoneme_groups):
                 f.write(word + ' ' + phoneme + '\n')
         return file_name


### PR DESCRIPTION
This prevent permission errors associated with storing things in the
/tmp/mycroft directory and with reusing files. When mycroft was first run as a different user this could cause the voice thread to fail when it attempts to create or open the already-existing folder or file. Now, instead of being put in something like `/tmp/mycroft/hey mycroft.dict` the generated dicts are placed into a file such as `/tmp/tmpxl6Ysh`.