### PR TITLE
Add libjpeg-turbo package to build_host scripts

### DIFF
--- a/build_host_setup_arch.sh
+++ b/build_host_setup_arch.sh
@@ -23,7 +23,8 @@ sudo pacman -S --needed \
     curl \
     pkg-config \
     icu \
-    automake
+    automake \
+    libjpeg-turbo
 
 # upgrade virtualenv to latest from pypi
 sudo pip2 install --upgrade virtualenv

--- a/build_host_setup_debian.sh
+++ b/build_host_setup_debian.sh
@@ -24,5 +24,6 @@ sudo apt-get install -y \
     curl \
     libicu-dev \
     pkg-config \
-    automake
+    automake \
+    libjpeg-dev
 

--- a/build_host_setup_docker.sh
+++ b/build_host_setup_docker.sh
@@ -25,4 +25,6 @@ apt-get install -y \
     curl \
     libicu-dev \
     pkg-config \
-    automake
+    automake \
+    libjpeg-dev
+    

--- a/build_host_setup_fedora.sh
+++ b/build_host_setup_fedora.sh
@@ -24,7 +24,8 @@ sudo dnf install -y \
     curl \
     pkgconfig \
     libicu-devel \
-    automake
+    automake \
+    libjpeg-turbo-devel
 
 # upgrade virtualenv to latest from pypi
 sudo pip install --upgrade virtualenv


### PR DESCRIPTION
Adds libjpeg/libjpeg-turbo as requirement in the `build_host_setup_*` scripts. This library is a requirement for `pillow` used by the display manager.

I've tested on debian and fedora, I have no arch installation but have tried to find the correct package.

Resloves #926