### PR TITLE
Updating build host script for pillow dependencies

### DIFF
--- a/build_host_setup_debian.sh
+++ b/build_host_setup_debian.sh
@@ -24,5 +24,14 @@ sudo apt-get install -y \
     curl \
     libicu-dev \
     pkg-config \
+    libtiff5-dev \
+    libjpeg8-dev \
+    zlib1g-dev \
+    libfreetype6-dev \ 
+    liblcms2-dev \
+    libwebp-dev \
+    tcl8.6-dev \
+    tk8.6-dev \
+    python-tk \
     automake
 

--- a/build_host_setup_debian.sh
+++ b/build_host_setup_debian.sh
@@ -24,14 +24,6 @@ sudo apt-get install -y \
     curl \
     libicu-dev \
     pkg-config \
-    libtiff5-dev \
     libjpeg8-dev \
-    zlib1g-dev \
-    libfreetype6-dev \ 
-    liblcms2-dev \
-    libwebp-dev \
-    tcl8.6-dev \
-    tk8.6-dev \
-    python-tk \
     automake
 


### PR DESCRIPTION
Adding in the pillow dependencies required to install it.  Without these it won't work on debian.