### PR TITLE
#801 Refactor setup_base.py to use new versioning method

### DIFF
--- a/mycroft/util/setup_base.py
+++ b/mycroft/util/setup_base.py
@@ -36,8 +36,9 @@ def place_manifest(manifest_file):
 def get_version():
     version = None
     try:
-        import mycroft.__version__
-        version = mycroft.__version__.version
+        import mycroft.version
+        version = mycroft.version.VersionManager.get()
+        logger.debug(version)
     except Exception as e:
         try:
             version = "dev-" + subprocess.check_output(


### PR DESCRIPTION
This refactors setup_base.py to use the current `mycroft.version` method for checking the current version of mycroft rather than the deprecated `mycroft.__version__`. This was causing issues with the packaging process if git wasn't installed, as using subprocess to call git was the next method used.