### PR TITLE
Remove ignoring SIG_CHLD

### DIFF
--- a/mycroft/skills/container.py
+++ b/mycroft/skills/container.py
@@ -25,10 +25,6 @@ from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.skills.core import create_skill_descriptor, load_skill
 from mycroft.skills.intent_service import IntentService
 from mycroft.util.log import getLogger
-import signal
-
-# ignore DIGCHLD to terminate subprocesses correctly
-signal.signal(signal.SIGCHLD, signal.SIG_IGN)
 
 __author__ = 'seanfitz'
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -22,7 +22,6 @@ import time
 
 import os.path
 import re
-import signal
 import time
 from os.path import join, dirname, splitext, isdir
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -18,7 +18,6 @@
 
 import json
 import os
-import signal
 import subprocess
 import sys
 import time
@@ -36,9 +35,6 @@ from mycroft.skills.intent_service import IntentService
 from mycroft.util import connected
 from mycroft.util.log import getLogger
 import mycroft.dialog
-
-# ignore DIGCHLD to terminate subprocesses correctly
-signal.signal(signal.SIGCHLD, signal.SIG_IGN)
 
 logger = getLogger("Skills")
 


### PR DESCRIPTION
Ignoring `SIG_CHLD` can be convenient but parts of the python standard
library relies on the behavior of `SIG_CHLD` and will not work correctly
in this configuration.

The best way to handle defunct processes is for the skill creator to handle them (by removing their reference or waiting for completion). This has been discussed somewhat in #715, there may be a possibility to create a watchdog loop to shut down defunct processes but would be kind of a blunt sword and would probably cause other more sneaky issues.