### PR TITLE
speech client, error in control of interval between calls to wakeup recognizer #577

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -285,7 +285,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                 byte_data = byte_data[len(chunk):] + chunk
 
             buffers_since_check += 1.0
-            if buffers_since_check < buffers_per_check:
+            if buffers_since_check > buffers_per_check:
                 buffers_since_check -= buffers_per_check
                 said_wake_word = self.wake_word_in_audio(byte_data + silence)
 


### PR DESCRIPTION
Due to an error in client/speech/mic.py the wakeup recognizer is called for all sound chunks, instead of wait the expected 200 ms between two consecutive calls.

See #577 issue for details.