### PR TITLE
Bugfix/issues 343

### DIFF
--- a/mycroft/client/enclosure/api.py
+++ b/mycroft/client/enclosure/api.py
@@ -45,6 +45,9 @@ class EnclosureAPI:
         self.client.emit(
             Message("enclosure.system.blink", metadata={'times': times}))
 
+    def system_reset(self):
+        self.client.emit(Message("enclosure.system.reset"))
+
     def eyes_on(self):
         self.client.emit(Message("enclosure.eyes.on"))
 

--- a/mycroft/client/enclosure/api.py
+++ b/mycroft/client/enclosure/api.py
@@ -26,14 +26,16 @@ LOGGER = getLogger(__name__)
 
 class EnclosureAPI:
     """
-    This API is intended to be used to control Mycroft hardware capabilities.
-
-    It exposes all possible enclosure commands to be performed by a Mycroft
-    unit.
+    This API is intended to be used to interface with the hardware
+    that is running Mycroft.  It exposes all possible commands which
+    can be sent to a Mycroft enclosure implementation.
     """
 
     def __init__(self, client):
         self.client = client
+
+    def reset(self):
+        self.client.emit(Message("enclosure.reset"))
 
     def system_mute(self):
         self.client.emit(Message("enclosure.system.mute"))
@@ -44,9 +46,6 @@ class EnclosureAPI:
     def system_blink(self, times):
         self.client.emit(
             Message("enclosure.system.blink", metadata={'times': times}))
-
-    def system_reset(self):
-        self.client.emit(Message("enclosure.system.reset"))
 
     def eyes_on(self):
         self.client.emit(Message("enclosure.eyes.on"))

--- a/mycroft/client/enclosure/enclosure.py
+++ b/mycroft/client/enclosure/enclosure.py
@@ -210,6 +210,13 @@ class Enclosure:
                 # Use the serial port to check if this is a Mycroft
                 # Mark 1 unit.
                 platform = self.detect_platform()
+                if platform == 'unknown':
+                    # Since this is a semi-permanent detection, be
+                    # certain!  Sometimes noise on the serial line
+                    # causes a faulty mis-detection on a real
+                    # Mycroft Mark 1
+                    platform = self.detect_platform()
+
                 ConfigurationManager.set('enclosure', 'platform',
                                          platform)
         except Exception as e:
@@ -245,6 +252,12 @@ class Enclosure:
         LOGGER.info("Auto-detecting platform")
         try:
             self.__init_serial()
+            self.serial.flushInput()
+            self.serial.flushOutput()
+            time.sleep(1)
+            self.serial.flushInput()
+            self.serial.flushOutput()
+            time.sleep(1)
 
             # Write "system.ping"
             self.serial.write("system.ping")
@@ -264,6 +277,7 @@ class Enclosure:
                 # The Arduino returns a version number in the response
                 # with recent builds.  Empty the serial queue of all
                 # responses to the ping.
+                time.sleep(0.5)
                 self.serial.flushInput()
 
                 return "mycroft_mark_1"
@@ -304,7 +318,6 @@ class Enclosure:
             os.chdir(old_path)
 
     def __init_serial(self):
-        LOGGER.info("__init_serial...")
         if getattr(self, 'serial', None) is not None:
             return  # already initialized
 

--- a/mycroft/client/enclosure/enclosure.py
+++ b/mycroft/client/enclosure/enclosure.py
@@ -227,9 +227,14 @@ class Enclosure:
         self.client = WebsocketClient()
         self.reader = EnclosureReader(self.serial, self.client)
         self.writer = EnclosureWriter(self.serial, self.client)
+
+        # Create helpers to handle the various parts of the enclosure
         self.eyes = EnclosureEyes(self.client, self.writer)
         self.mouth = EnclosureMouth(self.client, self.writer)
         self.system = EnclosureArduino(self.client, self.writer)
+
+        # TODO: Remove this once the Skill can send images directly
+        #       to the Enclosure.
         self.weather = EnclosureWeather(self.client, self.writer)
         self.__register_events()
 

--- a/mycroft/client/enclosure/enclosure.py
+++ b/mycroft/client/enclosure/enclosure.py
@@ -39,7 +39,7 @@ from mycroft.util import str2bool
 from mycroft.util.audio_test import record
 from mycroft.util.log import getLogger
 
-__author__ = 'aatchison + jdorleans + iward'
+__author__ = 'aatchison + jdorleans + iward + penrods'
 
 LOGGER = getLogger("EnclosureClient")
 
@@ -212,17 +212,20 @@ class Enclosure:
                 platform = self.detect_platform()
                 ConfigurationManager.set('enclosure', 'platform',
                                          platform)
+        except Exception as e:
+            self.disconnect()
+            raise Exception("Exception: Unable to determine platform\n" +
+                            str(e))
 
-            if platform is "mycroft_mark_1":
-                # We are a mycroft_mark_1 unit, start up the
-                # enclosure client to communicate over the
-                # serial port
-                self.__init_serial()
-            else:
-                raise Exception("Exception: Not a Mycroft Mark 1")
-
-        except:
-            raise Exception("Exception: Unable to load configuration")
+        LOGGER.info("Platform = '" + platform + "'")
+        if platform == "mycroft_mark_1":
+            # We are a mycroft_mark_1 unit, start up the
+            # enclosure client to communicate over the
+            # serial port
+            self.__init_serial()
+        else:
+            self.disconnect()
+            raise Exception("Exception: Not a Mycroft Mark 1, shutting down")
 
         self.client = WebsocketClient()
         self.reader = EnclosureReader(self.serial, self.client)
@@ -233,28 +236,42 @@ class Enclosure:
         self.mouth = EnclosureMouth(self.client, self.writer)
         self.system = EnclosureArduino(self.client, self.writer)
 
-        # TODO: Remove this once the Skill can send images directly
-        #       to the Enclosure.
+        # TODO: Remove EnclosureWeather once the Skill can send images
+        #       directly to the EnclosureAPI.
         self.weather = EnclosureWeather(self.client, self.writer)
         self.__register_events()
 
     def detect_platform(self):
         LOGGER.info("Auto-detecting platform")
-        self.__init_serial()
+        try:
+            self.__init_serial()
 
-        # Write out "system.ping"
-        self.serial.write("system.ping\n")
-        time.sleep(0.5)
+            # Write "system.ping"
+            self.serial.write("system.ping")
+            time.sleep(1)
 
-        # Now check to see if we got a response from the ping
-        # This assumes only a Mycroft Arduino responds to this
-        # which is probably a dubious assumption.  But a
-        # decent enough auto-detect.
-        data = self.serial.readline()[:-2]
-        if "Command: system.ping" in data:
-            return "mycroft_mark_1"
-        else:
-            return "unknown"
+            # Now check to see if we got a response from the ping command.
+            data = self.serial.readline()
+            LOGGER.info("Serial response: '" + data + "'")
+
+            # The Mycroft Arduino echos the output to the serial line
+            # prefixed by "Command: ".  This assumes only a Mycroft
+            # Arduino responds to this, which is probably a dubious
+            # assumption, but a decent enough auto-detect for now.
+            if "Command: system.ping" in data:
+                # We have a Mycroft Mark 1!
+
+                # The Arduino returns a version number in the response
+                # with recent builds.  Empty the serial queue of all
+                # responses to the ping.
+                self.serial.flushInput()
+
+                return "mycroft_mark_1"
+        except:
+            pass
+
+        # Likely running on a generic Raspberry Pi or Linux desktop
+        return "unknown"
 
     def setup(self):
         must_upload = self.config.get('must_upload')
@@ -287,11 +304,12 @@ class Enclosure:
             os.chdir(old_path)
 
     def __init_serial(self):
-        if self.port is None:
+        LOGGER.info("__init_serial...")
+        if getattr(self, 'serial', None) is not None:
             return  # already initialized
 
+        LOGGER.info("Opening serial port")
         try:
-            LOGGER.info("Opening serial port" + data)
             self.port = self.config.get("port")
             self.rate = int(self.config.get("rate"))
             self.timeout = int(self.config.get("timeout"))
@@ -346,10 +364,15 @@ class Enclosure:
             LOGGER.error("Client error: {0}".format(e))
             self.stop()
 
+    def disconnect(self):
+        if getattr(self, 'serial', None) is not None:
+            self.serial.close()
+            self.serial = None
+
     def stop(self):
         self.writer.stop()
         self.reader.stop()
-        self.serial.close()
+        self.disconnect()
 
 
 def main():

--- a/mycroft/client/enclosure/eyes.py
+++ b/mycroft/client/enclosure/eyes.py
@@ -48,7 +48,6 @@ class EnclosureEyes:
         self.client.on('enclosure.eyes.spin', self.spin)
         self.client.on('enclosure.eyes.timedspin', self.timed_spin)
         self.client.on('enclosure.eyes.reset', self.reset)
-        self.client.on('enclosure.system.reset', self.system_reset)
 
     def on(self, event=None):
         self.writer.write("eyes.on")
@@ -93,13 +92,6 @@ class EnclosureEyes:
 
     def reset(self, event=None):
         self.writer.write("eyes.reset")
-
-    def system_reset(self, event=None):
-        # This is a little bit of an odd duck.  Handle reset
-        # of both the eyes and the mouth elements of the unit.
-        self.writer.write("eyes.reset")
-        time.sleep(0.25)
-        self.writer.write("mouth.reset")
 
     def spin(self, event=None):
         self.writer.write("eyes.spin")

--- a/mycroft/client/enclosure/eyes.py
+++ b/mycroft/client/enclosure/eyes.py
@@ -17,6 +17,7 @@
 
 
 from mycroft.util.log import getLogger
+import time
 
 __author__ = 'jdorleans'
 
@@ -47,6 +48,7 @@ class EnclosureEyes:
         self.client.on('enclosure.eyes.spin', self.spin)
         self.client.on('enclosure.eyes.timedspin', self.timed_spin)
         self.client.on('enclosure.eyes.reset', self.reset)
+        self.client.on('enclosure.system.reset', self.system_reset)
 
     def on(self, event=None):
         self.writer.write("eyes.on")
@@ -91,6 +93,13 @@ class EnclosureEyes:
 
     def reset(self, event=None):
         self.writer.write("eyes.reset")
+
+    def system_reset(self, event=None):
+        # This is a little bit of an odd duck.  Handle reset
+        # of both the eyes and the mouth elements of the unit.
+        self.writer.write("eyes.reset")
+        time.sleep(0.25)
+        self.writer.write("mouth.reset")
 
     def spin(self, event=None):
         self.writer.write("eyes.spin")

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -122,10 +122,13 @@ def handle_stop(event):
 
 
 def handle_open():
-    # Send the enclosure a message to reset the rolling
-    # eyes shown at boot on a unit
+    # The websocket is up and ready for business.  This is a reasonable time
+    # to declare the system is ready for normal operations.  Send the
+    # enclosure a message to reset itself to let the user know the system
+    # is ready to receive input, such as stopping the rolling eyes shown
+    # at boot on a Mycroft Mark 1 unit.
     enclosure = EnclosureAPI(client)
-    enclosure.system_reset()
+    enclosure.reset()
 
 
 def connect():

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -29,6 +29,7 @@ from mycroft.tts import tts_factory
 from mycroft.util.log import getLogger
 from mycroft.util import kill, connected
 from mycroft.util import play_mp3
+from mycroft.client.enclosure.api import EnclosureAPI
 
 logger = getLogger("SpeechClient")
 client = None
@@ -148,10 +149,11 @@ def main():
     event_thread.setDaemon(True)
     event_thread.start()
 
-    try:
-        subprocess.call('echo "eyes.reset" >/dev/ttyAMA0', shell=True)
-    except:
-        pass
+    # Send the enclosure a message to reset the rolling
+    # eyes shown at boot on a unit
+    enclosure = EnclosureAPI(client)
+    enclosure.eyes_reset()
+    enclosure.mouth_reset()
 
     try:
         loop.run()

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -121,6 +121,13 @@ def handle_stop(event):
     kill(["aplay"])
 
 
+def handle_open():
+    # Send the enclosure a message to reset the rolling
+    # eyes shown at boot on a unit
+    enclosure = EnclosureAPI(client)
+    enclosure.system_reset()
+
+
 def connect():
     client.run_forever()
 
@@ -144,16 +151,11 @@ def main():
         handle_multi_utterance_intent_failure)
     client.on('recognizer_loop:sleep', handle_sleep)
     client.on('recognizer_loop:wake_up', handle_wake_up)
+    client.on('open', handle_open)
     client.on('mycroft.stop', handle_stop)
     event_thread = Thread(target=connect)
     event_thread.setDaemon(True)
     event_thread.start()
-
-    # Send the enclosure a message to reset the rolling
-    # eyes shown at boot on a unit
-    enclosure = EnclosureAPI(client)
-    enclosure.eyes_reset()
-    enclosure.mouth_reset()
 
     try:
         loop.run()


### PR DESCRIPTION
Correct several issues that broke Mycroft on a generic Raspberry Pi:
* Removed a direct write to the serial port in the voice loop, now using the EnclosureAPI
* Added a system_reset() to the EnclosureAPI.  On the Mycroft Mark 1 this now resets both the mouth and eyes.
* The enclosure.py auto-detects if running on a Mark 1 or a generic Pi.  It kills itself if not on a Mark 1 (which prevents writing out the serial port connected to who-knows-what)
