### PR TITLE
Fix model folder in manifest

### DIFF
--- a/mycroft-base-MANIFEST.in
+++ b/mycroft-base-MANIFEST.in
@@ -1,4 +1,4 @@
-recursive-include mycroft/client/speech/model *
+recursive-include mycroft/client/speech/recognizer/model *
 include requirements.txt
 include mycroft/configuration/*.conf
 #include mycroft/tts/mycroft_voice_4.0.flitevox


### PR DESCRIPTION
Otherwise, the model folder doesn't get copied into the egg site package folder and when Pocketsphinx is created the Decoder returns a RuntimeError.