### PR TITLE
Implementing WolframAlpha changes from issue #600

### DIFF
--- a/mycroft/skills/wolfram_alpha/__init__.py
+++ b/mycroft/skills/wolfram_alpha/__init__.py
@@ -43,11 +43,11 @@ class EnglishQuestionParser(object):
     def __init__(self):
         self.regexes = [
             re.compile(
-                ".*(?P<QuestionWord>who|what|when|where|why|which) "
+                ".*(?P<QuestionWord>who|what|when|where|why|which|whose) "
                 "(?P<Query1>.*) (?P<QuestionVerb>is|are|was|were) "
                 "(?P<Query2>.*)"),
             re.compile(
-                ".*(?P<QuestionWord>who|what|when|where|why|which) "
+                ".*(?P<QuestionWord>who|what|when|where|why|which|how) "
                 "(?P<QuestionVerb>\w+) (?P<Query>.*)")
         ]
 
@@ -121,13 +121,13 @@ class WolframAlphaSkill(MycroftSkill):
 
     # TODO: Localization
     def handle_fallback(self, message):
-        self.enclosure.mouth_think()
-        LOG.debug("Falling back to WolframAlpha Skill!")
+        utt = message.data.get('utterance')
+        LOG.debug("WolframAlpha fallback attempt: " + utt)
         lang = message.data.get('lang')
         if not lang:
             lang = "en-us"
 
-        utterance = normalize(message.data.get('utterance'), lang)
+        utterance = normalize(utt, lang)
         parsed_question = self.question_parser.parse(utterance)
 
         query = utterance
@@ -141,10 +141,17 @@ class WolframAlphaSkill(MycroftSkill):
                 parsed_question['QuestionVerb'] = 'is'
             query = "%s %s %s" % (utt_word, utt_verb, utt_query)
             phrase = "know %s %s %s" % (utt_word, utt_query, utt_verb)
+            LOG.debug("Falling back to WolframAlpha: " + query)
         else:
-            phrase = "understand the phrase " + utterance
+            # This utterance doesn't look like a question, don't waste
+            # time with WolframAlpha.
+
+            # TODO: Log missed intent
+            LOG.debug("Unknown intent: " + utterance)
+            return
 
         try:
+            self.enclosure.mouth_think()
             res = self.client.query(query)
             result = self.get_result(res)
             others = self._find_did_you_mean(res)


### PR DESCRIPTION
This limits WolframAlphaSkill to only query WolframAlpha when the utterance doesn't match an intent (calling the fallback handler) and it contains an obvious question phrase.