### PR TITLE
#805 Removed unused dependencies from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,9 @@
-shortuuid==0.4.3
 pystache==0.5.4
-configobj==5.0.6
 wikipedia==1.4.0
 requests==2.13.0
-pyOpenSSL==16.2.0
-ndg-httpsclient==0.4.0
-pyasn1==0.1.9
 gTTS==1.1.7
 gTTS-token==1.1.1
 backports.ssl-match-hostname==3.4.0.2
-certifi==2016.2.28
 PyAudio==0.2.8
 pyee==1.0.1
 SpeechRecognition==3.1.3
@@ -23,7 +17,6 @@ requests-futures==0.9.5
 astral==1.4
 tzlocal==1.3
 parsedatetime==1.5
-pdoc==0.3.2
 pyyaml==3.11
 feedparser==5.2.1
 pyalsaaudio==0.8.2
@@ -36,8 +29,6 @@ pep8==1.7.0
 multi_key_dict==2.0.3
 pocketsphinx==0.1.0
 wifi==0.3.8
-pyroute2==0.4.5
-urllib5==5.0.0
 pyric==0.1.6
 inflection==0.3.1
 uuid==1.30

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,5 @@ pocketsphinx==0.1.0
 wifi==0.3.8
 pyric==0.1.6
 inflection==0.3.1
-uuid==1.30
 pytz==2017.2
 mock


### PR DESCRIPTION
This removes several dependencies from requirements.txt, as they are no longer used. I've tested Mycroft without these dependencies on desktop and everything seems to be working. I'd recommend testing on Picroft and the Mark 1 to make sure there aren't any issues there. 