### PR TITLE
Networking fix: resolves #363

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -161,7 +161,7 @@ class AudioConsumer(threading.Thread):
                 logger.error("Connection Error: {0}".format(e))
                 utterances.append("Say this device is not connected to the internet")
             except Exception as e:
-                logger.error("Unexpected exception: {0}".format(type(e)))
+                logger.error("Unexpected exception: {0}".format(e))
             else:
                 logger.debug("STT: " + text)
                 if text.strip() != '':

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -159,7 +159,9 @@ class AudioConsumer(threading.Thread):
                 utterances.append("pair my device")
             except ConnectionError as e:
                 logger.error("Connection Error: {0}".format(e))
-                utterances.append("Say this device is not connected to the internet")
+                utterances.append(
+                    "Say this device is not connected, "
+                    "to the internet")
             except Exception as e:
                 logger.error("Unexpected exception: {0}".format(e))
             else:
@@ -193,6 +195,7 @@ class AudioConsumer(threading.Thread):
             self.metrics.attr('utterances', utterances)
         else:
             raise sr.UnknownValueError
+
 
 class RecognizerLoopState(object):
     def __init__(self):

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -22,6 +22,7 @@ from Queue import Queue
 
 import pyee
 import speech_recognition as sr
+from requests.exceptions import ConnectionError
 
 from mycroft.client.speech.local_recognizer import LocalRecognizer
 from mycroft.client.speech.mic import MutableMicrophone, ResponsiveRecognizer
@@ -156,8 +157,11 @@ class AudioConsumer(threading.Thread):
                     "Your device is not registered yet. To start pairing, "
                     "login at cerberus dot mycroft dot A.I")
                 utterances.append("pair my device")
+            except ConnectionError as e:
+                logger.error("Connection Error: {0}".format(e))
+                utterances.append("Say this device is not connected to the internet")
             except Exception as e:
-                logger.error("Unexpected exception: {0}".format(e))
+                logger.error("Unexpected exception: {0}".format(type(e)))
             else:
                 logger.debug("STT: " + text)
                 if text.strip() != '':
@@ -168,31 +172,27 @@ class AudioConsumer(threading.Thread):
     def transcribe(self, audio_segments):
         utterances = []
         threads = []
-        if connected():
-            for audio in audio_segments:
-                if self._audio_length(audio) < self.MIN_AUDIO_SIZE:
-                    logger.debug("Audio too short to send to STT")
-                    continue
+        for audio in audio_segments:
+            if self._audio_length(audio) < self.MIN_AUDIO_SIZE:
+                logger.debug("Audio too short to send to STT")
+                continue
 
-                target = self._create_remote_stt_runnable(audio, utterances)
-                t = threading.Thread(target=target)
-                t.start()
-                threads.append(t)
+            target = self._create_remote_stt_runnable(audio, utterances)
+            t = threading.Thread(target=target)
+            t.start()
+            threads.append(t)
 
-            for thread in threads:
-                thread.join()
-            if len(utterances) > 0:
-                payload = {
-                    'utterances': utterances,
-                    'session': SessionManager.get().session_id
-                }
-                self.emitter.emit("recognizer_loop:utterance", payload)
-                self.metrics.attr('utterances', utterances)
-            else:
-                raise sr.UnknownValueError
-        else:  # TODO: Localization
-            self.__speak("This device is not connected to the Internet")
-
+        for thread in threads:
+            thread.join()
+        if len(utterances) > 0:
+            payload = {
+                'utterances': utterances,
+                'session': SessionManager.get().session_id
+            }
+            self.emitter.emit("recognizer_loop:utterance", payload)
+            self.metrics.attr('utterances', utterances)
+        else:
+            raise sr.UnknownValueError
 
 class RecognizerLoopState(object):
     def __init__(self):

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -32,7 +32,7 @@ from mycroft.configuration import ConfigurationManager
 from mycroft.messagebus.message import Message
 from mycroft.metrics import MetricsAggregator
 from mycroft.session import SessionManager
-from mycroft.util import CerberusAccessDenied
+from mycroft.util import TartarusAccessDenied
 from mycroft.util.log import getLogger
 
 logger = getLogger(__name__)
@@ -151,8 +151,8 @@ class AudioConsumer(threading.Thread):
                 logger.error(
                     "Could not request results from Speech Recognition "
                     "service; {0}".format(e))
-            except CerberusAccessDenied as e:
-                logger.error("AccessDenied from Cerberus proxy.")
+            except TartarusAccessDenied as e:
+                logger.error("AccessDenied from Tartarus proxy.")
                 self.__speak(
                     "Your device is not registered yet. To start pairing, "
                     "login at cerberus dot mycroft dot A.I")

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -32,7 +32,7 @@ from mycroft.configuration import ConfigurationManager
 from mycroft.messagebus.message import Message
 from mycroft.metrics import MetricsAggregator
 from mycroft.session import SessionManager
-from mycroft.util import CerberusAccessDenied, connected
+from mycroft.util import CerberusAccessDenied
 from mycroft.util.log import getLogger
 
 logger = getLogger(__name__)

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -16,12 +16,16 @@
 # along with Mycroft Core.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import os
-import subprocess
-from os.path import dirname
 import socket
+import subprocess
+import tempfile
 
+import os
+import os.path
 import psutil
+from os.path import dirname
+from mycroft.util.log import getLogger
+import mycroft.configuration
 
 __author__ = 'jdorleans'
 
@@ -89,5 +93,26 @@ def kill(names):
                 pass
 
 
-class CerberusAccessDenied(Exception):
+def create_signal(signal_name):
+    try:
+        with open(tempfile.gettempdir() + '/' + signal_name, 'w'):
+            return True
+    except IOError:
+        return False
+
+
+def check_for_signal(signal_name):
+    filename = tempfile.gettempdir() + '/' + signal_name
+    if os.path.isfile(filename):
+        os.remove(filename)
+        return True
+    return False
+
+
+def validate_param(value, name):
+    if not value:
+        raise ValueError("Missing or empty %s in mycroft.conf " % name)
+
+
+class TartarusAccessDenied(Exception):
     pass

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -88,26 +88,5 @@ def kill(names):
             except:
                 pass
 
-
-def connected(host="8.8.8.8", port=53, timeout=3):
-    """
-    Thanks to 7h3rAm on
-    Host: 8.8.8.8 (google-public-dns-a.google.com)
-    OpenPort: 53/tcp
-    Service: domain (DNS/TCP)
-    """
-    try:
-        socket.setdefaulttimeout(timeout)
-        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))
-        return True
-    except IOError:
-        try:
-            socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(
-                ("8.8.4.4", port))
-            return True
-        except IOError:
-            return False
-
-
 class CerberusAccessDenied(Exception):
     pass

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -88,5 +88,6 @@ def kill(names):
             except:
                 pass
 
+
 class CerberusAccessDenied(Exception):
     pass


### PR DESCRIPTION
This may be a better solution for reporting network connectivity problems. With this implementation, the request for speech recognition is always made, without checking for connection before starting the thread.

This closes #363 
