### PR TITLE
Features/eye volume

### DIFF
--- a/mycroft/client/enclosure/api.py
+++ b/mycroft/client/enclosure/api.py
@@ -70,6 +70,10 @@ class EnclosureAPI:
         self.client.emit(
             Message("enclosure.eyes.level", metadata={'level': level}))
 
+    def eyes_volume(self, volume):
+        self.client.emit(
+            Message("enclosure.eyes.volume", metadata={'volume': volume}))
+
     def mouth_reset(self):
         self.client.emit(Message("enclosure.mouth.reset"))
 

--- a/mycroft/client/enclosure/eyes.py
+++ b/mycroft/client/enclosure/eyes.py
@@ -43,6 +43,7 @@ class EnclosureEyes:
         self.client.on('enclosure.eyes.look', self.look)
         self.client.on('enclosure.eyes.color', self.color)
         self.client.on('enclosure.eyes.level', self.brightness)
+        self.client.on('enclosure.eyes.volume', self.volume)
 
     def on(self, event=None):
         self.writer.write("eyes.on")
@@ -78,3 +79,9 @@ class EnclosureEyes:
         if event and event.metadata:
             level = event.metadata.get("level", level)
         self.writer.write("eyes.level=" + str(level))
+
+    def volume(self, event=None):
+        volume = 4
+        if event and event.metadata:
+            volume = event.metadata.get("volume", volume)
+        self.writer.write("eyes.volume=" + str(volume))

--- a/mycroft/skills/volume/__init__.py
+++ b/mycroft/skills/volume/__init__.py
@@ -114,6 +114,7 @@ class VolumeSkill(MycroftSkill):
         new_code = self.fix_code(old_code + level)
         if new_code in self.VOLUMES:
             volume = self.VOLUMES[new_code]
+            self.enclosure.eyes_volume(volume)
             mixer.setvolume(volume)
         return new_code, new_code != old_code
 

--- a/mycroft/skills/volume/__init__.py
+++ b/mycroft/skills/volume/__init__.py
@@ -114,7 +114,7 @@ class VolumeSkill(MycroftSkill):
         new_code = self.fix_code(old_code + level)
         if new_code in self.VOLUMES:
             volume = self.VOLUMES[new_code]
-            self.enclosure.eyes_volume(volume)
+            self.enclosure.eyes_volume(new_code)
             mixer.setvolume(volume)
         return new_code, new_code != old_code
 


### PR DESCRIPTION
This PR allows Mycroft units to display their current volume level (using the NeoPixel LEDs on their eyes) when it's changed using the encoder dial. 

It relies on MycroftAI/enclosure#53.