### PR TITLE
Remove catching of KeyboardInterrupt from signal handler

### DIFF
--- a/mycroft/lock/__init__.py
+++ b/mycroft/lock/__init__.py
@@ -71,11 +71,8 @@ class Signal(object):  # python 3+ class Signal
         there is a previously defined handler call it.
         '''
         self.__user_func()  # call user function
-        try:
-            if self.__previous_func:
-                self.__previous_func(signame, sf)
-        except KeyboardInterrupt as kbi:
-            pass
+        if self.__previous_func:
+            self.__previous_func(signame, sf)
 
     #
     # reset the signal handler


### PR DESCRIPTION
Catching Keyboard interrupt is counter productive here as the previous
signal handler might be `SIGINT` which works by raising `KeyboardInterrupt`.

This has caused ctrl+c to remove the lock file but not stop the service.