### PR TITLE
Fix related to issue #457

### DIFF
--- a/mycroft/client/wifisetup/main.py
+++ b/mycroft/client/wifisetup/main.py
@@ -374,7 +374,7 @@ class WiFi:
                     if "(incomplete)" in o:
                         # ping the IP to get the ARP table entry reloaded
                         ip_disconnected = o.split(" ")[0]
-                        cli_no_output('/bin/ping', '-c', '1', '-W', 3,
+                        cli_no_output('/bin/ping', '-c', '1', '-W', '3',
                                       ip_disconnected)
                     else:
                         return True  # something on subnet is connected!


### PR DESCRIPTION
The bug was actually fixed by doing a rebase, catching hotfixes which were missing from the dev branch.

The bug exposed this line of code, which was throwing an error without the quotes on the parameter to ping.