### PR TITLE
Fix creation of /opt/mycroft/skills

### DIFF
--- a/scripts/install-msm.sh
+++ b/scripts/install-msm.sh
@@ -10,10 +10,10 @@ chmod +x msm/msm
 if [[ ${IS_TRAVIS} != true ]]; then
     echo "Create /opt/mycroft/skills if it doesn't exist"
     if [ ! -d ${SKILLS_DIR} ]; then
-        sudo chown $USER:$USER ${SKILLS_DIR}
+        sudo mkdir -p ${SKILLS_DIR}
     fi
 
     if [ ! -w ${SKILLS_DIR} ]; then
-    	sudo mkdir -p ${SKILLS_DIR}
+        sudo chown $USER:$USER ${SKILLS_DIR}
     fi
 fi


### PR DESCRIPTION
I got an error when trying to set up about the creation of `/opt/mycroft/skills`.

Looking into it, the commands here seemed to be backwards - it tested for directory existence and if not tried to set permissions, then tested for write permission and then tried to create.

Flipped those two around, also made indenting consistent, and the setup ran as expected.