### PR TITLE
Several command line interface (CLI) improvements

### DIFF
--- a/mycroft.sh
+++ b/mycroft.sh
@@ -49,10 +49,15 @@ function start-mycroft {
   echo "Mycroft $1$2 started"
 }
 
-function debug-start-mycroft {
-  screen -c $SCRIPTS/mycroft-$1.screen $DIR/start.sh $1 $2
+function start-mycroft-nolog {
+  screen -mdS mycroft-$1$2 $DIR/start.sh $1 $2 $3
   sleep 1
   verify-start mycroft-$1$2
+  echo "Mycroft $1$2 started"
+}
+
+function debug-start-mycroft {
+  $DIR/start.sh $1 $2
   echo "Mycroft $1$2 started"
 }
 
@@ -94,23 +99,21 @@ then
 elif [[ "$1" == "start" && -z "$2" ]]
 then
   start-mycroft service
-  start-mycroft voice
-  sleep 3
   start-mycroft skills
-  start-mycroft cli --quiet
+  start-mycroft voice
+  start-mycroft-nolog cli --quiet --simple
   exit 0
 elif [[ "$1" == "start" && "$2" == "-v" ]]
 then
   start-mycroft service
-  start-mycroft voice
-  sleep 3
   start-mycroft skills
+  start-mycroft voice
   exit 0
 elif [[ "$1" == "start" && "$2" == "-c" ]]
 then
   start-mycroft service
   start-mycroft skills
-  start-mycroft cli
+  start-mycroft-nolog cli --simple
   exit 0
 elif [[ "$1" == "start" && "$2" == "-d" ]]
 then
@@ -121,9 +124,8 @@ then
 elif [[ "$1" == "stop" && -z "$2" ]]
 then
   stop-mycroft service
-  stop-mycroft voice
-  sleep 3
   stop-mycroft skills
+  stop-mycroft voice
   stop-mycroft cli
   exit 0
 elif [[ "$1" == "restart" && -z "$2" ]]

--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -33,6 +33,7 @@ import subprocess                                           # nopep8
 import curses                                               # nopep8
 import curses.ascii                                         # nopep8
 import textwrap                                             # nopep8
+import json                                                 # nopep8
 from threading import Thread, Lock                          # nopep8
 from mycroft.messagebus.client.ws import WebsocketClient    # nopep8
 from mycroft.messagebus.message import Message              # nopep8
@@ -57,7 +58,9 @@ log_line_lr_scroll = 0  # amount to scroll left/right for long lines
 longest_visible_line = 0  # for HOME key
 
 mergedLog = []
-log_filters = ["enclosure.mouth.viseme"]
+filteredLog = []
+default_log_filters = ["enclosure.mouth.viseme"]
+log_filters = list(default_log_filters)
 log_files = []
 
 # Values used to display the audio meter
@@ -84,6 +87,30 @@ def stripNonAscii(text):
 
 
 ##############################################################################
+# Settings
+
+config_file = os.path.join(os.path.expanduser("~"), ".mycroft_cli.conf")
+
+
+def load_settings():
+    global log_filters
+
+    try:
+        with open(config_file, 'r') as f:
+            config = json.load(f)
+        if "filters" in config:
+            log_filters = config["filters"]
+    except:
+        pass
+
+
+def save_settings():
+    config["filters"] = log_filters
+    with open(config_file, 'w') as f:
+        json.dump(config, f)
+
+
+##############################################################################
 # Log file monitoring
 
 class LogMonitorThread(Thread):
@@ -96,8 +123,6 @@ class LogMonitorThread(Thread):
         log_files.append(filename)
 
     def run(self):
-        global mergedLog
-
         while True:
             try:
                 st_results = os.stat(self.filename)
@@ -113,6 +138,8 @@ class LogMonitorThread(Thread):
     def read_file_from(self, bytefrom):
         global meter_cur
         global meter_thresh
+        global filteredLog
+        global mergedLog
 
         with open(self.filename, 'rb') as fh:
             fh.seek(bytefrom)
@@ -128,10 +155,13 @@ class LogMonitorThread(Thread):
                         ignore = True
                         break
 
-                if not ignore:
+                if ignore:
+                    mergedLog.append(self.logid+line.strip())
+                else:
                     if bSimple:
                         print line.strip()
                     else:
+                        filteredLog.append(self.logid+line.strip())
                         mergedLog.append(self.logid+line.strip())
 
 
@@ -186,6 +216,35 @@ def start_mic_monitor(filename):
         thread.start()
 
 
+def add_log_message(message):
+    """ Show a message for the user (mixed in the logs) """
+    global filteredLog
+    global mergedLog
+
+    message = "@"+message       # the first byte is a code
+    filteredLog.append(message)
+    mergedLog.append(message)
+    scr.erase()
+    scr.refresh()
+
+
+def rebuild_filtered_log():
+    global filteredLog
+    global mergedLog
+
+    filteredLog = []
+    for line in mergedLog:
+        # Apply filters
+        ignore = False
+        for filtered_text in log_filters:
+            if filtered_text in line:
+                ignore = True
+                break
+
+        if not ignore:
+            filteredLog.append(line)
+
+
 ##############################################################################
 # Capturing output from Mycroft
 
@@ -231,6 +290,7 @@ def init_screen():
     global CLR_LOG1
     global CLR_LOG2
     global CLR_LOG_DEBUG
+    global CLR_LOG_CMDMESSAGE
     global CLR_METER_CUR
     global CLR_METER
 
@@ -253,6 +313,7 @@ def init_screen():
         CLR_LOG1 = curses.color_pair(3)
         CLR_LOG2 = curses.color_pair(6)
         CLR_LOG_DEBUG = curses.color_pair(4)
+        CLR_LOG_CMDMESSAGE = curses.color_pair(2)
         CLR_METER_CUR = curses.color_pair(2)
         CLR_METER = curses.color_pair(4)
 
@@ -263,8 +324,8 @@ def page_log(page_up):
         log_line_offset += 10
     else:
         log_line_offset -= 10
-    if log_line_offset > len(mergedLog):
-        log_line_offset = len(mergedLog)-10
+    if log_line_offset > len(filteredLog):
+        log_line_offset = len(filteredLog)-10
     if log_line_offset < 0:
         log_line_offset = 0
     draw_screen()
@@ -352,7 +413,7 @@ def draw_screen():
         scr.erase()
 
     # Display log output at the top
-    cLogs = len(mergedLog)
+    cLogs = len(filteredLog)
     cLogLinesToShow = curses.LINES-13
     start = clamp(cLogs - cLogLinesToShow, 0, cLogs - 1) - log_line_offset
     end = cLogs - log_line_offset
@@ -371,7 +432,7 @@ def draw_screen():
     y = 2
     len_line = 0
     for i in range(start, end):
-        log = mergedLog[i]
+        log = filteredLog[i]
         logid = log[0]
         if len(log) > 25 and log[5] == '-' and log[8] == '-':
             log = log[27:]  # skip logid & date/time at the front of log line
@@ -385,6 +446,8 @@ def draw_screen():
         else:
             if logid == "1":
                 clr = CLR_LOG1
+            elif logid == "@":
+                clr = CLR_LOG_CMDMESSAGE
             else:
                 clr = CLR_LOG2
 
@@ -501,9 +564,12 @@ def show_help():
                CLR_CMDLINE)
     scr.addstr(11, 0,  "=" * (curses.COLS-1),
                CLR_CMDLINE)
-    scr.addstr(12, 0,  ":help              this screen")
-    scr.addstr(13, 0,  ":quit or :exit     exit the program")
-    scr.addstr(14, 0,  ":meter [show|hide] display of microphone level")
+    scr.addstr(12, 0,  ":help                   this screen")
+    scr.addstr(13, 0,  ":quit or :exit          exit the program")
+    scr.addstr(14, 0,  ":meter (show|hide)      display of microphone level")
+    scr.addstr(15, 0,  ":filter [remove] 'str'  adds or removes a log filter")
+    scr.addstr(16, 0,  ":filter (clear|reset)   reset filters")
+    scr.addstr(17, 0,  ":filter (show|list)     display current filters")
 
     scr.addstr(curses.LINES-1, 0,  center(23) + "Press any key to return",
                CLR_HEADING)
@@ -526,6 +592,8 @@ def center(str_len):
 
 def handle_cmd(cmd):
     global show_meter
+    global log_filters
+    global mergedLog
 
     if "show" in cmd and "log" in cmd:
         pass
@@ -534,10 +602,38 @@ def handle_cmd(cmd):
     elif "exit" in cmd or "quit" in cmd:
         return 1
     elif "meter" in cmd:
+        # microphone level meter
         if "hide" in cmd or "off" in cmd:
             show_meter = False
         elif "show" in cmd or "on" in cmd:
             show_meter = True
+    elif "filter" in cmd:
+        if "show" in cmd or "list" in cmd:
+            # display active filters
+            add_log_message("Filters: "+str(log_filters))
+            return
+
+        if "reset" in cmd or "clear" in cmd:
+            log_filters = list(default_log_filters)
+        else:
+            # extract last word(s)
+            cmd = cmd.strip()
+            last_char = cmd[-1]
+            if last_char == '"' or last_char == "'":
+                parts = cmd.split(last_char)
+                word = parts[-2]
+            else:
+                parts = cmd.split(" ")
+                word = parts[-1]
+
+            if "remove" in cmd and word in log_filters:
+                log_filters.remove(word)
+            else:
+                log_filters.append(word)
+
+        rebuild_filtered_log()
+        add_log_message("Filters: "+str(log_filters))
+
     # TODO: More commands
     # elif "find" in cmd:
     #    ... search logs for given string
@@ -685,7 +781,6 @@ def simple_cli():
     event_thread.start()
     try:
         while True:
-            # TODO: Change this mechanism
             # Sleep for a while so all the output that results
             # from the previous command finishes before we print.
             time.sleep(1.5)
@@ -723,5 +818,7 @@ if __name__ == "__main__":
         sys.stderr = sys.__stderr__
         simple_cli()
     else:
+        load_settings()
         curses.wrapper(main)
         curses.endwin()
+        save_settings()


### PR DESCRIPTION
* The chat history section now wraps long text strings (see issue #648)
* Redesigned the section title to combine the header and underscore lines into a single line to save screen space
* Recolored several screen elements to make more sense.  The query and the chat history now retain the cyan color, etc.
* The screen fully refreshes periodically, cleaning up garbage that might have accumulated from outside text being written to the terminal
* The mic meter no longer wraps around the screen when level numbers are too long
* Added log filtering commands to the CLI.  So you can do things within the CLI like:
   :filter DEBUG  (filters out any lines containing "DEBUG")
   :filter remove DEBUG (stop filtering "DEBUG")
   :filter "not this" (filters out any log lines containing "not this")
   :filter list (displays active filters)
   :filter clear (removes all filters)
* Added a ~/.mycroft-cli.conf configuration file.  It currently contains the last-used filters.
* The mycroft.sh scripts were firing up the "fancy" CLI in the background and logging it constantly.  This resulted in huge log files because of the constantly updated microphone level indicator.