### PR TITLE
Fixed typo in skills/core.py -- "loaded"

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -107,7 +107,7 @@ def load_skill(skill_descriptor, emitter):
             skill.bind(emitter)
             skill.load_data_files(dirname(skill_descriptor['info'][1]))
             skill.initialize()
-            logger.info("Lodaded " + skill_descriptor["name"])
+            logger.info("Loaded " + skill_descriptor["name"])
             return skill
         else:
             logger.warn(


### PR DESCRIPTION
There was a typo ("Lodaded" instead of "Loaded") which I have fixed.  This PR fixes that.