### PR TITLE
Fix build_host_setup_debian.sh

### DIFF
--- a/build_host_setup_debian.sh
+++ b/build_host_setup_debian.sh
@@ -23,6 +23,6 @@ sudo apt-get install -y \
     flac \
     curl \
     libicu-dev \
-    pkgconfig \
+    pkg-config \
     automake
 


### PR DESCRIPTION
Fix typo and correctly install the `pkg-config` package. Resolves #615 