### PR TITLE
Update build_host_setup_debian.sh

### DIFF
--- a/build_host_setup_debian.sh
+++ b/build_host_setup_debian.sh
@@ -12,6 +12,7 @@ sudo apt-get install -y \
     libffi-dev \
     libssl-dev \
     autoconf \
+    automake \
     bison \
     swig \
     libglib2.0-dev \


### PR DESCRIPTION
Issue-568: In file "build_host_setup_debian.sh" of main directory, a dependency is missing "automake".