### PR TITLE
Add expect_response option to speak_methods

### DIFF
--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -27,7 +27,7 @@ from mycroft.identity import IdentityManager
 from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.tts import TTSFactory
-from mycroft.util import kill, play_wav, resolve_resource_file
+from mycroft.util import kill, play_wav, resolve_resource_file, create_signal
 from mycroft.util.log import getLogger
 
 logger = getLogger("SpeechClient")
@@ -89,6 +89,7 @@ def handle_multi_utterance_intent_failure(event):
 
 def handle_speak(event):
     utterance = event.data['utterance']
+    expect_response = event.data.get('expect_response', False)
 
     # This is a bit of a hack for Picroft.  The analog audio on a Pi blocks
     # for 30 seconds fairly often, so we don't want to break on periods
@@ -105,6 +106,9 @@ def handle_speak(event):
             mute_and_speak(chunk)
     else:
         mute_and_speak(utterance)
+
+    if expect_response:
+        create_signal('buttonPress')
 
 
 def handle_sleep(event):

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -263,10 +263,13 @@ class MycroftSkill(object):
         re.compile(regex_str)  # validate regex
         self.emitter.emit(Message('register_vocab', {'regex': regex_str}))
 
-    def speak(self, utterance):
-        self.emitter.emit(Message("speak", {'utterance': utterance}))
+    def speak(self, utterance, expect_response=False):
+        data = {'utterance': utterance,
+                'expect_response': expect_response}
+        self.emitter.emit(Message("speak", data))
 
-    def speak_dialog(self, key, data={}):
+    def speak_dialog(self, key, data={}, expect_response=False):
+        data['expect_response'] = expect_response
         self.speak(self.dialog_renderer.render(key, data))
 
     def init_dialog(self, root_directory):


### PR DESCRIPTION
If `expect_response` flag is set to `True` the STT will be triggered just as if the wakeword has been received or the button on the Mycroft enclosure has been pressed.

The `speak` and `speak_dialog` methods will continue to work as before

```python
self.speak('Hello there')
```

But if Mycroft asks a user a question and would like a response from the user the STT can be triggered directly after mycroft finish speaking by setting the `expect_result` parameter to `True`

```python
self.speak('Would you like a cookie?', expect_response=True)
```

Can be useful to create some more natural interaction between the user and Mycroft.

A test skill using this can be downloaded here:
https://drive.google.com/open?id=0B2_BylN8IxZUal9VWFoyNTIyS3c
`Hey mycroft I'd like a cup of tea`