### PR TITLE
Issues 568 - Fix dependencies to build latest mimic

### DIFF
--- a/build_host_setup_arch.sh
+++ b/build_host_setup_arch.sh
@@ -20,7 +20,10 @@ sudo pacman -S --needed \
     mpg123 \
     screen \
     flac \
-    curl
+    curl \
+    pkg-config \
+    icu \
+    automake
 
 # upgrade virtualenv to latest from pypi
 sudo pip2 install --upgrade virtualenv

--- a/build_host_setup_debian.sh
+++ b/build_host_setup_debian.sh
@@ -22,5 +22,7 @@ sudo apt-get install -y \
     screen \
     flac \
     curl \
-    libicu-dev
+    libicu-dev \
+    pkgconfig \
+    automake
 

--- a/build_host_setup_fedora.sh
+++ b/build_host_setup_fedora.sh
@@ -22,7 +22,10 @@ sudo dnf install -y \
     portaudio-devel \
     mpg123 \
     screen \
-    curl
+    curl \
+    pkgconfig \
+    libicu-devel \
+    automake
 
 # upgrade virtualenv to latest from pypi
 sudo pip install --upgrade virtualenv


### PR DESCRIPTION
This bug fixes #568 in fedora, arch and debian. Testing is appreciated, as I just checked the package names over the web.

Closes: https://github.com/MycroftAI/mimic/issues/102