### PR TITLE
Preparation for next mimic-release

### DIFF
--- a/scripts/install-mimic.sh
+++ b/scripts/install-mimic.sh
@@ -4,10 +4,11 @@ set -Ee
 
 MIMIC_DIR=mimic
 CORES=$(nproc)
+MIMIC_VERSION=1.1.0
 
 # download and install mimic
 if [ ! -d ${MIMIC_DIR} ]; then
-    git clone https://github.com/MycroftAI/mimic.git
+    git clone --branch ${MIMIC_VERSION} https://github.com/MycroftAI/mimic.git
     cd ${MIMIC_DIR}
     ./configure --with-audio=alsa
     make #-j$CORES


### PR DESCRIPTION
We intend to merge the mimic development branch into the master and create **mimic v1.2.0**, the build system has changed and the current install script will not generate a mimic installation that's usable. (New build script and a new required library)

This PR updates the script to checkout a specific mimic-version, in this case the current **v1.1.0**.

I would appreciate if this could be merged quickly so we can release **mimic v1.2.0** without causing failed Mycroft installs and then begin with the changes needed in install script and build_host scripts for mycroft.