### PR TITLE
i18n: language codes are not always two word

### DIFF
--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -40,8 +40,11 @@ class STT(object):
 
     @staticmethod
     def init_language(config_core):
-        langs = config_core.get("lang", "en-US").split("-")
-        return langs[0].lower() + "-" + langs[1].upper()
+        lang = config_core.get("lang", "en-US")
+        langs = lang.split("-")
+        if len(langs) == 2:
+            return langs[0].lower() + "-" + langs[1].upper()
+        return lang
 
     @abstractmethod
     def execute(self, audio, language=None):


### PR DESCRIPTION
Allow single word and more complex language codes.

See issue #610 for details.