### PR TITLE
Fix wifi indication in speech client

### DIFF
--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -124,8 +124,6 @@ def main():
     event_thread.setDaemon(True)
     event_thread.start()
 
-    if connected() is False:  # TODO: Localization
-        mute_and_speak("This device is not connected to the Internet")
     subprocess.call('echo "eyes.reset" >/dev/ttyAMA0', shell=True)
 
     try:


### PR DESCRIPTION
The check for internet connection in the speech client wasn't working, as it started too early for it to be useful.