### PR TITLE
Make expect response trigger when mycroft stops speaking

### DIFF
--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -96,6 +96,13 @@ def handle_multi_utterance_intent_failure(event):
     mute_and_speak("Sorry, I didn't catch that. Please rephrase your request.")
 
 
+def _trigger_expect_response(message):
+    """
+        Makes mycroft start listening on 'recognizer_loop:audio_output_end'
+    """
+    create_signal('startListening')
+
+
 def handle_speak(event):
     global _last_stop_signal
 
@@ -104,7 +111,9 @@ def handle_speak(event):
     create_signal("isSpeaking")
 
     utterance = event.data['utterance']
-    expect_response = event.data.get('expect_response', False)
+
+    if event.data.get('expect_response', False):
+        ws.once('recognizer_loop:audio_output_end', _trigger_expect_response)
 
     # This is a bit of a hack for Picroft.  The analog audio on a Pi blocks
     # for 30 seconds fairly often, so we don't want to break on periods
@@ -132,9 +141,6 @@ def handle_speak(event):
 
     # This check will clear the "signal"
     check_for_signal("isSpeaking")
-
-    if expect_response:
-        create_signal('startListening')
 
 
 def handle_sleep(event):


### PR DESCRIPTION
Fixes bug that was introduced when moving to threaded approach for tts. Previously mycroft started listening as soon as tts had generated all voice data when `expect_response` was used to trigger listening. 

This PR makes listening trigger on `recognizer_loop:audio_output_end`. This should ensure that audio completes before the listening is triggered.
Resolves #919