### PR TITLE
Update skills system to load from subfolders

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -37,7 +37,7 @@ __author__ = 'seanfitz'
 PRIMARY_SKILLS = ['intent', 'wake']
 BLACKLISTED_SKILLS = ["send_sms", "media"]
 SKILLS_BASEDIR = dirname(__file__)
-THIRD_PARTY_SKILLS_DIR = "/opt/mycroft/skills"
+THIRD_PARTY_SKILLS_DIR = ["/opt/mycroft/third_party", "/opt/mycroft/skills"] # Note: /opt/mycroft/skills is recommended, /opt/mycroft/third_party is for backwards compatibility
 
 MainModule = '__init__'
 
@@ -117,6 +117,14 @@ def get_skills(skills_folder):
     possible_skills = os.listdir(skills_folder)
     for i in possible_skills:
         location = join(skills_folder, i)
+        if (isdir(location) and
+           not MainModule + ".py" in os.listdir(location)):
+            for j in os.listdir(location):
+                name = join(location, j)
+                if (not isdir(name) or
+                        not MainModule + ".py" in os.listdir(name)):
+                    continue
+                skills.append(create_skill_descriptor(name))
         if (not isdir(location) or
                 not MainModule + ".py" in os.listdir(location)):
             continue

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -37,7 +37,9 @@ __author__ = 'seanfitz'
 PRIMARY_SKILLS = ['intent', 'wake']
 BLACKLISTED_SKILLS = ["send_sms", "media"]
 SKILLS_BASEDIR = dirname(__file__)
-THIRD_PARTY_SKILLS_DIR = ["/opt/mycroft/third_party", "/opt/mycroft/skills"] # Note: /opt/mycroft/skills is recommended, /opt/mycroft/third_party is for backwards compatibility
+THIRD_PARTY_SKILLS_DIR = ["/opt/mycroft/third_party", "/opt/mycroft/skills"]
+# Note: /opt/mycroft/skills is recommended, /opt/mycroft/third_party
+# is for backwards compatibility
 
 MainModule = '__init__'
 
@@ -118,7 +120,7 @@ def get_skills(skills_folder):
     for i in possible_skills:
         location = join(skills_folder, i)
         if (isdir(location) and
-           not MainModule + ".py" in os.listdir(location)):
+                not MainModule + ".py" in os.listdir(location)):
             for j in os.listdir(location):
                 name = join(location, j)
                 if (not isdir(name) or
@@ -146,8 +148,8 @@ def load_skills(emitter, skills_root=SKILLS_BASEDIR):
             load_skill(skill, emitter)
 
     for skill in skills:
-        if (skill['name'] not in PRIMARY_SKILLS and skill['name'] not in
-                BLACKLISTED_SKILLS):
+        if (skill['name'] not in PRIMARY_SKILLS and
+                skill['name'] not in BLACKLISTED_SKILLS):
             load_skill(skill, emitter)
 
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -44,7 +44,7 @@ def load_skills_callback():
     for loc in THIRD_PARTY_SKILLS_DIR:
         if exists(loc):
             load_skills(client, loc)
-    
+
     if ini_third_party_skills_dir and exists(ini_third_party_skills_dir):
         load_skills(ws, ini_third_party_skills_dir)
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -41,9 +41,10 @@ def load_skills_callback():
     except AttributeError as e:
         logger.warning(e.message)
 
-    if exists(THIRD_PARTY_SKILLS_DIR):
-        load_skills(ws, THIRD_PARTY_SKILLS_DIR)
-
+    for loc in THIRD_PARTY_SKILLS_DIR:
+        if exists(loc):
+            load_skills(client, loc)
+    
     if ini_third_party_skills_dir and exists(ini_third_party_skills_dir):
         load_skills(ws, ini_third_party_skills_dir)
 


### PR DESCRIPTION
This updates the skill loading to be able to look one subfolder deep for skills. It also adds back `/opt/mycroft/third_party` as a possible place to look for skills for backwards compatibility purposes.