### PR TITLE
Revert "Fixes Issue 588"

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -111,16 +111,15 @@ def load_skill(skill_descriptor, emitter):
             skill.bind(emitter)
             skill.load_data_files(dirname(skill_descriptor['info'][1]))
             skill.initialize()
-            logger.info("Loaded " + skill_descriptor["name"])
+            logger.info("Lodaded " + skill_descriptor["name"])
             return skill
         else:
             logger.warn(
                 "Module %s does not appear to be skill" % (
                     skill_descriptor["name"]))
-    except Exception as e:
+    except:
         logger.error(
-            "Failed to load skill: " +
-            skill_descriptor["name"], exc_info=True + " " + e)
+            "Failed to load skill: " + skill_descriptor["name"], exc_info=True)
     return None
 
 
@@ -247,14 +246,14 @@ class MycroftSkill(object):
         def receive_handler(message):
             try:
                 handler(message)
-            except Exception as e:
+            except:
                 # TODO: Localize
                 self.speak(
                     "An error occurred while processing a request in " +
                     self.name)
                 logger.error(
                     "An error occurred while processing a request in " +
-                    self.name, exc_info=True + " " + e)
+                    self.name, exc_info=True)
 
         self.emitter.on(intent_parser.name, receive_handler)
 


### PR DESCRIPTION
Reverts MycroftAI/mycroft-core#591

The change done in the exception treatment causes itself another exception:

Exception in thread Thread-14:
Traceback (most recent call last):
File "/usr/lib/python2.7/threading.py", line 801, in __bootstrap_inner
self.run()
File "/usr/lib/python2.7/threading.py", line 1073, in run
self.function(*self.args, **self.kwargs)
File "/home/pma/varios/mycroft/mycroft-core/mycroft/skills/main.py", line 112, in watch_skills
create_skill_descriptor(skill["path"]), ws)
File "/home/pma/varios/mycroft/mycroft-core/mycroft/skills/core.py", line 123, in load_skill
skill_descriptor["name"], exc_info=True + " " + e)
TypeError: unsupported operand type(s) for +: 'bool' and 'str'

rollback? original code seems ok.