### PR TITLE
Issue/dont compile pocketsphinx

### DIFF
--- a/build_host_setup.sh
+++ b/build_host_setup.sh
@@ -20,7 +20,8 @@ sudo apt-get install -y \
     portaudio19-dev \
     mpg123 \
     screen \
-    curl
+    curl \
+    python-pocketsphinx
 
 # upgrade virtualenv to latest from pypi
 sudo pip install --upgrade virtualenv

--- a/build_host_setup.sh
+++ b/build_host_setup.sh
@@ -20,8 +20,7 @@ sudo apt-get install -y \
     portaudio19-dev \
     mpg123 \
     screen \
-    curl \
-    python-pocketsphinx
+    curl
 
 # upgrade virtualenv to latest from pypi
 sudo pip install --upgrade virtualenv

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -50,10 +50,10 @@ pip install -r requirements.txt
 CORES=$(nproc)
 echo Building with $CORES cores.
 
-#build and install pocketsphinx
-#cd ${TOP}
-#${TOP}/scripts/install-pocketsphinx.sh -q
-#build and install mimic
+build and install pocketsphinx
+cd ${TOP}
+${TOP}/scripts/install-pocketsphinx.sh -q
+build and install mimic
 cd ${TOP}
 ${TOP}/scripts/install-mimic.sh
 

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -50,7 +50,7 @@ pip install -r requirements.txt
 CORES=$(nproc)
 echo Building with $CORES cores.
 
-build and install pocketsphinx
+#build and install pocketsphinx
 cd ${TOP}
 ${TOP}/scripts/install-pocketsphinx.sh -q
 build and install mimic

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -51,8 +51,8 @@ CORES=$(nproc)
 echo Building with $CORES cores.
 
 #build and install pocketsphinx
-cd ${TOP}
-${TOP}/scripts/install-pocketsphinx.sh -q
+#cd ${TOP}
+#${TOP}/scripts/install-pocketsphinx.sh -q
 #build and install mimic
 cd ${TOP}
 ${TOP}/scripts/install-mimic.sh

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -50,24 +50,9 @@ pip install -r requirements.txt
 CORES=$(nproc)
 echo Building with $CORES cores.
 
-# clone pocketsphinx-python at HEAD (fix to a constant version later)
-#if [ ! -d ${TOP}/pocketsphinx-python ]; then
-  # build sphinxbase and pocketsphinx if we haven't already
-#  git clone --recursive https://github.com/cmusphinx/pocketsphinx-python
-#  cd ${TOP}/pocketsphinx-python/sphinxbase
-#  ./autogen.sh
-#  ./configure
-#  make -j$CORES
-#  cd ${TOP}/pocketsphinx-python/pocketsphinx
-#  ./autogen.sh
-#  ./configure
-#  make -j$CORES
-#fi
-
-# build and install pocketsphinx python bindings
-#cd ${TOP}/pocketsphinx-python
-#python setup.py install
-
+#build and install pocketsphinx
+cd ${TOP}
+${TOP}/scripts/install-pocketsphinx.sh -q
 #build and install mimic
 cd ${TOP}
 ${TOP}/scripts/install-mimic.sh

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -51,22 +51,22 @@ CORES=$(nproc)
 echo Building with $CORES cores.
 
 # clone pocketsphinx-python at HEAD (fix to a constant version later)
-if [ ! -d ${TOP}/pocketsphinx-python ]; then
+#if [ ! -d ${TOP}/pocketsphinx-python ]; then
   # build sphinxbase and pocketsphinx if we haven't already
-  git clone --recursive https://github.com/cmusphinx/pocketsphinx-python
-  cd ${TOP}/pocketsphinx-python/sphinxbase
-  ./autogen.sh
-  ./configure
-  make -j$CORES
-  cd ${TOP}/pocketsphinx-python/pocketsphinx
-  ./autogen.sh
-  ./configure
-  make -j$CORES
-fi
+#  git clone --recursive https://github.com/cmusphinx/pocketsphinx-python
+#  cd ${TOP}/pocketsphinx-python/sphinxbase
+#  ./autogen.sh
+#  ./configure
+#  make -j$CORES
+#  cd ${TOP}/pocketsphinx-python/pocketsphinx
+#  ./autogen.sh
+#  ./configure
+#  make -j$CORES
+#fi
 
 # build and install pocketsphinx python bindings
-cd ${TOP}/pocketsphinx-python
-python setup.py install
+#cd ${TOP}/pocketsphinx-python
+#python setup.py install
 
 #build and install mimic
 cd ${TOP}

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -51,9 +51,9 @@ CORES=$(nproc)
 echo Building with $CORES cores.
 
 #build and install pocketsphinx
-cd ${TOP}
-${TOP}/scripts/install-pocketsphinx.sh -q
-build and install mimic
+#cd ${TOP}
+#${TOP}/scripts/install-pocketsphinx.sh -q
+#build and install mimic
 cd ${TOP}
 ${TOP}/scripts/install-mimic.sh
 

--- a/mycroft/client/speech/local_recognizer.py
+++ b/mycroft/client/speech/local_recognizer.py
@@ -19,7 +19,7 @@
 import time
 
 import os
-from pocketsphinx.pocketsphinx import Decoder
+from pocketsphinx import Decoder
 import tempfile
 
 __author__ = 'seanfitz, jdorleans'

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,5 +32,5 @@ netifaces==0.10.4
 pyjokes==0.5.0
 psutil==4.1.0
 pep8==1.7.0
-ulti_key_dict==2.0.3
+multi_key_dict==2.0.3
 pocketsphinx==0.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,5 @@ netifaces==0.10.4
 pyjokes==0.5.0
 psutil==4.1.0
 pep8==1.7.0
-multi_key_dict==2.0.3
+ulti_key_dict==2.0.3
+pocketsphinx==0.1.0

--- a/scripts/install-pocketsphinx.sh
+++ b/scripts/install-pocketsphinx.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# exit on any error
+set -Ee
+
+#TOP="."
+
+
+function enable_local {
+ sed -i -- 's/from pocketsphinx.pocketsphinx import Decoder/from pocketsphinx import Decoder/g' mycroft/client/speech/local_recognizer.py
+}
+
+function disable_local {
+ sed -i -- 's/from pocketsphinx import Decoder/from pocketsphinx.pocketsphinx import Decoder/g' mycroft/client/speech/local_recognizer.py
+
+}
+function install_pocketsphinx {
+  # clone pocketsphinx-python at HEAD (fix to a constant version later)
+  if [ ! -d ${TOP}/pocketsphinx-python ]; then
+   # build sphinxbase and pocketsphinx if we haven't already
+    git clone --recursive https://github.com/cmusphinx/pocketsphinx-python
+    cd ${TOP}/pocketsphinx-python/sphinxbase
+    ./autogen.sh
+    ./configure
+    make -j$CORES
+    cd ${TOP}/pocketsphinx-python/pocketsphinx
+    ./autogen.sh
+    ./configure
+    make -j$CORES
+  fi
+
+  # build and install pocketsphinx python bindings
+  cd ${TOP}/pocketsphinx-python
+  python setup.py install
+
+}
+
+if [ "$1" = "-q" ]; then
+  enable_local
+  install_pocketsphinx
+  exit 0
+fi
+
+echo "This script will checkout, compile, and install pocketsphinx locally if the debian package python-pocketsphinx is not available"
+
+PS3='Please enter your choice: '
+options=("Enable local checkout, compile and install" "Disable local checkout and exit" "Do nothing and quit")
+select opt in "${options[@]}"
+do
+    case $opt in
+        "Enable local checkout, compile and install")
+            echo "you chose choice 1"
+            enable_local
+            install_pocketsphinx
+            ;;
+        "Disable local checkout and exit")
+            echo "you chose choice 2"
+            disable_local
+            exit 0
+            ;;
+        "Do nothing and quit")
+            echo "you chose choice 3"
+            exit 0
+            ;;
+                    *) echo invalid option;;
+    esac
+done
+

--- a/scripts/install-pocketsphinx.sh
+++ b/scripts/install-pocketsphinx.sh
@@ -18,14 +18,16 @@ function install_pocketsphinx {
   if [ ! -d ${TOP}/pocketsphinx-python ]; then
    # build sphinxbase and pocketsphinx if we haven't already
     git clone --recursive https://github.com/cmusphinx/pocketsphinx-python
-    cd ${TOP}/pocketsphinx-python/sphinxbase
+    pushd ./pocketsphinx-python/sphinxbase
     ./autogen.sh
     ./configure
     make -j$CORES
-    cd ${TOP}/pocketsphinx-python/pocketsphinx
+    popd
+    pushd ./pocketsphinx-python/pocketsphinx
     ./autogen.sh
     ./configure
     make -j$CORES
+    popd
   fi
 
   # build and install pocketsphinx python bindings


### PR DESCRIPTION
I can't understand what is wrong with using pip to install pocketsphinx with python bindings. Unlike the debian packages python-pocketsphinx, the pip method installes a newer version '0.1.0'. I have run dev_setup and my packaging scripts to create debs by adding pocketsphinx to `requirements.txt` and it seems to work just fine. 

it would really help the packaging efforts as well as the development setup if we didn't have to compile  pocketsphinx each time. 