### PR TITLE
added blacklist check to load_skill#551

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -96,6 +96,9 @@ def open_intent_envelope(message):
 def load_skill(skill_descriptor, emitter):
     try:
         logger.info("ATTEMPTING TO LOAD SKILL: " + skill_descriptor["name"])
+        if skill_descriptor['name'] in BLACKLISTED_SKILLS:
+            logger.info("SKILL IS BLACKLISTED " + skill_descriptor["name"])
+            return None
         skill_module = imp.load_module(
             skill_descriptor["name"] + MainModule, *skill_descriptor["info"])
         if (hasattr(skill_module, 'create_skill') and


### PR DESCRIPTION
skill blacklisting was checked in load_skills which is no longer used in favor of watch_skills calling load_skill directly

bad behaviour example:

"tell me about chickens" would trigger sendSMS to "me" with message "about chickens" instead of searching wikipedia

issue #551 