### PR TITLE
Issue #460- Adds Phonetic Spelling to Pairing Skill

### DIFF
--- a/mycroft/skills/pairing/__init__.py
+++ b/mycroft/skills/pairing/__init__.py
@@ -35,9 +35,9 @@ class PairingSkill(MycroftSkill):
         self.delay = 10
         self.activator = None
         self.nato_dict= 'A':'A as in Alpha', 'B':'B as in Bravo','C':'C as in Charlie', 'D':'D as in Delta',\
-                         'E':'E as in Echo', 'F':'F as in Foxtrot', 'G':'G as in Golf',"H":"H as in Hotel",\
+                         'E':'E as in Echo', 'F':'F as in Fox. trot', 'G':'G as in Golf',"H":"H as in Hotel",\
                          'I':'I as in India', 'J':'J as in Juliet', 'K':'K as in Kilo', 'L':'L as in Lima', \
-                         'M':'M as in Mike', 'N':'N as in November', 'O':'O as in Oscar', 'P':'P as in Papa',\
+                         'M':'M as in Mike', 'N':'N as in November', 'O':'O as in Oscar', 'P':'P as in Pa-pa',\
                          'Q':'Q as in Quebec','R':'R as in Romeo','S':'S as in Sierra', 'T':'T as in Tango', \
                          'U':'U as in Uniform', 'V':'V as in Victor', 'W':'W as in Whiskey',\
                          'X':'X as in X. Ray', 'Y':'Y as in Yankee', 'Z':'Z as in Zulu', '1':'One', '2':'Two', '3':'Three',\

--- a/mycroft/skills/pairing/__init__.py
+++ b/mycroft/skills/pairing/__init__.py
@@ -85,7 +85,7 @@ class PairingSkill(MycroftSkill):
         return device is not None
 
     def speak_code(self):
-        data = {"code": '. '.join(self.data.get("code"))}
+        data = {"code": '. '.join(self.data.get("code")).replace("0", "zero")}
         self.speak_dialog("pairing.code", data)
 
     def stop(self):

--- a/mycroft/skills/pairing/__init__.py
+++ b/mycroft/skills/pairing/__init__.py
@@ -34,7 +34,7 @@ class PairingSkill(MycroftSkill):
         self.state = str(uuid4())
         self.delay = 10
         self.activator = None
-        self.nato_dict= 'A':'A as in Alpha', 'B':'B as in Bravo','C':'C as in Charlie', 'D':'D as in Delta',\
+        self.nato_dict= {'A':'A as in Alpha', 'B':'B as in Bravo','C':'C as in Charlie', 'D':'D as in Delta',\
                          'E':'E as in Echo', 'F':'F as in Fox. trot', 'G':'G as in Golf',"H":"H as in Hotel",\
                          'I':'I as in India', 'J':'J as in Juliet', 'K':'K as in Kilo', 'L':'L as in Lima', \
                          'M':'M as in Mike', 'N':'N as in November', 'O':'O as in Oscar', 'P':'P as in Pa-pa',\

--- a/mycroft/skills/pairing/__init__.py
+++ b/mycroft/skills/pairing/__init__.py
@@ -34,11 +34,12 @@ class PairingSkill(MycroftSkill):
         self.state = str(uuid4())
         self.delay = 10
         self.activator = None
-        self.nato_dict= {'A':'A as in Alpha', 'B':'B as in Bravo','C':'C as in Charlie', 'D':'D as in Delta',\
-                         'E':'E as in Echo', 'F':'F as in Foxtrot', 'G':'G as in Golf',"H":" as in Hotel",\
-                         'I':'I as in India', 'J':'J as in Juliet', 'K':'K as in Kilo', 'L':'L as in Lima', 'M':'M as in Mike',\
-                         'N':'N as in November', 'O':'O as in Oscar', 'P':'P as in Papa', 'Q':'Q as in Quebec', 'R':'R as in Romeo',\
-                         'S':'S as in Sierra', 'T':'T as in Tango', 'U':'U as in Uniform', 'V':'V as in Victor', 'W':'W as in Whiskey',\
+        self.nato_dict= 'A':'A as in Alpha', 'B':'B as in Bravo','C':'C as in Charlie', 'D':'D as in Delta',\
+                         'E':'E as in Echo', 'F':'F as in Foxtrot', 'G':'G as in Golf',"H":"H as in Hotel",\
+                         'I':'I as in India', 'J':'J as in Juliet', 'K':'K as in Kilo', 'L':'L as in Lima', \
+                         'M':'M as in Mike', 'N':'N as in November', 'O':'O as in Oscar', 'P':'P as in Papa',\
+                         'Q':'Q as in Quebec','R':'R as in Romeo','S':'S as in Sierra', 'T':'T as in Tango', \
+                         'U':'U as in Uniform', 'V':'V as in Victor', 'W':'W as in Whiskey',\
                          'X':'X as in X. Ray', 'Y':'Y as in Yankee', 'Z':'Z as in Zulu', '1':'One', '2':'Two', '3':'Three',\
                          '4':'Four', '5':'Five', '6':'Six', '7':'Seven', '8':'Eight', '9':'Nine',\
                          '0':'Zero'}

--- a/mycroft/skills/pairing/__init__.py
+++ b/mycroft/skills/pairing/__init__.py
@@ -85,7 +85,9 @@ class PairingSkill(MycroftSkill):
         return device is not None
 
     def speak_code(self):
-        data = {"code": '. '.join(self.data.get("code")).replace("0", "zero")}
+        code = self.data.get("code")
+        self.log.info("Pairing code: " + code)
+        data = {"code": '. '.join(code).replace("0", "zero")}
         self.speak_dialog("pairing.code", data)
 
     def stop(self):


### PR DESCRIPTION
Adds NATO Phonetic alphabet to pairing skill, so reads codes as:
"A as in Alpaha, Three, B as in Bravo...."