### PR TITLE
Issue#850 Check for mimic.

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -80,7 +80,7 @@ echo "Building with $CORES cores."
 #build and install mimic
 cd "${TOP}"
 
-build_mimic="${build_mimic:-n}"  
+build_mimic="${build_mimic:-y}"  
 if [[ "$build_mimic" == 'y' ]] ; then
   echo "WARNING: The following can take a long time to run!"
   "${TOP}/scripts/install-mimic.sh"

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -45,13 +45,12 @@ if [[ "$1" == '-sm' ]] ; then
   build_mimic='n'
 fi
 
-if [[ $1 -ne '-sm' ]] && hash mimic ; then
+if [[ "$1" != '-sm' ]] && hash mimic ; then
   if mimic -lv | grep -q Voice ; then
     echo "Existing mimic installation. press y to build mimic again, any other key to skip."
     read -n1 build_mimic
   fi
 fi
-
 
 
 # create virtualenv, consistent with virtualenv-wrapper conventions

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -40,13 +40,19 @@ else
     VIRTUALENV_ROOT="$WORKON_HOME/mycroft"
 fi
 
-# check for existing mimic (f26/previous build/etc)
-if hash mimic ; then
+# skip mimic build?
+if [[ "$1" == '-sm' ]] ; then 
+  build_mimic='n'
+fi
+
+if [[ $1 -ne '-sm' ]] && hash mimic ; then
   if mimic -lv | grep -q Voice ; then
     echo "Existing mimic installation. press y to build mimic again, any other key to skip."
     read -n1 build_mimic
   fi
 fi
+
+
 
 # create virtualenv, consistent with virtualenv-wrapper conventions
 if [ ! -d "${VIRTUALENV_ROOT}" ]; then


### PR DESCRIPTION
Since mimic is now available from packages on Fedora 26 (and probably elsewhere), or from previous build, query about building again if it's found.

Additionally, allow for mimic build to be skipped if correct parameter is passed to script.  

pip was called as both pip and pip2, I changed this to just pip for consistency. Both are called after the activate, so should be using the virtualenv's default pip?