### PR TITLE
Drop rpmfusion from Fedora install script

### DIFF
--- a/build_host_setup_fedora.sh
+++ b/build_host_setup_fedora.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-sudo rpm -Uvh http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-23.noarch.rpm
-
 sudo dnf install -y \
     git \
     python \

--- a/build_host_setup_fedora.sh
+++ b/build_host_setup_fedora.sh
@@ -19,6 +19,7 @@ sudo dnf install -y \
     s3cmd \
     portaudio-devel \
     mpg123 \
+    mpg123-plugins-pulseaudio \
     screen \
     curl \
     pkgconfig \


### PR DESCRIPTION
From Fedora 25 mpg123 is now included in the main Fedora repositories
so we don't need to add the rpmfusion repos for the build dependencies.

Signed-off-by: Peter Robinson <pbrobinson@gmail.com>