### PR TITLE
Hack to deal with a silly problem happening during upgrade of Mark 1

### DIFF
--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -178,6 +178,24 @@ def handle_open():
     # Reset the UI to indicate ready for speech processing
     EnclosureAPI(ws).reset()
 
+    # TEMPORARY HACK:  Look for multiple instance of the mycroft-speech-client
+    # which could happen when upgrading a shipping Mark 1 from release 0.8.17
+    # or before.  When found, force the unit to reboot...
+    import psutil
+    import subprocess
+    count_instances = 0
+    for process in psutil.process_iter():
+        if process.cmdline() == ['python2.7',
+                                 '/usr/local/bin/mycroft-speech-client']:
+            count_instances += 1
+    if (count_instances > 1):
+        ws.emit(Message("enclosure.eyes.spin"))
+        ws.emit(Message("enclosure.mouth.reset"))
+        time.sleep(0.5)  # Allows system time to start the eyes spinning
+        subprocess.call('systemctl reboot -i', shell=True)
+    # END HACK
+    # TODO: Remove this hack ASAP
+
 
 def connect():
     ws.run_forever()


### PR DESCRIPTION
Hack to deal with a silly problem happening during upgrade of Mark 1 with
0.8.17 or earlier build.  A Series of Unfortunate Events leads to two instances
of the mycroft-skills service running.  This causes double-answers, which is
confusing to everyone.  The root problem that lead to this is corrected in
release 0.8.18, but resolving it in packaging is ridiculously difficult.

So, we'll do this simple hack for the interim.  It is harmless and useless if
not running in the Mark 1 environment.