### PR TITLE
Restore the drawing of icons when showing weather.py

### DIFF
--- a/mycroft/client/enclosure/api.py
+++ b/mycroft/client/enclosure/api.py
@@ -173,7 +173,20 @@ class EnclosureAPI:
         self.ws.emit(Message("enclosure.mouth.text", {'text': text}))
 
     def weather_display(self, img_code, temp):
-        """Show a weather icon (deprecated)"""
+        """Show a the temperature and a weather icon
+
+        Args:
+            img_code (char): one of the following icon codes
+                         0 = sunny
+                         1 = partly cloudy
+                         2 = cloudy
+                         3 = light rain
+                         4 = raining
+                         5 = stormy
+                         6 = snowing
+                         7 = wind/mist
+            temp (int): the temperature (either C or F, not indicated)
+        """
         self.ws.emit(Message("enclosure.weather.display",
                              {'img_code': img_code, 'temp': temp}))
 

--- a/mycroft/client/enclosure/weather.py
+++ b/mycroft/client/enclosure/weather.py
@@ -25,7 +25,7 @@ LOGGER = getLogger(__name__)
 
 class EnclosureWeather:
     """
-    Listens to enclosure commands to display indicators of the weather.
+    Listens for Enclosure API commands to display indicators of the weather.
 
     Performs the associated command on Arduino by writing on the Serial port.
     """
@@ -40,8 +40,36 @@ class EnclosureWeather:
 
     def display(self, event=None):
         if event and event.data:
+            # Convert img_code to icon
             img_code = event.data.get("img_code", None)
+            icon = None
+            if img_code == 0:
+                # sunny
+                icon = "IICEIBMDNLMDIBCEAA"
+            elif img_code == 1:
+                # partly cloudy
+                icon = "IIEEGBGDHLHDHBGEEA"
+            elif img_code == 2:
+                # cloudy
+                icon = "IIIBMDMDODODODMDIB"
+            elif img_code == 3:
+                # light rain
+                icon = "IIMAOJOFPBPJPFOBMA"
+            elif img_code == 4:
+                # raining
+                icon = "IIMIOFOBPFPDPJOFMA"
+            elif img_code == 5:
+                # storming
+                icon = "IIAAIIMEODLBJAAAAA"
+            elif img_code == 6:
+                # snowing
+                icon = "IIJEKCMBPHMBKCJEAA"
+            elif img_code == 7:
+                # wind/mist
+                icon = "IIABIBIBIJIJJGJAGA"
+
             temp = event.data.get("temp", None)
-            if img_code is not None and temp is not None:
-                msg = "weather.display=" + str(img_code) + str(temp)
+            if icon is not None and temp is not None:
+                icon = "x=2,"+icon
+                msg = "weather.display=" + str(temp) + "," + str(icon)
                 self.writer.write(msg)


### PR DESCRIPTION
This implements the image drawing functionality of the lastest Mark 1 enclosure instead of the old numeric weather icon codes.