### PR TITLE
change loading order

### DIFF
--- a/mycroft/configuration/__init__.py
+++ b/mycroft/configuration/__init__.py
@@ -30,7 +30,9 @@ LOG = getLogger(__name__)
 DEFAULT_CONFIG = join(dirname(__file__), 'mycroft.conf')
 SYSTEM_CONFIG = '/etc/mycroft/mycroft.conf'
 USER_CONFIG = join(expanduser('~'), '.mycroft/mycroft.conf')
+REMOTE_CONFIG = "mycroft.ai"
 
+load_order = [DEFAULT_CONFIG, REMOTE_CONFIG, SYSTEM_CONFIG, USER_CONFIG]
 
 class ConfigurationLoader(object):
     """
@@ -158,8 +160,13 @@ class ConfigurationManager(object):
 
     @staticmethod
     def load_defaults():
-        ConfigurationManager.__config = ConfigurationLoader.load()
-        return RemoteConfiguration.load(ConfigurationManager.__config)
+        for location in load_order:
+            LOG.info("Loading configuration: " + location)
+            if location == REMOTE_CONFIG:
+                RemoteConfiguration.load(ConfigurationManager.__config)
+            else:
+                ConfigurationManager.__config = ConfigurationLoader.load(ConfigurationManager.__config, [location])
+        return ConfigurationManager.__config
 
     @staticmethod
     def load_local(locations=None, keep_user_config=True):

--- a/mycroft/configuration/__init__.py
+++ b/mycroft/configuration/__init__.py
@@ -34,6 +34,7 @@ REMOTE_CONFIG = "mycroft.ai"
 
 load_order = [DEFAULT_CONFIG, REMOTE_CONFIG, SYSTEM_CONFIG, USER_CONFIG]
 
+
 class ConfigurationLoader(object):
     """
     A utility for loading Mycroft configuration files.
@@ -165,7 +166,8 @@ class ConfigurationManager(object):
             if location == REMOTE_CONFIG:
                 RemoteConfiguration.load(ConfigurationManager.__config)
             else:
-                ConfigurationManager.__config = ConfigurationLoader.load(ConfigurationManager.__config, [location])
+                ConfigurationManager.__config = ConfigurationLoader.load(
+                    ConfigurationManager.__config, [location])
         return ConfigurationManager.__config
 
     @staticmethod


### PR DESCRIPTION
load_order = [DEFAULT_CONFIG, REMOTE_CONFIG, SYSTEM_CONFIG, USER_CONFIG]

remote config was loaded last, 

trouble:
  - custom TTS would be over-rided
  - timezone is never right

messagebus Logs:

> /home/user/.virtualenvs/mycroft/bin/python /home/user/mycroft-core-base/mycroft/messagebus/service/main.py
> 2017-04-10 20:28:20,247 - mycroft.configuration - INFO - Loading configuration: /home/user/mycroft-core-base/mycroft/configuration/mycroft.conf
> 2017-04-10 20:28:20,248 - mycroft.configuration - INFO - Loading configuration: mycroft.ai
> 2017-04-10 20:28:20,248 - mycroft.configuration - INFO - Loading configuration: /etc/mycroft/mycroft.conf
> 2017-04-10 20:28:20,248 - mycroft.configuration - INFO - Loading configuration: /home/user/.mycroft/mycroft.conf

it could use some tweaking, skills logs seem a little poluted:
```

2017-04-10 20:37:30,369 - mycroft.configuration - INFO - Loading configuration: /home/user/mycroft-core-base/mycroft/configuration/mycroft.conf
2017-04-10 20:37:30,370 - mycroft.configuration - DEBUG - Configuration '/home/user/mycroft-core-base/mycroft/configuration/mycroft.conf' loaded
2017-04-10 20:37:30,370 - mycroft.configuration - DEBUG - Configuration '/home/user/.mycroft/mycroft.conf' not found
2017-04-10 20:37:30,370 - mycroft.configuration - INFO - Loading configuration: mycroft.ai
2017-04-10 20:37:30,702 - requests.packages.urllib3.connectionpool - DEBUG - Starting new HTTPS connection (1): api.mycroft.ai
2017-04-10 20:37:31,458 - requests.packages.urllib3.connectionpool - DEBUG - https://api.mycroft.ai:443 "GET /v1/device/9fdfa9f1-82d5-4f83-9a45-ee27b2b6a060/setting HTTP/1.1" 200 2860
2017-04-10 20:37:31,477 - requests.packages.urllib3.connectionpool - DEBUG - Starting new HTTPS connection (1): api.mycroft.ai
2017-04-10 20:37:32,190 - requests.packages.urllib3.connectionpool - DEBUG - https://api.mycroft.ai:443 "GET /v1/device/9fdfa9f1-82d5-4f83-9a45-ee27b2b6a060/location HTTP/1.1" 200 4
2017-04-10 20:37:32,202 - mycroft.configuration - INFO - Loading configuration: /etc/mycroft/mycroft.conf
2017-04-10 20:37:32,202 - mycroft.configuration - DEBUG - Configuration '/etc/mycroft/mycroft.conf' not found
2017-04-10 20:37:32,202 - mycroft.configuration - DEBUG - Configuration '/home/user/.mycroft/mycroft.conf' not found
2017-04-10 20:37:32,203 - mycroft.configuration - INFO - Loading configuration: /home/user/.mycroft/mycroft.conf
2017-04-10 20:37:32,203 - mycroft.configuration - DEBUG - Configuration '/home/user/.mycroft/mycroft.conf' not found
2017-04-10 20:37:32,203 - mycroft.configuration - DEBUG - Configuration '/home/user/.mycroft/mycroft.conf' not found
2017-04-10 20:37:32,240 - mycroft.messagebus.client.ws - INFO - Connected

```