### PR TITLE
Fix install-pygtk to use new version of cairo

### DIFF
--- a/scripts/install-pygtk.sh
+++ b/scripts/install-pygtk.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Ensure we're in a virtualenv.
 if [ "$VIRTUAL_ENV" == "" ]
 then
@@ -23,7 +24,7 @@ then
     echo -e "\E[1m * Installing cairo...\E[0m"
     # Fetch, build, and install py2cairo.
     (   cd $CACHE
-        curl 'http://cairographics.org/releases/py2cairo-1.10.0.tar.bz2' > "py2cairo.tar.bz2"
+        curl 'https://www.cairographics.org/releases/py2cairo-1.10.0.tar.bz2' > "py2cairo.tar.bz2"
         tar -xvf py2cairo.tar.bz2
         (   cd py2cairo*
             autoreconf -ivf


### PR DESCRIPTION
In the install-pygtk script, the installation of cairo was failing because it was using an outdated URL. I've updated the URL, and cairo now installs correctly.