### PR TITLE
Fixes issue #461

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -37,7 +37,7 @@ class Api(object):
         query = self.build_query(params)
         url = self.build_url(params)
         response = requests.request(method, url, headers=headers, params=query,
-                                    data=data, json=json)
+                                    data=data, json=json, timeout=(3.05, 15))
         return self.get_response(response)
 
     def request(self, params):


### PR DESCRIPTION
Changed the default network timeout to just over 3 seconds to establish the connection, then 15 seconds for all reads.  These values are as per the suggestion of http://docs.python-requests.org/en/master/user/advanced/.