### PR TITLE
Minor onboarding refinements

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -219,11 +219,21 @@ class STTApi(Api):
         })
 
 
+def has_been_paired():
+    """ Determine if this device has ever been paired with a web backend
+
+    Returns:
+        bool: True if ever paired with backend (not factory reset)
+    """
+    id = IdentityManager.get()    
+    return id.uuid is not None and id.uuid != ""    
+    
+    
 def is_paired():
-    """ Determine if this device has been paired with a web backend
+    """ Determine if this device is actively paired with a web backend
 
     Determines if the installation of Mycroft has been paired by the user
-    with the backend system.
+    with the backend system, and if that pairing is still active.
 
     Returns:
         bool: True if paired with backend

--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -225,10 +225,10 @@ def has_been_paired():
     Returns:
         bool: True if ever paired with backend (not factory reset)
     """
-    id = IdentityManager.get()    
-    return id.uuid is not None and id.uuid != ""    
-    
-    
+    id = IdentityManager.get()
+    return id.uuid is not None and id.uuid != ""
+
+
 def is_paired():
     """ Determine if this device is actively paired with a web backend
 

--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -36,7 +36,7 @@ from mycroft.util import play_wav, create_signal, connected, \
     wait_while_speaking
 from mycroft.util.audio_test import record
 from mycroft.util.log import getLogger
-from mycroft.api import is_paired
+from mycroft.api import is_paired, has_been_paired
 
 __author__ = 'aatchison', 'jdorleans', 'iward'
 
@@ -85,7 +85,7 @@ class EnclosureReader(Thread):
             self.ws.emit(Message("enclosure.started"))
 
         if "mycroft.stop" in data:
-            if is_paired():
+            if has_been_paired():
                 create_signal('buttonPress')
                 self.ws.emit(Message("mycroft.stop"))
 
@@ -264,7 +264,7 @@ class Enclosure(object):
             # clients are up and connected to the messagebus in order to
             # receive the "speak".  This was sometimes happening too
             # quickly and the user wasn't notified what to do.
-            Timer(5, self.on_no_internet).start()
+            Timer(5, self._do_net_check).start()
 
     def on_no_internet(self, event=None):
         if connected():
@@ -278,7 +278,7 @@ class Enclosure(object):
         Enclosure._last_internet_notification = time.time()
 
         # TODO: This should go into EnclosureMark1 subclass of Enclosure.
-        if is_paired():
+        if has_been_paired():
             # Handle the translation within that code.
             self.ws.emit(Message("speak", {
                 'utterance': "This device is not connected to the Internet. "
@@ -349,3 +349,30 @@ class Enclosure(object):
             self.reader.stop()
             self.serial.close()
             self.ws.close()
+
+    def _do_net_check(self):
+        # TODO: This should live in the derived Enclosure, e.g. Enclosure_Mark1
+        LOG.info("Checking internet connection")
+        if not connected():  # and self.conn_monitor is None:
+            if has_been_paired():
+                # TODO: Enclosure/localization
+                self.ws.emit(Message("speak", {
+                    'utterance': "This unit is not connected to the Internet. Either "
+                        "plug in a network cable or hold the button on top for "
+                        "two seconds, then select wifi from the menu"}))
+            else:
+                # Begin the unit startup process, this is the first time it
+                # is being run with factory defaults.
+                
+                # TODO: This logic should be in Enclosure_Mark1
+                # TODO: Enclosure/localization
+                
+                # Don't listen to mic during this out-of-box experience
+                self.ws.emit(Message("mycroft.mic.mute", None))
+                
+                # Kick off wifi-setup automatically
+                self.ws.emit(Message("mycroft.wifi.start", {'msg': "Hello I am "
+                    "Mycroft, your new assistant.  To assist you I need to be "
+                    "connected to the internet.  You can either plug me in "
+                    "with a network cable, or use wifi.  To setup wifi ",
+                    'allow_timeout': False}))

--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -357,22 +357,26 @@ class Enclosure(object):
             if has_been_paired():
                 # TODO: Enclosure/localization
                 self.ws.emit(Message("speak", {
-                    'utterance': "This unit is not connected to the Internet. Either "
-                        "plug in a network cable or hold the button on top for "
-                        "two seconds, then select wifi from the menu"}))
+                    'utterance': "This unit is not connected to the Internet."
+                                 " Either plug in a network cable or hold the "
+                                 "button on top for two seconds, then select "
+                                 "wifi from the menu"
+                    }))
             else:
                 # Begin the unit startup process, this is the first time it
                 # is being run with factory defaults.
-                
+
                 # TODO: This logic should be in Enclosure_Mark1
                 # TODO: Enclosure/localization
-                
+
                 # Don't listen to mic during this out-of-box experience
                 self.ws.emit(Message("mycroft.mic.mute", None))
-                
+
                 # Kick off wifi-setup automatically
-                self.ws.emit(Message("mycroft.wifi.start", {'msg': "Hello I am "
-                    "Mycroft, your new assistant.  To assist you I need to be "
-                    "connected to the internet.  You can either plug me in "
-                    "with a network cable, or use wifi.  To setup wifi ",
-                    'allow_timeout': False}))
+                self.ws.emit(Message("mycroft.wifi.start",
+                                     {'msg': "Hello I am Mycroft, your new "
+                                      "assistant.  To assist you I need to be "
+                                      "connected to the internet.  You can "
+                                      "either plug me in with a network cable,"
+                                      " or use wifi.  To setup wifi ",
+                                      'allow_timeout': False}))

--- a/mycroft/client/enclosure/api.py
+++ b/mycroft/client/enclosure/api.py
@@ -52,11 +52,11 @@ class EnclosureAPI:
         self.ws.emit(Message("enclosure.system.reset"))
 
     def system_mute(self):
-        """Turn off the system microphone (not listening for wakeword)."""
+        """Mute (turn off) the system speaker."""
         self.ws.emit(Message("enclosure.system.mute"))
 
     def system_unmute(self):
-        """Turn the system microphone on (listening for wakeword)."""
+        """Unmute (turn on) the system speaker."""
         self.ws.emit(Message("enclosure.system.unmute"))
 
     def system_blink(self, times):

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -255,6 +255,12 @@ class RecognizerLoop(EventEmitter):
         if self.microphone:
             self.microphone.unmute()
 
+    def is_muted(self):
+        if self.microphone:
+            return self.microphone.is_muted()
+        else:
+            return True  # consider 'no mic' muted
+
     def sleep(self):
         self.state.sleeping = True
 

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -28,7 +28,7 @@ from mycroft.identity import IdentityManager
 from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.tts import TTSFactory
-from mycroft.util import kill, create_signal, check_for_signal
+from mycroft.util import kill, create_signal, check_for_signal, stop_speaking
 from mycroft.util.log import getLogger
 from mycroft.lock import Lock as PIDLock  # Create/Support PID locking file
 
@@ -80,12 +80,15 @@ def mute_and_speak(utterance):
         tts_hash = hash(str(config.get('tts', '')))
 
     ws.emit(Message("recognizer_loop:audio_output_start"))
+    already_muted = loop.is_muted()
     try:
         logger.info("Speak: " + utterance)
-        loop.mute()
+        if not already_muted:
+            loop.mute()  # only mute if necessary
         tts.execute(utterance)
     finally:
-        loop.unmute()
+        if not already_muted:
+            loop.unmute()  # restore
         lock.release()
         ws.emit(Message("recognizer_loop:audio_output_end"))
 
@@ -143,11 +146,18 @@ def handle_wake_up(event):
     loop.awaken()
 
 
+def handle_mic_mute(event):
+    loop.mute()
+
+
+def handle_mic_unmute(event):
+    loop.unmute()
+
+
 def handle_stop(event):
     global _last_stop_signal
     _last_stop_signal = time.time()
-    kill([config.get('tts').get('module')])
-    kill(["aplay"])
+    stop_speaking()
 
 
 def handle_paired(event):
@@ -155,6 +165,7 @@ def handle_paired(event):
 
 
 def handle_open():
+    # TODO: Move this into the Enclosure (not speech client)
     # Reset the UI to indicate ready for speech processing
     EnclosureAPI(ws).reset()
 
@@ -190,6 +201,8 @@ def main():
         handle_multi_utterance_intent_failure)
     ws.on('recognizer_loop:sleep', handle_sleep)
     ws.on('recognizer_loop:wake_up', handle_wake_up)
+    ws.on('mycroft.mic.mute', handle_mic_mute)
+    ws.on('mycroft.mic.unmute', handle_mic_unmute)
     ws.on('mycroft.stop', handle_stop)
     ws.on("mycroft.paired", handle_paired)
     event_thread = Thread(target=connect)

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -38,7 +38,6 @@ from mycroft.util import (
     play_wav
 )
 from mycroft.util.log import getLogger
-from mycroft.api import is_paired
 
 config = ConfigurationManager.instance()
 listener_config = config.get('listener')
@@ -129,6 +128,9 @@ class MutableMicrophone(Microphone):
         if self.stream:
             self.stream.unmute()
 
+    def is_muted(self):
+        return self.muted
+
 
 class ResponsiveRecognizer(speech_recognition.Recognizer):
     # Padding of silence when feeding to pocketsphinx
@@ -179,8 +181,6 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         return audioop.rms(sound_chunk, sample_width)
 
     def wake_word_in_audio(self, frame_data):
-        if not is_paired():
-            return False
         hyp = self.wake_word_recognizer.transcribe(frame_data)
         return self.wake_word_recognizer.found_wake_word(hyp)
 

--- a/mycroft/client/wifisetup/main.py
+++ b/mycroft/client/wifisetup/main.py
@@ -365,8 +365,10 @@ class WiFi:
                 timeStarted = time.time()  # reset start time after connection
                 timeLastAnnounced = time.time() - 45  # announce how to connect
 
-            if time.time() - timeStarted > 60 * 5:
-                # After 5 minutes, shut down the access point
+            if time.time() - timeStarted > 60 * 5 and is_paired():
+                # After 5 minutes, shut down the access point (unless the
+                # system has never been setup, in which case we stay up
+                # indefinitely)
                 LOG.info("Auto-shutdown of access point after 5 minutes")
                 self.stop()
                 continue
@@ -521,6 +523,7 @@ class WiFi:
             self.server.join()
             self.server = None
         LOG.info("Access point stopped!")
+        self.enclosure.mouth_reset()
 
     def _do_net_check(self):
         # give system 5 seconds to resolve network or get plugged in

--- a/mycroft/client/wifisetup/main.py
+++ b/mycroft/client/wifisetup/main.py
@@ -294,17 +294,17 @@ class WiFi:
         '''
         if self.starting:
             return
-        
+
         self.starting = True
         LOG.info("Starting access point...")
-        
+
         self.intro_msg = ""
         if event and event.data.get("msg"):
             self.intro_msg = event.data.get("msg")
         self.allow_timeout = True
         if event and event.data.get("allow_timeout"):
             self.allow_timeout = event.data.get("allow_timeout")
-        
+
         # Fire up our access point
         self.ap.up()
         if not self.server:
@@ -543,7 +543,7 @@ class WiFi:
             self.server.server.server_close()
             self.server.join()
             self.server = None
-        LOG.info("Access point stopped!")  
+        LOG.info("Access point stopped!")
 
     def run(self):
         try:

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -111,6 +111,8 @@ class Mimic(TTS):
         for pair in pairs:
             if mycroft.util.check_for_signal('buttonPress'):
                 return
+            if mycroft.util.check_for_signal('stoppingTTS', -1):
+                return
             pho_dur = pair.split(":")  # phoneme:duration
             if len(pho_dur) == 2:
                 code = VISIMES.get(pho_dur[0], '4')

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -384,6 +384,6 @@ def stop_speaking():
         kill([config.get('tts').get('module')])
         kill(["aplay"])
         time.sleep(0.25)
-        
+
     # This consumes the signal
     check_for_signal('stoppingTTS')

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -82,7 +82,7 @@ def resolve_resource_file(res_name):
 
 
 def play_wav(uri):
-    config = mycroft.configuration.ConfigurationManager.get()
+    config = mycroft.configuration.ConfigurationManager.instance()
     play_cmd = config.get("play_wav_cmdline")
     play_wav_cmd = str(play_cmd).split(" ")
     for index, cmd in enumerate(play_wav_cmd):
@@ -92,7 +92,7 @@ def play_wav(uri):
 
 
 def play_mp3(uri):
-    config = mycroft.configuration.ConfigurationManager.get()
+    config = mycroft.configuration.ConfigurationManager.instance()
     play_cmd = config.get("play_mp3_cmdline")
     play_mp3_cmd = str(play_cmd).split(" ")
     for index, cmd in enumerate(play_mp3_cmd):
@@ -230,7 +230,7 @@ def curate_cache(dir, min_free_percent=5.0):
 
 
 def get_cache_directory(domain=None):
-    """Get a directory for caches data
+    """Get a directory for caching data
 
     This directory can be used to hold temporary caches of data to
     speed up performance.  This directory will likely be part of a
@@ -244,7 +244,8 @@ def get_cache_directory(domain=None):
     Return:
         str: a path to the directory where you can cache data
     """
-    dir = mycroft.configuration.ConfigurationManager.get().get("cache_path")
+    config = mycroft.configuration.ConfigurationManager.instance()
+    dir = config.get("cache_path")
     if not dir:
         # If not defined, use /tmp/mycroft/cache
         dir = os.path.join(tempfile.gettempdir(), "mycroft", "cache")
@@ -264,7 +265,8 @@ def get_ipc_directory(domain=None):
     Returns:
         str: a path to the IPC directory
     """
-    dir = mycroft.configuration.ConfigurationManager.get().get("ipc_path")
+    config = mycroft.configuration.ConfigurationManager.instance()
+    dir = config.get("ipc_path")
     if not dir:
         # If not defined, use /tmp/mycroft/ipc
         dir = os.path.join(tempfile.gettempdir(), "mycroft", "ipc")
@@ -364,3 +366,11 @@ def wait_while_speaking():
     time.sleep(0.1)  # Wait briefly in for any queued speech to begin
     while is_speaking():
         time.sleep(0.1)
+
+
+def stop_speaking():
+    # TODO: Less hacky approach to this once Audio Manager is implemented
+    # Skills should only be able to stop speech they've initiated
+    config = mycroft.configuration.ConfigurationManager.instance()
+    kill([config.get('tts').get('module')])
+    kill(["aplay"])


### PR DESCRIPTION
* The wifi setup no longer stops after 5 minutes unless already paired (i.e. still onboarding)
* The mouth resets on wifisetup stop (clearing the scrolling home.mycroft.ai)
* Changed several ConfigurationManager.get() calls to ConfigurationManager.instance().  Exactly the same, but .instance() is clearer/preferred.
* Added a mycroft.util.stop_speaking() method.  Not perfect, but works for now and can be replaced later when AudioManager is in place.

A forthcoming change to the pairing skill will utilize the stop_speaking method.