### PR TITLE
Update pyOpenSSL version to 16.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pystache==0.5.4
 configobj==5.0.6
 wikipedia==1.4.0
 requests==2.13.0
-pyOpenSSL==16.0.0
+pyOpenSSL==16.2.0
 ndg-httpsclient==0.4.0
 pyasn1==0.1.9
 gTTS==1.1.7


### PR DESCRIPTION
16.0.0 seem to have problems with newer versions of system installed
openSSL stack. Discussion in issue #705

Thanks to BoBeR182 for providing this solution. The same problem have been reported in a bunch of different project and this seems to be the agreed upon solution.

Resolves #705 