### PR TITLE
Move audio output start and end messages to TTS class

### DIFF
--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -82,7 +82,8 @@ class PlaybackThread(Thread):
                 else:
                     self.p.communicate()
                 self.p.wait()
-                self.tts.end_audio()
+                if len(self.queue) == 0:
+                    self.tts.end_audio()
                 self.blink(0.2)
             except:
                 pass

--- a/mycroft/tts/espeak_tts.py
+++ b/mycroft/tts/espeak_tts.py
@@ -28,8 +28,10 @@ class ESpeak(TTS):
         super(ESpeak, self).__init__(lang, voice, ESpeakValidator(self))
 
     def execute(self, sentence):
+        self.begin_audio()
         subprocess.call(
             ['espeak', '-v', self.lang + '+' + self.voice, sentence])
+        self.end_audio()
 
 
 class ESpeakValidator(TTSValidator):

--- a/mycroft/tts/remote_tts.py
+++ b/mycroft/tts/remote_tts.py
@@ -24,6 +24,7 @@ from requests_futures.sessions import FuturesSession
 from mycroft.tts import TTS
 from mycroft.util import remove_last_slash, play_wav
 from mycroft.util.log import getLogger
+from mycroft.messagebus.message import Message
 
 __author__ = 'jdorleans'
 
@@ -50,9 +51,12 @@ class RemoteTTS(TTS):
         if len(phrases) > 0:
             for req in self.__requests(phrases):
                 try:
+                    self.begin_audio()
                     self.__play(req)
                 except Exception, e:
                     LOGGER.error(e.message)
+                finally:
+                    self.end_audio()
 
     @staticmethod
     def __get_phrases(sentence):

--- a/mycroft/tts/spdsay_tts.py
+++ b/mycroft/tts/spdsay_tts.py
@@ -28,8 +28,10 @@ class SpdSay(TTS):
         super(SpdSay, self).__init__(lang, voice, SpdSayValidator(self))
 
     def execute(self, sentence):
+        self.begin_audio()
         subprocess.call(
             ['spd-say', '-l', self.lang, '-t', self.voice, sentence])
+        self.end_audio()
 
 
 class SpdSayValidator(TTSValidator):


### PR DESCRIPTION
This prevents them from being outputted too early if playback is run on another thread

In addition, this clears out redundant quiet checks