### PR TITLE
Bufix/issue 586

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -308,7 +308,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         assert isinstance(source, AudioSource), "Source must be an AudioSource"
 
         bytes_per_sec = source.SAMPLE_RATE * source.SAMPLE_WIDTH
-        sec_per_buffer = float(source.CHUNK) / bytes_per_sec
+        sec_per_buffer = float(source.CHUNK) / source.SAMPLE_RATE
 
         logger.debug("Waiting for wake word...")
         self.wait_until_wake_word(source, sec_per_buffer)

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -307,7 +307,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         """
         assert isinstance(source, AudioSource), "Source must be an AudioSource"
 
-        bytes_per_sec = source.SAMPLE_RATE * source.SAMPLE_WIDTH
+#        bytes_per_sec = source.SAMPLE_RATE * source.SAMPLE_WIDTH
         sec_per_buffer = float(source.CHUNK) / source.SAMPLE_RATE
 
         logger.debug("Waiting for wake word...")


### PR DESCRIPTION
In file mic.py of core/clients/speech we can see:

bytes_per_sec = source.SAMPLE_RATE * source.SAMPLE_WIDTH
sec_per_buffer = float(source.CHUNK) / bytes_per_sec

this is not correct, the sec_per_buffer real value is CHUNK/SAMPLE_RATE.

See issue #586 for details.
