### PR TITLE
#372 - dev_setup.sh ignores WORKON_HOME when VIRTUALENV_ROOT is unset

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -33,7 +33,12 @@ if [ $(id -u) -eq 0 ]; then
 fi
 
 TOP=$(cd $(dirname $0) && pwd -L)
-VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${HOME}/.virtualenvs/mycroft"}
+
+if [ -z "$WORKON_HOME" ]; then
+    VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${HOME}/.virtualenvs/mycroft"}
+else
+    VIRTUALENV_ROOT="$WORKON_HOME"
+fi
 
 # create virtualenv, consistent with virtualenv-wrapper conventions
 if [ ! -d ${VIRTUALENV_ROOT} ]; then

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -37,7 +37,7 @@ TOP=$(cd $(dirname $0) && pwd -L)
 if [ -z "$WORKON_HOME" ]; then
     VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${HOME}/.virtualenvs/mycroft"}
 else
-    VIRTUALENV_ROOT="$WORKON_HOME"
+    VIRTUALENV_ROOT="$WORKON_HOME/mycroft"
 fi
 
 # create virtualenv, consistent with virtualenv-wrapper conventions


### PR DESCRIPTION
```
  - favor using the WORKON_HOME environment variable over
    VIRTUALENV_ROOT
  - closes #372 
```
