### PR TITLE
Add intent fallback system

### DIFF
--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -90,7 +90,7 @@ def mute_and_speak(utterance):
         lock.release()
 
 
-def handle_intent_failure(event):
+def handle_complete_intent_failure(event):
     logger.info("Failed to find intent.")
     # TODO: Localize
     mute_and_speak("Sorry, I didn't catch that. Please rephrase your request.")
@@ -205,7 +205,7 @@ def main():
     loop.on('recognizer_loop:no_internet', handle_no_internet)
     ws.on('open', handle_open)
     ws.on('speak', handle_speak)
-    ws.on('intent_failure', handle_intent_failure)
+    ws.on('complete_intent_failure', handle_complete_intent_failure)
     ws.on('recognizer_loop:sleep', handle_sleep)
     ws.on('recognizer_loop:wake_up', handle_wake_up)
     ws.on('mycroft.mic.mute', handle_mic_mute)

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -90,8 +90,8 @@ def mute_and_speak(utterance):
         lock.release()
 
 
-def handle_multi_utterance_intent_failure(event):
-    logger.info("Failed to find intent on multiple intents.")
+def handle_intent_failure(event):
+    logger.info("Failed to find intent.")
     # TODO: Localize
     mute_and_speak("Sorry, I didn't catch that. Please rephrase your request.")
 
@@ -205,9 +205,7 @@ def main():
     loop.on('recognizer_loop:no_internet', handle_no_internet)
     ws.on('open', handle_open)
     ws.on('speak', handle_speak)
-    ws.on(
-        'multi_utterance_intent_failure',
-        handle_multi_utterance_intent_failure)
+    ws.on('intent_failure', handle_intent_failure)
     ws.on('recognizer_loop:sleep', handle_sleep)
     ws.on('recognizer_loop:wake_up', handle_wake_up)
     ws.on('mycroft.mic.mute', handle_mic_mute)

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -20,6 +20,7 @@ import abc
 import imp
 import time
 
+import operator
 import os.path
 import re
 import time
@@ -187,6 +188,8 @@ class MycroftSkill(object):
     Skills implementation.
     """
 
+    fallback_handlers = {}
+
     def __init__(self, name, emitter=None):
         self.name = name
         self.bind(emitter)
@@ -198,6 +201,38 @@ class MycroftSkill(object):
         self.log = getLogger(name)
         self.reload_skill = True
         self.events = []
+
+    @staticmethod
+    def on_intent_failure(message):
+        """Goes through all fallback handler until one returns true"""
+        for _, handler in sorted(MycroftSkill.fallback_handlers.items(),
+                                 key=operator.itemgetter(0)):
+            if handler(message):
+                return
+        logger.warn('No fallback could handle intent.')
+
+    @staticmethod
+    def register_fallback(handler, priority):
+        """
+        Register a function to be called as a general info fallback
+        Fallback should receive message and return
+        a boolean (True if succeeded or False if failed)
+
+        Lower priority gets run first
+        0 for high priority 100 for low priority
+        """
+        while priority in MycroftSkill.fallback_handlers:
+            priority += 1
+
+        MycroftSkill.fallback_handlers[priority] = handler
+
+    @staticmethod
+    def remove_fallback(handler_to_del):
+        for priority, handler in MycroftSkill.fallback_handlers.items():
+            if handler == handler_to_del:
+                del MycroftSkill.fallback_handlers[priority]
+                return
+        logger.warn('Could not remove fallback!')
 
     @property
     def location(self):

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -203,13 +203,19 @@ class MycroftSkill(object):
         self.events = []
 
     @staticmethod
-    def on_intent_failure(message):
-        """Goes through all fallback handler until one returns true"""
-        for _, handler in sorted(MycroftSkill.fallback_handlers.items(),
-                                 key=operator.itemgetter(0)):
-            if handler(message):
-                return
-        logger.warn('No fallback could handle intent.')
+    def make_intent_failure_handler(ws):
+        """Goes through all fallback handlers until one returns true"""
+        def handler(message):
+            for _, handler in sorted(MycroftSkill.fallback_handlers.items(),
+                                     key=operator.itemgetter(0)):
+                try:
+                    if handler(message):
+                        return
+                except Exception as e:
+                    logger.info('Exception in fallback: ' + str(e))
+            ws.emit(Message('complete_intent_failure'))
+            logger.warn('No fallback could handle intent.')
+        return handler
 
     @staticmethod
     def register_fallback(handler, priority):

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -14,8 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Mycroft Core.  If not, see <http://www.gnu.org/licenses/>.
-
-
 import abc
 import imp
 import time
@@ -188,8 +186,6 @@ class MycroftSkill(object):
     Skills implementation.
     """
 
-    fallback_handlers = {}
-
     def __init__(self, name, emitter=None):
         self.name = name
         self.bind(emitter)
@@ -201,44 +197,6 @@ class MycroftSkill(object):
         self.log = getLogger(name)
         self.reload_skill = True
         self.events = []
-
-    @staticmethod
-    def make_intent_failure_handler(ws):
-        """Goes through all fallback handlers until one returns true"""
-        def handler(message):
-            for _, handler in sorted(MycroftSkill.fallback_handlers.items(),
-                                     key=operator.itemgetter(0)):
-                try:
-                    if handler(message):
-                        return
-                except Exception as e:
-                    logger.info('Exception in fallback: ' + str(e))
-            ws.emit(Message('complete_intent_failure'))
-            logger.warn('No fallback could handle intent.')
-        return handler
-
-    @staticmethod
-    def register_fallback(handler, priority):
-        """
-        Register a function to be called as a general info fallback
-        Fallback should receive message and return
-        a boolean (True if succeeded or False if failed)
-
-        Lower priority gets run first
-        0 for high priority 100 for low priority
-        """
-        while priority in MycroftSkill.fallback_handlers:
-            priority += 1
-
-        MycroftSkill.fallback_handlers[priority] = handler
-
-    @staticmethod
-    def remove_fallback(handler_to_del):
-        for priority, handler in MycroftSkill.fallback_handlers.items():
-            if handler == handler_to_del:
-                del MycroftSkill.fallback_handlers[priority]
-                return
-        logger.warn('Could not remove fallback!')
 
     @property
     def location(self):
@@ -424,3 +382,50 @@ class MycroftSkill(object):
         self.emitter.emit(
             Message("detach_skill", {"skill_name": self.name + ":"}))
         self.stop()
+
+
+class FallbackSkill(MycroftSkill):
+    fallback_handlers = {}
+
+    def __init__(self, name, emitter=None):
+        MycroftSkill.__init__(self, name, emitter)
+
+    @staticmethod
+    def make_intent_failure_handler(ws):
+        """Goes through all fallback handlers until one returns true"""
+
+        def handler(message):
+            for _, handler in sorted(FallbackSkill.fallback_handlers.items(),
+                                     key=operator.itemgetter(0)):
+                try:
+                    if handler(message):
+                        return
+                except Exception as e:
+                    logger.info('Exception in fallback: ' + str(e))
+            ws.emit(Message('complete_intent_failure'))
+            logger.warn('No fallback could handle intent.')
+
+        return handler
+
+    @staticmethod
+    def register_fallback(handler, priority):
+        """
+        Register a function to be called as a general info fallback
+        Fallback should receive message and return
+        a boolean (True if succeeded or False if failed)
+
+        Lower priority gets run first
+        0 for high priority 100 for low priority
+        """
+        while priority in FallbackSkill.fallback_handlers:
+            priority += 1
+
+        FallbackSkill.fallback_handlers[priority] = handler
+
+    @staticmethod
+    def remove_fallback(handler_to_del):
+        for priority, handler in FallbackSkill.fallback_handlers.items():
+            if handler == handler_to_del:
+                del FallbackSkill.fallback_handlers[priority]
+                return
+        logger.warn('Could not remove fallback!')

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -390,12 +390,12 @@ class FallbackSkill(MycroftSkill):
     def __init__(self, name, emitter=None):
         MycroftSkill.__init__(self, name, emitter)
 
-    @staticmethod
-    def make_intent_failure_handler(ws):
+    @classmethod
+    def make_intent_failure_handler(cls, ws):
         """Goes through all fallback handlers until one returns true"""
 
         def handler(message):
-            for _, handler in sorted(FallbackSkill.fallback_handlers.items(),
+            for _, handler in sorted(cls.fallback_handlers.items(),
                                      key=operator.itemgetter(0)):
                 try:
                     if handler(message):
@@ -407,8 +407,8 @@ class FallbackSkill(MycroftSkill):
 
         return handler
 
-    @staticmethod
-    def register_fallback(handler, priority):
+    @classmethod
+    def register_fallback(cls, handler, priority):
         """
         Register a function to be called as a general info fallback
         Fallback should receive message and return
@@ -417,15 +417,15 @@ class FallbackSkill(MycroftSkill):
         Lower priority gets run first
         0 for high priority 100 for low priority
         """
-        while priority in FallbackSkill.fallback_handlers:
+        while priority in cls.fallback_handlers:
             priority += 1
 
-        FallbackSkill.fallback_handlers[priority] = handler
+        cls.fallback_handlers[priority] = handler
 
-    @staticmethod
-    def remove_fallback(handler_to_del):
-        for priority, handler in FallbackSkill.fallback_handlers.items():
+    @classmethod
+    def remove_fallback(cls, handler_to_del):
+        for priority, handler in cls.fallback_handlers.items():
             if handler == handler_to_del:
-                del FallbackSkill.fallback_handlers[priority]
+                del cls.fallback_handlers[priority]
                 return
         logger.warn('Could not remove fallback!')

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -63,14 +63,9 @@ class IntentService(object):
             reply = message.reply(
                 best_intent.get('intent_type'), best_intent)
             self.emitter.emit(reply)
-        elif len(utterances) == 1:
+        else:
             self.emitter.emit(Message("intent_failure", {
                 "utterance": utterances[0],
-                "lang": lang
-            }))
-        else:
-            self.emitter.emit(Message("multi_utterance_intent_failure", {
-                "utterances": utterances,
                 "lang": lang
             }))
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -117,7 +117,7 @@ def _load_skills():
 
     check_connection()
 
-    ws.on('intent_failure', MycroftSkill.on_intent_failure)
+    ws.on('intent_failure', MycroftSkill.make_intent_failure_handler(ws))
 
     # Create skill_manager listener and invoke the first time
     ws.on('skill_manager', skills_manager)

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -30,7 +30,7 @@ from mycroft.lock import Lock  # Creates PID file for single instance
 from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import load_skill, create_skill_descriptor, \
-    MainModule, SKILLS_DIR, MycroftSkill
+    MainModule, SKILLS_DIR, FallbackSkill
 from mycroft.skills.intent_service import IntentService
 from mycroft.util import connected
 from mycroft.util.log import getLogger
@@ -117,7 +117,7 @@ def _load_skills():
 
     check_connection()
 
-    ws.on('intent_failure', MycroftSkill.make_intent_failure_handler(ws))
+    ws.on('intent_failure', FallbackSkill.make_intent_failure_handler(ws))
 
     # Create skill_manager listener and invoke the first time
     ws.on('skill_manager', skills_manager)

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -30,7 +30,7 @@ from mycroft.lock import Lock  # Creates PID file for single instance
 from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import load_skill, create_skill_descriptor, \
-    MainModule, SKILLS_DIR
+    MainModule, SKILLS_DIR, MycroftSkill
 from mycroft.skills.intent_service import IntentService
 from mycroft.util import connected
 from mycroft.util.log import getLogger
@@ -116,6 +116,8 @@ def _load_skills():
         skill_reload_thread
 
     check_connection()
+
+    ws.on('intent_failure', MycroftSkill.on_intent_failure)
 
     # Create skill_manager listener and invoke the first time
     ws.on('skill_manager', skills_manager)


### PR DESCRIPTION
This is a new system that allows other skills to register as fallbacks to handle general knowledge queries. For now, each skill self-assigns a priority where `0` is the `highest` and `100` is very low priority. When an intent failure occurs, each fallback gets run until one returns True meaning it found a response to speak to the user. Example usage:

**`skill-my-fallback/__init__.py`**:
```Python
from mycroft.skills.core import MycroftSkill
class MyFallbackSkilll(MycroftSkill):
    def __init__(self):
        MycroftSkill.__init__(self, name="MyFallbackSkill")

    def initialize(self):
        self.register_fallback(self.handle_fallback, 80)

    def handle_fallback(self, message):
        if 'what is' in message.data['utterance']:
            self.speak_dialog('the answer is always 42')
            return True
        return False
```

This PR also removes the multi utterance intent fail. It only makes sense to emit an `intent_failure` regardless of the amount of intents, especially since we only ever receive one utterance anymore.

This PR relies on [this PR][skill-pr] in skill-wolfram-alpha. Instructions for testing:
```
git fetch
git checkout feature/fallbacks
mycroft_dir="$(pwd)"
cd /opt/mycroft/skills/skill-wolfram-alpha
git fetch
git checkout feature/fallbacks
cd "$mycroft_dir"
./mycroft.sh start
```
Then test functionality of Wolfram Alpha for questions like `what is a fox` (and maybe wolfram skill reloading when `/opt/mycroft/skill-wolfram-alpha/__init__.py` is edited).

[skill-pr]:https://github.com/MycroftAI/skill-wolfram-alpha/pull/3