### PR TITLE
Implementing audio cache feature in issue #598

### DIFF
--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -43,6 +43,7 @@ class TTS(object):
         self.voice = voice
         self.filename = '/tmp/tts.wav'
         self.validator = validator
+        self.enclosure = None
         random.seed()
 
     def init(self, ws):
@@ -51,10 +52,20 @@ class TTS(object):
 
     @abstractmethod
     def execute(self, sentence):
+        ''' This performs TTS, blocking until audio completes
+
+        This performs the TTS sequence.  Upon completion, the sentence will
+        have been spoken.   Optionally, the TTS engine may have sent visemes
+        to the enclosure by the TTS engine.
+
+        Args:
+            sentence (str): Words to be spoken
+        '''
+        # TODO: Move caching support from mimic_tts to here for all TTS
         pass
 
     def blink(self, rate=1.0):
-        if random.random() < rate:
+        if self.enclosure and random.random() < rate:
             self.enclosure.eyes_blink("b")
 
 

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -24,6 +24,7 @@ from time import time, sleep
 from mycroft import MYCROFT_ROOT_PATH
 from mycroft.configuration import ConfigurationManager
 from mycroft.tts import TTS, TTSValidator
+import mycroft.util
 from mycroft.util.log import getLogger
 LOGGER = getLogger(__name__)
 
@@ -127,8 +128,9 @@ class MimicValidator(TTSValidator):
         try:
             subprocess.call([BIN, '--version'])
         except:
+            LOGGER.info("Falied to find mimic at: " + BIN)
             raise Exception(
-                'Mimic is not installed. Run install-mimic.sh to install it.')
+                'Mimic was not found. Run install-mimic.sh to install it.')
 
     def get_tts_class(self):
         return Mimic

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -22,6 +22,8 @@ import tempfile
 
 import os
 import os.path
+import time
+from stat import S_ISREG, ST_MTIME, ST_MODE, ST_SIZE
 import psutil
 from os.path import dirname
 from mycroft.util.log import getLogger
@@ -173,6 +175,71 @@ def connected(host="8.8.8.8", port=53, timeout=3):
             return False
 
 
+def curate_cache(dir, min_free_percent=5.0):
+    """Clear out the directory if needed
+
+    This assumes all the files in the directory can be deleted as freely
+
+    Args:
+        dir (str): directory path that holds cached files
+        min_free_percent (float): percentage (0.0-100.0) of drive to keep free
+    """
+
+    # Simpleminded implementation -- keep a certain percentage of the
+    # disk available.
+    # TODO: Would be easy to add more options, like whitelisted files, etc.
+    space = psutil.disk_usage(dir)
+
+    # space.percent = space.used/space.total*100.0
+    percent_free = 100.0-space.percent
+    if percent_free < min_free_percent:
+        # calculate how many bytes we need to delete
+        bytes_needed = (min_free_percent - percent_free) / 100.0 * space.total
+        bytes_needed = int(bytes_needed + 1.0)
+
+        # get all entries in the directory w/ stats
+        entries = (os.path.join(dir, fn) for fn in os.listdir(dir))
+        entries = ((os.stat(path), path) for path in entries)
+
+        # leave only regular files, insert modification date
+        entries = ((stat[ST_MTIME], stat[ST_SIZE], path)
+                   for stat, path in entries if S_ISREG(stat[ST_MODE]))
+
+        # delete files with oldest modification date until space is freed
+        space_freed = 0
+        for moddate, fsize, path in sorted(entries):
+            try:
+                os.remove(path)
+                space_freed += fsize
+            except:
+                pass
+
+            if space_freed > bytes_needed:
+                return  # deleted enough!
+
+
+def get_cache_directory(domain=None):
+    """Get a directory for caches data
+
+    This directory can be used to hold temporary caches of data to
+    speed up performance.  This directory will likely be part of a
+    small RAM disk and may be cleared at any time.  So code that
+    uses these cached files must be able to fallback and regenerate
+    the file.
+
+    Args:
+        domain (str): The cache domain.  Basically just a subdirectory.
+
+    Return:
+        str: a path to the directory where you can cache data
+    """
+    dir = mycroft.configuration.ConfigurationManager.get().get("cache_path")
+    if not dir:
+        # If not defined, use /tmp/mycroft/cache
+        dir = os.path.join(tempfile.gettempdir(), "mycroft", "cache")
+    return _ensure_directory_exists(dir, domain)
+
+
 def get_ipc_directory(domain=None):
     """Get the directory used for Inter Process Communication
 
@@ -184,12 +251,25 @@ def get_ipc_directory(domain=None):
             overlapping signal filenames.
 
     Returns:
-        str: a path to the IPC folder
+        str: a path to the IPC directory
     """
     dir = mycroft.configuration.ConfigurationManager.get().get("ipc_path")
     if not dir:
         # If not defined, use /tmp/mycroft/ipc
         dir = os.path.join(tempfile.gettempdir(), "mycroft", "ipc")
+    return _ensure_directory_exists(dir, domain)
+
+
+def _ensure_directory_exists(dir, domain=None):
+    """ Create a directory and give access rights to all
+
+    Args:
+        domain (str): The IPC domain.  Basically a subdirectory to prevent
+            overlapping signal filenames.
+
+    Returns:
+        str: a path to the directory
+    """
     if domain:
         dir = os.path.join(dir, domain)
     dir = os.path.normpath(dir)
@@ -197,7 +277,7 @@ def get_ipc_directory(domain=None):
     if not os.path.isdir(dir):
         try:
             save = os.umask(0)
-            os.makedirs(dir, 0777)  # give everyone rights to r/w to IPC dir
+            os.makedirs(dir, 0777)  # give everyone rights to r/w here
         except OSError:
             LOGGER.warn("Failed to create: " + dir)
             pass


### PR DESCRIPTION
The TTS audio is now cached.  If the same TTS is requested again, the cached WAV and phoneme sequence is reused.

Major points:
* Created mycroft.util.get_cache_directory().  You can give this a domain, also.  The mycroft.conf can define where this directory resides, so enclosures can have this reside on a ramdisk, for instance.
* Created mycroft.util.curate_cache().  This retains a percentage of the disk size free.