### PR TITLE
Allow test to finsh immediately

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -142,15 +142,22 @@ def create_skill_descriptor(skill_folder):
 
 
 def load_skills(emitter, skills_root=SKILLS_BASEDIR):
+    skill_list = []
     skills = get_skills(skills_root)
     for skill in skills:
         if skill['name'] in PRIMARY_SKILLS:
-            load_skill(skill, emitter)
+            skill_list.append(load_skill(skill, emitter))
 
     for skill in skills:
         if (skill['name'] not in PRIMARY_SKILLS and
                 skill['name'] not in BLACKLISTED_SKILLS):
-            load_skill(skill, emitter)
+            skill_list.append(load_skill(skill, emitter))
+    return skill_list
+
+
+def unload_skills(skills):
+    for s in skills:
+        s.cleanup()
 
 
 class MycroftSkill(object):
@@ -262,3 +269,7 @@ class MycroftSkill(object):
     def is_stop(self):
         passed_time = time.time() - self.stop_time
         return passed_time < self.stop_threshold
+
+    def cleanup(self):
+        """ Clean up running threads, etc. """
+        pass

--- a/mycroft/skills/scheduled_skills.py
+++ b/mycroft/skills/scheduled_skills.py
@@ -113,6 +113,11 @@ class ScheduledSkill(MycroftSkill):
     def notify(self, timestamp):
         pass
 
+    def cleanup(self):
+        """ Cancel timer making the skill ready for shutdown """
+        if self.timer:
+            self.timer.cancel()
+
 
 class ScheduledCRUDSkill(ScheduledSkill):
     """

--- a/test/skills/discover_tests.py
+++ b/test/skills/discover_tests.py
@@ -50,8 +50,13 @@ class IntentTestSequence(unittest.TestCase):
     __metaclass__ = IntentTestSequenceMeta
 
     def setUp(self):
-        self.emitter = MockSkillsLoader(
-            os.path.join(PROJECT_ROOT, 'mycroft', 'skills')).load_skills()
+        self.loader = MockSkillsLoader(
+            os.path.join(PROJECT_ROOT, 'mycroft', 'skills'))
+        self.emitter = self.loader.load_skills()
+
+    def tearDown(self):
+        self.loader.unload_skills()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/skills/skill_tester.py
+++ b/test/skills/skill_tester.py
@@ -3,7 +3,7 @@ import json
 from pyee import EventEmitter
 
 from mycroft.messagebus.message import Message
-from mycroft.skills.core import load_skills
+from mycroft.skills.core import load_skills, unload_skills
 
 __author__ = 'seanfitz'
 
@@ -31,8 +31,11 @@ class MockSkillsLoader(object):
         self.emitter = RegistrationOnlyEmitter()
 
     def load_skills(self):
-        load_skills(self.emitter, self.skills_root)
+        self.skills = load_skills(self.emitter, self.skills_root)
         return self.emitter.emitter  # kick out the underlying emitter
+
+    def unload_skills(self):
+        unload_skills(self.skills)
 
 
 class SkillTest(object):


### PR DESCRIPTION
This is a way to fix #447 

# What it does
The PR adds a cleanup method to skills and allows this to be run when calling `unload_skills()`. For scheduled skills this cancels running timers that would be blocking termination. (as timers reference a class method the class won't be garbage collected)

The `unload_skills()` method is now called when the skill intent test is teared down allowing the unittest to finish directly.