### PR TITLE
Use exit status of msm to determine install success

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -23,6 +23,8 @@
 # This script assists in the installation and management of
 # skills loaded from Github.  
 
+set -e
+
 mycroft_skill_folder="/opt/mycroft/skills"
 mycroft_virtualenv=~/.virtualenvs/mycroft/bin/activate
 
@@ -37,8 +39,17 @@ function help() {
 	echo -e "example: msm install https://github.com/ethanaward/demo_skill.git\n"
 }
 
-function install() {
+
+function goto_skills_dir {
+        if [ ! -d $mycroft_skill_folder ]; then
+            echo "Couldn't install skill, $mycroft_skill_folder does not exist"
+            exit 1
+        fi
         cd $mycroft_skill_folder
+}
+
+function install() {
+        goto_skills_dir
 	if [ -z "$2" ]; then
 		echo "You must pass the git url or skill name"
 		exit 1
@@ -80,7 +91,7 @@ function install() {
 }
 
 function update() {
-        cd $mycroft_skill_folder
+        goto_skills_dir
 	for d in $(ls -d */); do
 		if git -C "$d" rev-parse --git-dir > /dev/null 2>&1; then
 			cd $d

--- a/mycroft/res/text/en-us/sorry I couldn't install default skills.dialog
+++ b/mycroft/res/text/en-us/sorry I couldn't install default skills.dialog
@@ -1,0 +1,2 @@
+sorry I couldn't install default skills
+an error occured while installing default skills

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -57,16 +57,25 @@ def connect():
 
 
 def install_default_skills(speak=True):
+    """
+        Install default skill set using msm.
+
+        Args:
+            speak (optional): Enable response for success. Default True
+    """
     if exists(MSM_BIN):
-        p = subprocess.Popen(MSM_BIN + " default", stderr=subprocess.STDOUT,
-                             stdout=subprocess.PIPE, shell=True)
-        t = p.communicate()[0]
-        if t.splitlines()[-1] == "Installed!" and speak:
+        res = subprocess.call(MSM_BIN + " default", stderr=subprocess.STDOUT,
+                              stdout=subprocess.PIPE, shell=True)
+        if res == 0 and speak:
             ws.emit(Message("speak", {
                 'utterance': mycroft.dialog.get("skills updated")}))
         elif not connected():
             ws.emit(Message("speak", {
                 'utterance': mycroft.dialog.get("no network connection")}))
+        elif res != 0:
+            ws.emit(Message("speak", {
+                'utterance': mycroft.dialog.get(
+                             "sorry I couldn't install default skills")}))
 
     else:
         logger.error("Unable to invoke Mycroft Skill Manager: " + MSM_BIN)


### PR DESCRIPTION
- msm will now return immediately if an error occurs
- install_default_skills now checks exit status instead of text output

Gives basic error information while installing default skills. Resolves #781