### PR TITLE
#438 - Added KaldiSTT as a Speech to Text-Engine.

### DIFF
--- a/mycroft/client/wifisetup/main.py
+++ b/mycroft/client/wifisetup/main.py
@@ -520,7 +520,7 @@ def main():
     try:
         wifi.run()
     except Exception as e:
-        print (e)
+        print(e)
     finally:
         sys.exit()
 

--- a/mycroft/skills/configuration/__init__.py
+++ b/mycroft/skills/configuration/__init__.py
@@ -54,7 +54,8 @@ class ConfigurationSkill(ScheduledSkill):
             self.update()
         except HTTPError as e:
             if e.response.status_code == 401:
-                self.log.warn("Impossible to update configuration because device isn't paired")
+                self.log.warn("Impossible to update configuration because "
+                              "device isn't paired")
         self.schedule()
 
     def update(self):

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -37,7 +37,7 @@ __author__ = 'seanfitz'
 PRIMARY_SKILLS = ['intent', 'wake']
 BLACKLISTED_SKILLS = ["send_sms", "media"]
 SKILLS_BASEDIR = dirname(__file__)
-THIRD_PARTY_SKILLS_DIR = "/opt/mycroft/skills"
+THIRD_PARTY_SKILLS_DIR = ["/opt/mycroft/third_party", "/opt/mycroft/skills"] # Note: /opt/mycroft/skills is recommended, /opt/mycroft/third_party is for backwards compatibility
 
 MainModule = '__init__'
 
@@ -117,6 +117,14 @@ def get_skills(skills_folder):
     possible_skills = os.listdir(skills_folder)
     for i in possible_skills:
         location = join(skills_folder, i)
+        if (isdir(location) and
+           not MainModule + ".py" in os.listdir(location)):
+            for j in os.listdir(location):
+                name = join(location, j)
+                if (not isdir(name) or
+                        not MainModule + ".py" in os.listdir(name)):
+                    continue
+                skills.append(create_skill_descriptor(name))
         if (not isdir(location) or
                 not MainModule + ".py" in os.listdir(location)):
             continue

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -37,7 +37,9 @@ __author__ = 'seanfitz'
 PRIMARY_SKILLS = ['intent', 'wake']
 BLACKLISTED_SKILLS = ["send_sms", "media"]
 SKILLS_BASEDIR = dirname(__file__)
-THIRD_PARTY_SKILLS_DIR = ["/opt/mycroft/third_party", "/opt/mycroft/skills"] # Note: /opt/mycroft/skills is recommended, /opt/mycroft/third_party is for backwards compatibility
+THIRD_PARTY_SKILLS_DIR = ["/opt/mycroft/third_party", "/opt/mycroft/skills"]
+# Note: /opt/mycroft/skills is recommended, /opt/mycroft/third_party
+# is for backwards compatibility
 
 MainModule = '__init__'
 
@@ -118,7 +120,7 @@ def get_skills(skills_folder):
     for i in possible_skills:
         location = join(skills_folder, i)
         if (isdir(location) and
-           not MainModule + ".py" in os.listdir(location)):
+                not MainModule + ".py" in os.listdir(location)):
             for j in os.listdir(location):
                 name = join(location, j)
                 if (not isdir(name) or
@@ -146,8 +148,8 @@ def load_skills(emitter, skills_root=SKILLS_BASEDIR):
             load_skill(skill, emitter)
 
     for skill in skills:
-        if (skill['name'] not in PRIMARY_SKILLS and skill['name'] not in
-                BLACKLISTED_SKILLS):
+        if (skill['name'] not in PRIMARY_SKILLS and
+                skill['name'] not in BLACKLISTED_SKILLS):
             load_skill(skill, emitter)
 
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -138,8 +138,8 @@ def load_skills(emitter, skills_root=SKILLS_BASEDIR):
             load_skill(skill, emitter)
 
     for skill in skills:
-        if (skill['name'] not in PRIMARY_SKILLS and
-                    skill['name'] not in BLACKLISTED_SKILLS):
+        if (skill['name'] not in PRIMARY_SKILLS and skill['name'] not in
+                BLACKLISTED_SKILLS):
             load_skill(skill, emitter)
 
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -44,7 +44,7 @@ def load_skills_callback():
     for loc in THIRD_PARTY_SKILLS_DIR:
         if exists(loc):
             load_skills(client, loc)
-    
+
     if ini_third_party_skills_dir and exists(ini_third_party_skills_dir):
         load_skills(ws, ini_third_party_skills_dir)
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -41,9 +41,10 @@ def load_skills_callback():
     except AttributeError as e:
         logger.warning(e.message)
 
-    if exists(THIRD_PARTY_SKILLS_DIR):
-        load_skills(ws, THIRD_PARTY_SKILLS_DIR)
-
+    for loc in THIRD_PARTY_SKILLS_DIR:
+        if exists(loc):
+            load_skills(client, loc)
+    
     if ini_third_party_skills_dir and exists(ini_third_party_skills_dir):
         load_skills(ws, ini_third_party_skills_dir)
 

--- a/mycroft/skills/wolfram_alpha/__init__.py
+++ b/mycroft/skills/wolfram_alpha/__init__.py
@@ -179,7 +179,7 @@ class WolframAlphaSkill(MycroftSkill):
             if len(others) > 0:
                 self.speak_dialog('others.found',
                                   data={'utterance': utterance, 'alternative':
-                                      others[0]})
+                                        others[0]})
             else:
                 self.speak_dialog("not.understood", data={'phrase': phrase})
 

--- a/mycroft/version/__init__.py
+++ b/mycroft/version/__init__.py
@@ -30,10 +30,12 @@ class VersionManager(object):
 
     @staticmethod
     def get():
-        if exists(VersionManager.__location) and isfile(VersionManager.__location):
+        if (exists(VersionManager.__location) and
+                isfile(VersionManager.__location)):
             try:
                 with open(VersionManager.__location) as f:
                     return json.load(f)
             except:
-                LOG.error("Failed to load version from '%s'" % VersionManager.__location)
+                LOG.error("Failed to load version from '%s'"
+                          % VersionManager.__location)
         return {"coreVersion": None, "enclosureVersion": None}


### PR DESCRIPTION
Kaldi gstreamer server has to run on localhost. Use this kaldi gstreamer server: https://github.com/alumae/kaldi-gstreamer-server 
Tested on a local machine with the kaldigstserver shipped with lucida (another AI). For using KaldiSTT you have to set the config for server to "update": false and the stt to "module": "kaldi" with "port" to your kaldigstserver port Number. Default is 8081.