### PR TITLE
Fixed allow_timeout (used in out-of-the-box); and a wifi setup tweak

### DIFF
--- a/mycroft/client/wifisetup/main.py
+++ b/mycroft/client/wifisetup/main.py
@@ -301,7 +301,7 @@ class WiFi:
         if event and event.data.get("msg"):
             self.intro_msg = event.data.get("msg")
         self.allow_timeout = True
-        if event and event.data.get("allow_timeout"):
+        if event and event.data.get("allow_timeout") is False:
             self.allow_timeout = event.data.get("allow_timeout")
 
         # Fire up our access point
@@ -416,7 +416,7 @@ class WiFi:
                 # has disconnected
                 if not self._is_ARP_filled():
                     cARPFailures += 1
-                    if cARPFailures > 2:
+                    if cARPFailures > 5:
                         self._connection_prompt("Connection lost.")
                         bHasConnected = False
                 else:


### PR DESCRIPTION
Fixed the allow_timeout (used in out-of-the-box); and a wifi setup disconnect tweak

* The allow_timeout value was tested poorly, preventing it from actually doing anything
* Upped the number of arp/ping test failures from 3 to 6 when validating the connection.  This makes falsely detecting a wifi setup disconnect pretty unlikely.