### PR TITLE
Cleaning up the MANIFEST file used for packaging

### DIFF
--- a/mycroft-base-MANIFEST.in
+++ b/mycroft-base-MANIFEST.in
@@ -1,12 +1,9 @@
 recursive-include mycroft/client/speech/model *
 include requirements.txt
 include mycroft/configuration/*.conf
-recursive-include mycroft/skills/*/dialog *
-recursive-include mycroft/skills/*/vocab *
-recursive-include mycroft/skills/*/regex *
-include mycroft/skills/alarm/alarm.mp3
-include mycroft/skills/volume/blop-mark-diangelo.wav
-include mycroft/res/snd/start_listening.wav
 #include mycroft/tts/mycroft_voice_4.0.flitevox
 recursive-include mycroft/client/wifisetup/web/* *
 include mycroft/client/wifisetup/web/index.html
+recursive-include mycroft/res *
+recursive-include mycroft/res/snd *
+recursive-include mycroft/res/text/* *


### PR DESCRIPTION
Several changes:
* Removed old references to skills/* subdirectories (now skills are not a part of mycroft-core, so unneeded)
* Added includes for mycroft/res files