### PR TITLE
Closes #801 - Refactor setup_base to use CORE_VERSION_STR

### DIFF
--- a/mycroft/util/setup_base.py
+++ b/mycroft/util/setup_base.py
@@ -36,8 +36,8 @@ def place_manifest(manifest_file):
 def get_version():
     version = None
     try:
-        import mycroft.__version__
-        version = mycroft.__version__.version
+        from mycroft.version import CORE_VERSION_STR
+        version = CORE_VERSION_STR
     except Exception as e:
         try:
             version = "dev-" + subprocess.check_output(


### PR DESCRIPTION
This changes the get_version method to get the version from CORE_VERSION_STR instead of the deprecated __version__.  This also doesn't have the issue of the previous PR, where it would check for a file that doesn't exist during the build process, and so break packaging. @aatchison, it would be good if you could double check that this works for the current packaging process.