### PR TITLE
Issues #56 - Move TTS process killing to speech client

### DIFF
--- a/mycroft/client/enclosure/enclosure.py
+++ b/mycroft/client/enclosure/enclosure.py
@@ -75,7 +75,6 @@ class EnclosureReader(Thread):
 
         if "mycroft.stop" in data:
             self.client.emit(Message("mycroft.stop"))
-            kill(['mimic'])  # TODO - Refactoring in favor of Mycroft Stop
 
         if "volume.up" in data:
             self.client.emit(

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -90,6 +90,7 @@ def handle_wake_up(event):
 def handle_stop(event):
     kill([config.get('tts').get('module')])
 
+
 def connect():
     client.run_forever()
 

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -25,6 +25,7 @@ from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.tts import tts_factory
 from mycroft.util.log import getLogger
+from mycroft.util import kill
 
 logger = getLogger("SpeechClient")
 client = None
@@ -86,6 +87,9 @@ def handle_wake_up(event):
     loop.awaken()
 
 
+def handle_stop(event):
+    kill([config.get('tts').get('module')])
+
 def connect():
     client.run_forever()
 
@@ -109,6 +113,7 @@ def main():
         handle_multi_utterance_intent_failure)
     client.on('recognizer_loop:sleep', handle_sleep)
     client.on('recognizer_loop:wake_up', handle_wake_up)
+    client.on('mycroft.stop', handle_stop)
     event_thread = Thread(target=connect)
     event_thread.setDaemon(True)
     event_thread.start()


### PR DESCRIPTION
This removes `kill(['mimic'])` from the enclosure client and moves it to the speech client. It also changes it to use the configured TTS client rather than assuming the user is using mimic.

Note that saying `Mycroft stop` still will not work most of the time, as the speech client mutes the microphone when saying something. One possible fix would be to add a config option that the user can set if they are using headphones or a system with echo cancellation, as the main reason that the microphone is muted is to prevent Mycroft from hearing himself while speaking.