### PR TITLE
Reduce max recording time #528

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -133,7 +133,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
     # The maximum length a phrase can be recorded,
     # provided there is noise the entire time
-    RECORDING_TIMEOUT = 30.0
+    RECORDING_TIMEOUT = 10.0
 
     # The maximum time it will continue to record silence
     # when not enough noise has been detected


### PR DESCRIPTION
Fixes issues #528
Max recording time is now 10 seconds instead of 30.  This deals with cases where a noisy background prevents the listener's silence detection from triggering.  30 seconds was WAAY too long to keep listening -- nobody is going to be saying something that long for now.