### PR TITLE
Bugfix/issue 702

### DIFF
--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -136,6 +136,11 @@ def read_dict(filename, div='='):
 
 
 def create_file(filename):
+    """ Create the file filename and create any directories needed
+
+        Args:
+            filename: Path to the file to be created
+    """
     try:
         os.makedirs(dirname(filename))
     except OSError:

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -301,9 +301,9 @@ def create_signal(signal_name):
             valid in filenames.
     """
     try:
-        with open(os.path.join(get_ipc_directory(), "signal", signal_name),
-                  'w'):
-            return True
+        path = os.path.join(get_ipc_directory(), "signal", signal_name)
+        create_file(path)
+        return os.path.isfile(path)
     except IOError:
         return False
 
@@ -321,7 +321,6 @@ def check_for_signal(signal_name, sec_lifetime=0):
         bool: True if the signal is defined, False otherwise
     """
     path = os.path.join(get_ipc_directory(), "signal", signal_name)
-
     if os.path.isfile(path):
         if sec_lifetime == 0:
             # consume this single-use signal

--- a/test/util/test_signal.py
+++ b/test/util/test_signal.py
@@ -1,0 +1,30 @@
+from os.path import dirname, join, exists, isfile
+import unittest
+from shutil import rmtree
+from mycroft.util import create_signal, check_for_signal
+
+
+class TestSignals(unittest.TestCase):
+    def setUp(self):
+        if exists('/tmp/mycroft'):
+            rmtree('/tmp/mycroft')
+
+    def test_create_signal(self):
+        create_signal('test_signal')
+        self.assertTrue(isfile('/tmp/mycroft/ipc/signal/test_signal'))
+
+    def test_check_signal(self):
+        if exists('/tmp/mycroft'):
+            rmtree('/tmp/mycroft')
+        # check that signal is not found if file does not exist
+        self.assertFalse(check_for_signal('test_signal'))
+
+        # Check that the signal is found when created
+        create_signal('test_signal')
+        self.assertTrue(check_for_signal('test_signal'))
+        # Check that the signal is removed after use
+        self.assertFalse(isfile('/tmp/mycroft/ipc/signal/test_signal'))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Uses `create_file()` to create the signal file, ensuring the directory is created.

Also adds basic test cases for the function. Resolves #702 