### PR TITLE
#824 Change has_been_paired to load the current identity file

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -225,7 +225,9 @@ def has_been_paired():
     Returns:
         bool: True if ever paired with backend (not factory reset)
     """
-    id = IdentityManager.get()
+    # This forces a load from the identity file in case the pairing state
+    # has recently changed
+    id = IdentityManager.load()
     return id.uuid is not None and id.uuid != ""
 
 

--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -77,7 +77,8 @@ class EnclosureReader(Thread):
                 LOG.error("Reading error: {0}".format(e))
 
     def process(self, data):
-        self.ws.emit(Message(data))
+        if not "mycroft.stop" in data:
+            self.ws.emit(Message(data))
 
         if "Command: system.version" in data:
             # This happens in response to the "system.version" message

--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -77,7 +77,10 @@ class EnclosureReader(Thread):
                 LOG.error("Reading error: {0}".format(e))
 
     def process(self, data):
-        if not "mycroft.stop" in data:
+        # TODO: Look into removing this emit altogether.
+        # We need to check if any other serial bus messages
+        # are handled by other parts of the code
+        if "mycroft.stop" not in data:
             self.ws.emit(Message(data))
 
         if "Command: system.version" in data:


### PR DESCRIPTION
This changes the has_been_paired function to load the current identity file in case the pairing state has recently changed. It also removes the doubling of `mycroft.stop` messages.