### PR TITLE
Improved handling of button press

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -271,6 +271,26 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
     def sec_to_bytes(sec, source):
         return sec * source.SAMPLE_RATE * source.SAMPLE_WIDTH
 
+    def _skip_wake_word(self):
+        # Check if told programatically to skip the wake word, like
+        # when we are in a dialog with the user.
+        if check_for_signal('startListening'):
+            return True
+
+        # Pressing the Mark 1 button can start recording (unless
+        # it is being used to mean 'stop' instead)
+        if check_for_signal('buttonPress', 1):
+            # give other processes time to consume this signal if
+            # it was meant to be a 'stop'
+            sleep(0.25)
+            if check_for_signal('buttonPress'):
+                # Signal is still here, assume it was intended to
+                # begin recording
+                logger.debug("Button Pressed, wakeword not needed")
+                return True
+
+        return False
+
     def _wait_until_wake_word(self, source, sec_per_buffer):
         """Listen continuously on source until a wake word is spoken
 
@@ -305,21 +325,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         counter = 0
 
         while not said_wake_word:
-            # Check if told programatically to skip the wake word for dialog
-            if check_for_signal('startListening'):
-                said_wake_word = True
-                continue
-
-            # Pressing the button can start recording (unless it is being
-            # used to mean 'stop' instead)
-            if check_for_signal('buttonPress', 1):
-                # give others time to consume this as 'stop'
-                sleep(0.25)
-                if check_for_signal('buttonPress'):
-                    # signal is still here, assume it was to begin recording
-                    logger.debug("Button Pressed, wakeword not needed")
-                    said_wake_word = True
-                    continue
+            if self._skip_wake_word():
+                break
 
             chunk = self.record_sound_chunk(source)
 


### PR DESCRIPTION
Improved the way the button press is handled.  Now the listener gives the rest
of the system a moment to consume the button press before it interprets it
as a request to begin listening.

Also replaced the use of the "buttonPress" signal when "expect_response"
was indicated with an utterance.  Now the signal "startListening" is
created, differentiating it from a buttonPress.