### PR TITLE
allow skills not to reload

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -180,6 +180,7 @@ class MycroftSkill(object):
         self.file_system = FileSystemAccess(join('skills', name))
         self.registered_intents = []
         self.log = getLogger(name)
+        self.reload_skill = True
 
     @property
     def location(self):

--- a/mycroft/skills/intent/__init__.py
+++ b/mycroft/skills/intent/__init__.py
@@ -31,6 +31,7 @@ class IntentSkill(MycroftSkill):
     def __init__(self):
         MycroftSkill.__init__(self, name="IntentSkill")
         self.engine = IntentDeterminationEngine()
+        self.reload_skill = False
 
     def initialize(self):
         self.emitter.on('register_vocab', self.handle_register_vocab)

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -103,6 +103,8 @@ def watch_skills():
                         continue
                     elif skill.get(
                             "instance") and modified > last_modified_skill:
+                        if not skill["instance"].reload_skill:
+                            continue
                         logger.debug("Reloading Skill: " + skill_folder)
                         skill["instance"].shutdown()
                         clear_skill_events(skill["instance"])


### PR DESCRIPTION
when changing intent skill it would get auto-reloaded and miss register_intent messages causing weird behaviour

in my dictation skill, writign dictated file to skill folder caused skill to reload and reset some variables

skills should be allowed to ask not to be reloaded