### PR TITLE
Replace outdated mustache library

### DIFF
--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -16,7 +16,6 @@
 # along with Mycroft Core.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import mustache
 import pystache
 import os
 import random

--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -17,6 +17,7 @@
 
 
 import mustache
+import pystache
 import os
 import random
 from mycroft.util import log
@@ -78,7 +79,7 @@ class MustacheDialogRenderer(object):
             index = random.randrange(len(template_functions))
         else:
             index %= len(template_functions)
-        return mustache.render(template_functions[index], context)
+        return pystache.render(template_functions[index], context)
 
 
 class DialogLoader(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 shortuuid==0.4.3
-mustache==0.1.4
+pystache==0.5.4
 configobj==5.0.6
 wikipedia==1.4.0
 requests==2.8.1


### PR DESCRIPTION
This replaces the outdated [mustache Python liibray](https://github.com/peterldowns/python-mustache), as it is no longer supported. It replaces it with [pystache](https://github.com/defunkt/pystache), which provides the exact same functionality but is still being maintained.