### PR TITLE
Issue #425 -- Integrate new Arduino update method ( Mark I enclosure no start at boot)

### DIFF
--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -215,25 +215,7 @@ class Enclosure(object):
         self.system = EnclosureArduino(self.ws, self.writer)
         self.weather = EnclosureWeather(self.ws, self.writer)
         self.__register_events()
-        #self.update()
-        self.test()
         self.started = True
-
-    def update(self):
-        if self.config.get("update"):
-            try:
-                self.speak("Upgrading enclosure version")
-                subprocess.check_call("/opt/enclosure/upload.sh")
-                self.speak("Enclosure update completed")
-                ConfigurationManager.save({"enclosure": {"update": False}})
-            except:
-                self.speak("I cannot upgrade right now, I'll try later")
-
-    def test(self):
-        if self.config.get("test"):
-            self.speak("Beginning hardware test")
-            self.writer.write("test.begin")
-            ConfigurationManager.save({"enclosure": {"test": False}})
 
     def __init_serial(self):
         try:


### PR DESCRIPTION
In order to go ahead with the new Arduino update method, as well as fix the boot issue, I have removed update and test from the enclosure client.
