### PR TITLE
Issues-410 - Fixing 'install_pygtk.sh cd: too many arguments'

### DIFF
--- a/scripts/install-pygtk.sh
+++ b/scripts/install-pygtk.sh
@@ -69,7 +69,7 @@ then
     (   cd $CACHE
         curl 'https://pypi.python.org/packages/source/P/PyGTK/pygtk-2.24.0.tar.bz2' > 'pygtk.tar.bz2'
         tar -xvf pygtk.tar.bz2
-        (   cd pygtk*
+        (   cd pygtk-*
             ./configure --prefix=$VIRTUAL_ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$VIRTUAL_ENV/lib/pkgconfig
             make -j$CORES
             make install


### PR DESCRIPTION
Simply adding a hyphen at line 72: pygtk-* did it.
The reason of this bug is that in the cache directory we have two files starting with pygtk, but only a folder continues with a hyphen.