### PR TITLE
Fix for issue #659, broken git install after recent changes

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -119,7 +119,7 @@
   // Override: SYSTEM (e.g. Picroft)
   "enclosure": {
     // Platform name (e.g. 'Picroft', 'Mark_1'
-    // Override: SYSTEM
+    // Override: SYSTEM (set by specific enclosures)
     # "platform": "picroft",
     
     // COMM params to the Arduino/faceplate
@@ -134,8 +134,18 @@
     "test": false
   },
 
+  // Level of logs to store, one of  "CRITICAL", "ERROR", "WARNGIN", "INFO", "DEBUG"
+  // Override: none
+  "log_level": "DEBUG",
+  
+  // Messagebus types that will NOT be output to logs
+  // Override: none
+  "ignore_logs": ["enclosure.mouth.viseme"],
 
+  // Settings related to remote sessions
+  // Overrride: none
   "session": {
+    // Time To Live, in seconds
     "ttl": 180
   },
 

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -28,7 +28,7 @@ __author__ = 'seanfitz'
 logger = getLogger(__name__)
 
 
-class Intent(object):
+class IntentService(object):
     def __init__(self, emitter):
         self.engine = IntentDeterminationEngine()
         self.emitter = emitter

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -30,7 +30,7 @@ from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import load_skill, create_skill_descriptor, \
     MainModule, SKILLS_DIR
-from mycroft.skills.intent import Intent
+from mycroft.skills.intent_service import IntentService
 from mycroft.util.log import getLogger
 from mycroft.lock import Lock  # Creates PID file for single instance
 
@@ -45,8 +45,9 @@ skills_directories = []
 skill_reload_thread = None
 skills_manager_timer = None
 
-installer_config = ConfigurationManager.get().get("SkillInstallerSkill")
-MSM_BIN = installer_config.get("path", join(MYCROFT_ROOT_PATH, 'msm', 'msm'))
+installer_config = ConfigurationManager.instance().get("SkillInstallerSkill")
+MSM_BIN = installer_config.get("path", join(MYCROFT_ROOT_PATH, 'msm',
+                                            'msm.sh'))
 
 
 def connect():
@@ -56,36 +57,53 @@ def connect():
 
 def skills_manager(message):
     global skills_manager_timer, ws
+
     if skills_manager_timer is None:
+        # TODO: Localization support
         ws.emit(
             Message("speak", {'utterance': "Checking for Updates"}))
-    os.system(MSM_BIN + " default")
+
+    # Install default skills and look for updates via Github
+    logger.debug("==== Invoking Mycroft Skill Manager: " + MSM_BIN)
+    if exists(MSM_BIN):
+        os.system("/bin/bash " + MSM_BIN + " default")
+    else:
+        logger.error("Unable to invoke Mycroft Skill Manager: " + MSM_BIN)
+
     if skills_manager_timer is None:
+        # TODO: Localization support
         ws.emit(Message("speak", {
             'utterance': "Skills Updated. Mycroft is ready"}))
-    skills_manager_timer = Timer(3600.0, skills_manager_dispatch)
+
+    # Perform check again once and hour
+    skills_manager_timer = Timer(3600.0, _skills_manager_dispatch)
     skills_manager_timer.daemon = True
     skills_manager_timer.start()
 
 
-def skills_manager_dispatch():
+def _skills_manager_dispatch():
     ws.emit(Message("skill_manager", {}))
 
 
-def load_watch_skills():
+def _load_watch_skills():
     global ws, loaded_skills, last_modified_skill, skills_directories, \
         skill_reload_thread
 
+    # Create skill_manager listener and invoke the first time
     ws.on('skill_manager', skills_manager)
     ws.emit(Message("skill_manager", {}))
 
-    Intent(ws)
-    skill_reload_thread = Timer(0, watch_skills)
+    # Create the Intent manager, which converts utterances to intents
+    # This is the heart of the voice invoked skill system
+    IntentService(ws)
+
+    # Create a thread that monitors the loaded skills, looking for updates
+    skill_reload_thread = Timer(0, _watch_skills)
     skill_reload_thread.daemon = True
     skill_reload_thread.start()
 
 
-def clear_skill_events(instance):
+def _clear_skill_events(instance):
     global ws
     events = ws.emitter._events
     instance_events = []
@@ -107,10 +125,12 @@ def clear_skill_events(instance):
         del events[event]
 
 
-def watch_skills():
+def _watch_skills():
     global ws, loaded_skills, last_modified_skill, \
         id_counter
 
+    # Scan the file folder that contains Skills.  If a Skill is updated,
+    # unload the existing version from memory and reload from the disk.
     while True:
         if exists(SKILLS_DIR):
             list = filter(lambda x: os.path.isdir(
@@ -135,25 +155,30 @@ def watch_skills():
                         continue
                     logger.debug("Reloading Skill: " + skill_folder)
                     skill["instance"].shutdown()
-                    clear_skill_events(skill["instance"])
+                    _clear_skill_events(skill["instance"])
                     del skill["instance"]
                 skill["loaded"] = True
                 skill["instance"] = load_skill(
                     create_skill_descriptor(skill["path"]), ws)
         last_modified_skill = max(
             map(lambda x: x.get("last_modified"), loaded_skills.values()))
+
+        # Pause briefly before beginning next scan
         time.sleep(2)
 
 
 def main():
     global ws
-    lock = Lock('skills')  # prevent multiply instances of this service
+    lock = Lock('skills')  # prevent multiple instances of this service
+
+    # Connect this Skill management process to the websocket
     ws = WebsocketClient()
     ConfigurationManager.init(ws)
 
-    ignore_logs = ConfigurationManager.get().get("ignore_logs")
+    ignore_logs = ConfigurationManager.instance().get("ignore_logs")
 
-    def echo(message):
+    # Listen for messages and echo them for logging
+    def _echo(message):
         try:
             _message = json.loads(message)
 
@@ -167,9 +192,10 @@ def main():
         except:
             pass
         logger.debug(message)
+    ws.on('message', _echo)
 
-    ws.on('message', echo)
-    ws.once('open', load_watch_skills)
+    # Kick off loading of skills
+    ws.once('open', _load_watch_skills)
     ws.run_forever()
 
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -46,8 +46,7 @@ skill_reload_thread = None
 skills_manager_timer = None
 
 installer_config = ConfigurationManager.instance().get("SkillInstallerSkill")
-MSM_BIN = installer_config.get("path", join(MYCROFT_ROOT_PATH, 'msm',
-                                            'msm.sh'))
+MSM_BIN = installer_config.get("path", join(MYCROFT_ROOT_PATH, 'msm', 'msm'))
 
 
 def connect():
@@ -66,7 +65,7 @@ def skills_manager(message):
     # Install default skills and look for updates via Github
     logger.debug("==== Invoking Mycroft Skill Manager: " + MSM_BIN)
     if exists(MSM_BIN):
-        os.system("/bin/bash " + MSM_BIN + " default")
+        os.system(MSM_BIN + " default")
     else:
         logger.error("Unable to invoke Mycroft Skill Manager: " + MSM_BIN)
 
@@ -85,7 +84,7 @@ def _skills_manager_dispatch():
     ws.emit(Message("skill_manager", {}))
 
 
-def _load_watch_skills():
+def _load_skills():
     global ws, loaded_skills, last_modified_skill, skills_directories, \
         skill_reload_thread
 
@@ -195,7 +194,7 @@ def main():
     ws.on('message', _echo)
 
     # Kick off loading of skills
-    ws.once('open', _load_watch_skills)
+    ws.once('open', _load_skills)
     ws.run_forever()
 
 


### PR DESCRIPTION
There are several issues with the changes recently made to break out
Skills from mycroft-core.
* The subdirectory mycroft/skills/intent/ is left behind when you do
  a pull, so the change to core.py that tries to
  "import mycroft.skills.intent" gets confused.  I renamed the file
  intent.py to intent_service.py
* Added a bunch of comments
* Made a bunch of functions "private", using the leading _
* The MSM install was failing.  Still working on that, but we should
  probably make msm.sh a part of mycroft-core instead of its own
  repo.
* Restored some mycroft.conf values that I noticed got lost during
  an automatic merge.