### PR TITLE
Added support for power control through unit menu mode

### DIFF
--- a/mycroft/client/enclosure/enclosure.py
+++ b/mycroft/client/enclosure/enclosure.py
@@ -113,10 +113,10 @@ class EnclosureReader(Thread):
             subprocess.call('speaker-test -P 10 -l 0 -s 1', shell=True)
 
         if "unit.shutdown" in data:
-            subprocess.call('sudo poweroff')
+            subprocess.call('sudo poweroff', shell = True)
 
         if "unit.reboot" in data:
-            subprocess.call('sudo reboot')
+            subprocess.call('sudo reboot', shell = True)
 
     def stop(self):
         self.alive = False

--- a/mycroft/client/enclosure/enclosure.py
+++ b/mycroft/client/enclosure/enclosure.py
@@ -118,6 +118,9 @@ class EnclosureReader(Thread):
         if "unit.reboot" in data:
             subprocess.call('sudo reboot', shell=True)
 
+        if "unit.setwifi" in data:
+            self.client.emit(Message("wifisetup.start"))
+
     def stop(self):
         self.alive = False
         self.join()

--- a/mycroft/client/enclosure/enclosure.py
+++ b/mycroft/client/enclosure/enclosure.py
@@ -113,10 +113,10 @@ class EnclosureReader(Thread):
             subprocess.call('speaker-test -P 10 -l 0 -s 1', shell=True)
 
         if "unit.shutdown" in data:
-            subprocess.call('sudo poweroff', shell = True)
+            subprocess.call('sudo poweroff', shell=True)
 
         if "unit.reboot" in data:
-            subprocess.call('sudo reboot', shell = True)
+            subprocess.call('sudo reboot', shell=True)
 
     def stop(self):
         self.alive = False

--- a/mycroft/client/enclosure/enclosure.py
+++ b/mycroft/client/enclosure/enclosure.py
@@ -112,6 +112,12 @@ class EnclosureReader(Thread):
             # Test audio muting on arduino
             subprocess.call('speaker-test -P 10 -l 0 -s 1', shell=True)
 
+        if "unit.shutdown" in data:
+            subprocess.call('sudo poweroff')
+
+        if "unit.reboot" in data:
+            subprocess.call('sudo reboot')
+
     def stop(self):
         self.alive = False
         self.join()


### PR DESCRIPTION
This PR allows users to reboot or shut down the Raspberry Pi on the hardware unit through its menu mode.

It relies on MycroftAI/enclosure#55, which implements menu mode itself.

