### PR TITLE
Bugfix/issue 624 - fix mimic_tts for unicode

### DIFF
--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -103,7 +103,10 @@ def handle_speak(event):
         chunks = re.split(r'(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?)\s',
                           utterance)
         for chunk in chunks:
-            mute_and_speak(chunk)
+            try:
+                mute_and_speak(chunk)
+            except:
+                logger.error('Error in mute_and_speak', exc_info=True)
     else:
         mute_and_speak(utterance)
 

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -20,6 +20,7 @@ import hashlib
 import os
 import os.path
 from time import time, sleep
+import unicodedata
 
 from mycroft import MYCROFT_ROOT_PATH
 from mycroft.configuration import ConfigurationManager
@@ -48,7 +49,7 @@ class Mimic(TTS):
             self.args += ['--setf', 'duration_stretch=' + stretch]
 
     def get_tts(self, sentence):
-        key = str(hashlib.md5(sentence).hexdigest())
+        key = str(hashlib.md5(sentence.encode('utf-8', 'ignore')).hexdigest())
         wav_file = os.path.join(mycroft.util.get_cache_directory("tts"),
                                 key + ".wav")
 


### PR DESCRIPTION
Convert input to the hash function to `bytes`/`str`.

This PR also add some basic feedback if something in the tts process fails. Resolves #624