### PR TITLE
Feature/decorate intenthandlers

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -161,14 +161,15 @@ def unload_skills(skills):
         s.shutdown()
 
 
-intent_list = []
+_intent_list = []
 
 
 def intent_handler(intent_parser):
+    """ Decorator for adding a method as an intent handler. """
     def real_decorator(func):
         def handler_method(*args, **kwargs):
             return func(*args, **kwargs)
-        intent_list.append((intent_parser, func))
+        _intent_list.append((intent_parser, func))
         return handler_method
     return real_decorator
 
@@ -250,11 +251,16 @@ class MycroftSkill(object):
 
         Usually used to create intents rules and register them.
         """
-        raise Exception("Initialize not implemented for skill: " + self.name)
+        logger.debug("No initialize function implemented")
 
-    def register_decorated(self):
-        for intent_parser, handler in intent_list:
+    def _register_decorated(self):
+        """
+        Register all intent handlers that has been decorated with an intent.
+        """
+        global _intent_list
+        for intent_parser, handler in _intent_list:
             self.register_intent(intent_parser, handler, need_self=True)
+        _intent_list = []
 
     def register_intent(self, intent_parser, handler, need_self=False):
         name = intent_parser.name
@@ -263,7 +269,6 @@ class MycroftSkill(object):
         self.registered_intents.append((name, intent_parser))
 
         def receive_handler_with_self(message):
-            print handler
             try:
                 handler(self, message)
             except:

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -107,6 +107,7 @@ def load_skill(skill_descriptor, emitter):
             skill._dir = dirname(skill_descriptor['info'][1])
             skill.load_data_files(dirname(skill_descriptor['info'][1]))
             skill.initialize()
+            skill._register_decorated()
             logger.info("Loaded " + skill_descriptor["name"])
             return skill
         else:

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -161,6 +161,18 @@ def unload_skills(skills):
         s.shutdown()
 
 
+intent_list = []
+
+
+def intent_handler(intent_parser):
+    def real_decorator(func):
+        def handler_method(*args, **kwargs):
+            return func(*args, **kwargs)
+        intent_list.append((intent_parser, func))
+        return handler_method
+    return real_decorator
+
+
 class MycroftSkill(object):
     """
     Abstract base class which provides common behaviour and parameters to all
@@ -240,11 +252,28 @@ class MycroftSkill(object):
         """
         raise Exception("Initialize not implemented for skill: " + self.name)
 
-    def register_intent(self, intent_parser, handler):
+    def register_decorated(self):
+        for intent_parser, handler in intent_list:
+            self.register_intent(intent_parser, handler, need_self=True)
+
+    def register_intent(self, intent_parser, handler, need_self=False):
         name = intent_parser.name
         intent_parser.name = self.name + ':' + intent_parser.name
         self.emitter.emit(Message("register_intent", intent_parser.__dict__))
         self.registered_intents.append((name, intent_parser))
+
+        def receive_handler_with_self(message):
+            print handler
+            try:
+                handler(self, message)
+            except:
+                # TODO: Localize
+                self.speak(
+                    "An error occurred while processing a request in " +
+                    self.name)
+                logger.error(
+                    "An error occurred while processing a request in " +
+                    self.name, exc_info=True)
 
         def receive_handler(message):
             try:
@@ -259,7 +288,10 @@ class MycroftSkill(object):
                     self.name, exc_info=True)
 
         if handler:
-            self.emitter.on(intent_parser.name, receive_handler)
+            if not need_self:
+                self.emitter.on(intent_parser.name, receive_handler)
+            else:
+                self.emitter.on(intent_parser.name, receive_handler_with_self)
             self.events.append((intent_parser.name, receive_handler))
 
     def disable_intent(self, intent_name):


### PR DESCRIPTION
A new way to create intent handlers for skills by simply decorating the methods with `@intent_handler(...)`.

Example of what it would look like:
```python
from mycroft.skills.core import MycroftSkill, intent_handler
from adapt.intent import IntentBuilder


class ASkill(MycroftSkill):
    def __init__(self):
        super(ASkill, self).__init__('ASkill')

    @intent_handler(IntentBuilder('AskillIntent').require('ASkill1').build())
    def handle(self, message):
        self.speak('A Skill handler')

    @intent_handler(IntentBuilder('AskillIntent2').require('ASkill2').build())
    def handle2(self, message):
        self.speak('Another Skill handler')

    @intent_handler(IntentBuilder('AskillIntent3').require('ASkill3').build())
    def handle3(self, message):
        self.speak('Third Skill handler')


def create_skill():
    return ASkill()
```

The above test case can be downloaded from [GoogleDrive](https://drive.google.com/file/d/0B6NfzYSsivqTM0R0Wl9lMjBYNEk/view?usp=sharing). Each of the intent handlers can be triggered with _first skill_,  _another skill_ and _third_skill_

Normal intent registration is still available (`def initialize(self)...`) so this is 100% backward compatible.

Future improvement: Adding possibility to read intent from file.