### PR TITLE
Enable config updates for skills in container

### DIFF
--- a/mycroft/skills/container.py
+++ b/mycroft/skills/container.py
@@ -77,6 +77,9 @@ class SkillContainer(object):
                                   port=params.port,
                                   ssl=params.use_ssl)
 
+        # Connect configuration manager to message bus to receive updates
+        ConfigurationManager.init(self.ws)
+
     def load_skill(self):
         if self.enable_intent:
             IntentService(self.ws)


### PR DESCRIPTION
Connects the skill containers ConfigManager to the messagebus the same way skills and the other mycroft processes does.