### PR TITLE
error in mic.py causes no phrase longer to 3 seconds can be used

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -179,15 +179,15 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         max_noise = 25
         min_noise = 0
 
-#        def increase_noise(level):
-#            if level < max_noise:
-#                return level + 200 * sec_per_buffer
-#            return level
-#
-#        def decrease_noise(level):
-#            if level > min_noise:
-#                return level - 100 * sec_per_buffer
-#            return level
+        # def increase_noise(level):
+        #   if level < max_noise:
+        #     return level + 200 * sec_per_buffer
+        #   return level
+        #
+        # def decrease_noise(level):
+        #   if level > min_noise:
+        #     return level - 100 * sec_per_buffer
+        # return level
 
         # Smallest number of loud chunks required to return
         min_loud_chunks = int(self.MIN_LOUD_SEC_PER_PHRASE / sec_per_buffer)
@@ -214,11 +214,11 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             test_threshold = self.energy_threshold * self.multiplier
             is_loud = energy > test_threshold
             if is_loud:
-#                noise = increase_noise(noise)
+                # noise = increase_noise(noise)
                 num_loud_chunks += 1
                 num_silence_chunks = 0
             else:
-#                noise = decrease_noise(noise)
+                # noise = decrease_noise(noise)
                 num_silence_chunks += 1
                 self.adjust_threshold(energy, sec_per_buffer)
 
@@ -229,9 +229,10 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                 f.close()
 
             was_loud_enough = num_loud_chunks > min_loud_chunks
-#            quiet_enough = noise <= min_noise
-#            recorded_too_much_silence = num_chunks > max_chunks_of_silence
-            recorded_too_much_silence = num_silence_chunks > max_chunks_of_silence
+            # quiet_enough = noise <= min_noise
+            # recorded_too_much_silence = num_chunks > max_chunks_of_silence
+            recorded_too_much_silence = 
+                num_silence_chunks > max_chunks_of_silence
             if was_loud_enough and recorded_too_much_silence:
                 phrase_complete = True
             if check_for_signal('buttonPress'):

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -179,15 +179,15 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         max_noise = 25
         min_noise = 0
 
-        def increase_noise(level):
-            if level < max_noise:
-                return level + 200 * sec_per_buffer
-            return level
-
-        def decrease_noise(level):
-            if level > min_noise:
-                return level - 100 * sec_per_buffer
-            return level
+#        def increase_noise(level):
+#            if level < max_noise:
+#                return level + 200 * sec_per_buffer
+#            return level
+#
+#        def decrease_noise(level):
+#            if level > min_noise:
+#                return level - 100 * sec_per_buffer
+#            return level
 
         # Smallest number of loud chunks required to return
         min_loud_chunks = int(self.MIN_LOUD_SEC_PER_PHRASE / sec_per_buffer)
@@ -204,6 +204,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         byte_data = '\0' * source.SAMPLE_WIDTH
 
         phrase_complete = False
+        num_silence_chunks = 0
         while num_chunks < max_chunks and not phrase_complete:
             chunk = self.record_sound_chunk(source)
             byte_data += chunk
@@ -213,10 +214,12 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             test_threshold = self.energy_threshold * self.multiplier
             is_loud = energy > test_threshold
             if is_loud:
-                noise = increase_noise(noise)
+#                noise = increase_noise(noise)
                 num_loud_chunks += 1
+                num_silence_chunks = 0
             else:
-                noise = decrease_noise(noise)
+#                noise = decrease_noise(noise)
+                num_silence_chunks += 1
                 self.adjust_threshold(energy, sec_per_buffer)
 
             if num_chunks % 10 == 0:
@@ -226,9 +229,10 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                 f.close()
 
             was_loud_enough = num_loud_chunks > min_loud_chunks
-            quiet_enough = noise <= min_noise
-            recorded_too_much_silence = num_chunks > max_chunks_of_silence
-            if quiet_enough and (was_loud_enough or recorded_too_much_silence):
+#            quiet_enough = noise <= min_noise
+#            recorded_too_much_silence = num_chunks > max_chunks_of_silence
+            recorded_too_much_silence = num_silence_chunks > max_chunks_of_silence
+            if was_loud_enough and recorded_too_much_silence:
                 phrase_complete = True
             if check_for_signal('buttonPress'):
                 phrase_complete = True

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -231,8 +231,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             was_loud_enough = num_loud_chunks > min_loud_chunks
             # quiet_enough = noise <= min_noise
             # recorded_too_much_silence = num_chunks > max_chunks_of_silence
-            recorded_too_much_silence =
-                num_silence_chunks > max_chunks_of_silence
+            recorded_too_much_silence = (
+                num_silence_chunks > max_chunks_of_silence )
             if was_loud_enough and recorded_too_much_silence:
                 phrase_complete = True
             if check_for_signal('buttonPress'):

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -232,7 +232,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             # quiet_enough = noise <= min_noise
             # recorded_too_much_silence = num_chunks > max_chunks_of_silence
             recorded_too_much_silence = (
-                num_silence_chunks > max_chunks_of_silence )
+                num_silence_chunks > max_chunks_of_silence)
             if was_loud_enough and recorded_too_much_silence:
                 phrase_complete = True
             if check_for_signal('buttonPress'):

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -231,7 +231,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             was_loud_enough = num_loud_chunks > min_loud_chunks
             # quiet_enough = noise <= min_noise
             # recorded_too_much_silence = num_chunks > max_chunks_of_silence
-            recorded_too_much_silence = 
+            recorded_too_much_silence =
                 num_silence_chunks > max_chunks_of_silence
             if was_loud_enough and recorded_too_much_silence:
                 phrase_complete = True


### PR DESCRIPTION
Error in mic.py causes no phrase longer to 3 seconds can be recorded.
See issue #595 for details.