### PR TITLE
Intent context (including conversations)

### DIFF
--- a/mycroft/skills/context.py
+++ b/mycroft/skills/context.py
@@ -1,0 +1,33 @@
+from functools import wraps
+
+"""
+    Helper decorators for handling context from skills.
+"""
+
+
+def adds_context(context, words=''):
+    """
+        Adds context to context manager.
+    """
+    def context_add_decorator(func):
+        @wraps(func)
+        def func_wrapper(*args, **kwargs):
+            ret = func(*args, **kwargs)
+            args[0].set_context(context)
+            return ret
+        return func_wrapper
+    return context_add_decorator
+
+
+def removes_context(context):
+    """
+        Removes context from the context manager.
+    """
+    def context_removes_decorator(func):
+        @wraps(func)
+        def func_wrapper(*args, **kwargs):
+            ret = func(*args, **kwargs)
+            args[0].remove_context(context)
+            return ret
+        return func_wrapper
+    return context_removes_decorator

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -316,6 +316,13 @@ class MycroftSkill(object):
                 logger.error('Could not enable ' + intent_name +
                              ', it hasn\'t been registered.')
 
+    def set_context(self, context, word=''):
+        self.emitter.emit(Message('add_context', {'context': context, 'word':
+                          word}))
+
+    def remove_context(self, context):
+        self.emitter.emit(Message('remove_context', {'context': context}))
+
     def register_vocabulary(self, entity, entity_type):
         self.emitter.emit(Message('register_vocab', {
             'start': entity, 'end': entity_type

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -317,10 +317,26 @@ class MycroftSkill(object):
                              ', it hasn\'t been registered.')
 
     def set_context(self, context, word=''):
+        """
+            Add context to intent service
+
+            Args:
+                context:    Keyword
+                word:       word connected to keyword
+        """
+        if not isinstance(context, basestring):
+            raise ValueError('context should be a string')
+        if not isinstance(word, basestring):
+            raise ValueError('word should be a string')
         self.emitter.emit(Message('add_context', {'context': context, 'word':
                           word}))
 
     def remove_context(self, context):
+        """
+            remove_context removes a keyword from from the context manager.
+        """
+        if not isinstance(context, basestring):
+            raise ValueError('context should be a string')
         self.emitter.emit(Message('remove_context', {'context': context}))
 
     def register_vocabulary(self, entity, entity_type):

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -106,6 +106,16 @@ class ContextManager(object):
                     missing_entities.remove(entity.get('data'))
         else:
             result = context
+
+        # Only use the latest instance of each keyword
+        stripped = []
+        processed = []
+        for f in result:
+            keyword = f['data'][0][1]
+            if keyword not in processed:
+                stripped.append(f)
+                processed.append(keyword)
+        result = stripped
         return result
 
 
@@ -113,7 +123,7 @@ class IntentService(object):
     def __init__(self, emitter):
         self.config = ConfigurationManager.get().get('context', {})
         self.engine = IntentDeterminationEngine()
-        self.context_keywords = self.config.get('keywords', [])
+        self.context_keywords = self.config.get('keywords', ['Location'])
         self.context_max_frames = self.config.get('max_frames', 3)
         self.context_timeout = self.config.get('timeout', 2)
         self.context_greedy = self.config.get('greedy', False)

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -22,21 +22,106 @@ from mycroft.messagebus.message import Message
 from mycroft.skills.core import open_intent_envelope
 from mycroft.util.log import getLogger
 from mycroft.util.parse import normalize
-
+from adapt.context import ContextManagerFrame
+import time
 __author__ = 'seanfitz'
 
 logger = getLogger(__name__)
 
 
+class ContextManager(object):
+    """
+    ContextManager
+    Use to track context throughout the course of a conversational session.
+    How to manage a session's lifecycle is not captured here.
+    """
+    def __init__(self):
+        self.frame_stack = []
+
+    def clear_context(self):
+        self.frame_stack = []
+
+    def remove_context(self, context_id):
+        self.frame_stack = [f for f in self.frame_stack
+                            if context_id in f.get('data', [])]
+
+    def inject_context(self, entity, metadata={}):
+        """
+        Args:
+            entity(object):
+                format {'data': 'Entity tag as <str>',
+                        'key': 'entity proper name as <str>',
+                         'confidence': <float>'
+                         }
+            metadata(object): dict, arbitrary metadata about the entity being
+            added
+        """
+        top_frame = self.frame_stack[0] if len(self.frame_stack) > 0 else None
+        if top_frame and top_frame[0].metadata_matches(metadata):
+            top_frame[0].merge_context(entity, metadata)
+        else:
+            frame = ContextManagerFrame(entities=[entity],
+                                        metadata=metadata.copy())
+            self.frame_stack.insert(0, (frame, time.time()))
+
+    def get_context(self, max_frames=None, missing_entities=[]):
+        """
+        Constructs a list of entities from the context.
+
+        Args:
+            max_frames(int): maximum number of frames to look back
+            missing_entities(list of str): a list or set of tag names,
+            as strings
+
+        Returns:
+            list: a list of entities
+        """
+        relevant_frames = [frame[0] for frame in self.frame_stack if
+                           time.time() - frame[1] < 120]
+        if not max_frames or max_frames > len(relevant_frames):
+            max_frames = len(relevant_frames)
+
+        missing_entities = list(missing_entities)
+        context = []
+        for i in xrange(max_frames):
+            frame_entities = [entity.copy() for entity in
+                              relevant_frames[i].entities]
+            for entity in frame_entities:
+                entity['confidence'] = entity.get('confidence', 1.0) \
+                    / (2.0 + i)
+            context += frame_entities
+
+        result = []
+        if len(missing_entities) > 0:
+            for entity in context:
+                if entity.get('data') in missing_entities:
+                    result.append(entity)
+                    # NOTE: this implies that we will only ever get one
+                    # of an entity kind from context, unless specified
+                    # multiple times in missing_entities. Cannot get
+                    # an arbitrary number of an entity kind.
+                    missing_entities.remove(entity.get('data'))
+        else:
+            result = context
+        print result
+        print "RETURNING!"
+        return result
+
+
 class IntentService(object):
     def __init__(self, emitter):
         self.engine = IntentDeterminationEngine()
+        self.context_manager = ContextManager()
         self.emitter = emitter
         self.emitter.on('register_vocab', self.handle_register_vocab)
         self.emitter.on('register_intent', self.handle_register_intent)
         self.emitter.on('recognizer_loop:utterance', self.handle_utterance)
         self.emitter.on('detach_intent', self.handle_detach_intent)
         self.emitter.on('detach_skill', self.handle_detach_skill)
+        # Context related handlers
+        self.emitter.on('add_context', self.handle_add_context)
+        self.emitter.on('remove_context', self.handle_remove_context)
+        self.emitter.on('clear_context', self.handle_clear_context)
 
     def handle_utterance(self, message):
         # Get language of the utterance
@@ -49,10 +134,13 @@ class IntentService(object):
         best_intent = None
         for utterance in utterances:
             try:
+                print "HANDLING INTENT"
                 # normalize() changes "it's a boy" to "it is boy", etc.
                 best_intent = next(self.engine.determine_intent(
-                    normalize(utterance, lang), 100))
-
+                                   normalize(utterance, lang), 100,
+                                   include_tags=True,
+                                   context_manager=self.context_manager))
+                print "DONE"
                 # TODO - Should Adapt handle this?
                 best_intent['utterance'] = utterance
             except StopIteration, e:
@@ -60,6 +148,9 @@ class IntentService(object):
                 continue
 
         if best_intent and best_intent.get('confidence', 0.0) > 0.0:
+            for tag in best_intent['__tags__']:
+                context_entity = tag.get('entities')[0]
+                self.context_manager.inject_context(context_entity)
             reply = message.reply(
                 best_intent.get('intent_type'), best_intent)
             self.emitter.emit(reply)
@@ -101,3 +192,20 @@ class IntentService(object):
             p for p in self.engine.intent_parsers if
             not p.name.startswith(skill_name)]
         self.engine.intent_parsers = new_parsers
+
+    def handle_add_context(self, message):
+        entity = {'confidence': 1.0}
+        context = message.data.get('context')
+        word = message.data.get('word')
+        print "Adding " + context
+        entity['data'] = [(word, context)]
+        entity['match'] = word
+        entity['key'] = word
+        self.context_manager.inject_context(entity)
+
+    def handle_remove_context(self, message):
+        context = message.data.get('context')
+        self.context_manager.remove_context(context)
+
+    def handle_clear_context(self, message):
+        self.context_manager.clear_context()

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -216,7 +216,7 @@ class IntentService(object):
     def handle_add_context(self, message):
         entity = {'confidence': 1.0}
         context = message.data.get('context')
-        word = message.data.get('word')
+        word = message.data.get('word') or ''
         entity['data'] = [(word, context)]
         entity['match'] = word
         entity['key'] = word

--- a/test/skills/intent_service.py
+++ b/test/skills/intent_service.py
@@ -1,0 +1,59 @@
+import unittest
+from mycroft.skills.intent_service import IntentService, ContextManager
+
+
+class MockEmitter(object):
+    def __init__(self):
+        self.reset()
+
+    def emit(self, message):
+        self.types.append(message.type)
+        self.results.append(message.data)
+
+    def get_types(self):
+        return self.types
+
+    def get_results(self):
+        return self.results
+
+    def reset(self):
+        self.types = []
+        self.results = []
+
+
+class ContextManagerTest(unittest.TestCase):
+    emitter = MockEmitter()
+
+    def setUp(self):
+        self.context_manager = ContextManager(3)
+
+    def test_add_context(self):
+        entity = {'confidence': 1.0}
+        context = 'TestContext'
+        word = 'TestWord'
+        print "Adding " + context
+        entity['data'] = [(word, context)]
+        entity['match'] = word
+        entity['key'] = word
+
+        self.assertEqual(len(self.context_manager.frame_stack), 0)
+        self.context_manager.inject_context(entity)
+        self.assertEqual(len(self.context_manager.frame_stack), 1)
+
+    def test_remove_context(self):
+        entity = {'confidence': 1.0}
+        context = 'TestContext'
+        word = 'TestWord'
+        print "Adding " + context
+        entity['data'] = [(word, context)]
+        entity['match'] = word
+        entity['key'] = word
+
+        self.context_manager.inject_context(entity)
+        self.assertEqual(len(self.context_manager.frame_stack), 1)
+        self.context_manager.remove_context('TestContext')
+        self.assertEqual(len(self.context_manager.frame_stack), 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR adds a simple context manager to the intent service allowing for some neat features. References #84.

- Context based conversation, intent handlers adds a requirement for a context when registering an intent handler. This context can then be provided by other intent_handlers using the `self.add_context()` method. (See examples below)
- Inject context such as location or time for other skills to use. This provides the possibility to have conversations like this

>  User: Hey Mycroft, what's the time in London
>  Mycroft: 10:42
>  User: Right, what's the weather over there?
>  Mycroft: Rain with a temperature of 14 degrees C

The Context manager will in default remember 3 entries back and with a time limit of 2 minutes. There is an option to configure the context management to be _greedy_, which will make it add every keyword as context. Mycroft will then guess correctly in a lot of cases but false positives will occur and the fallback skill(s) will not be triggered.

> User: Hey Mycroft, tell me a joke
> Mycroft: [Something about chuck norris]
> User: Hey Mycroft, tell me another
> Mycroft: [Chuck Norris does something new!]


# Context based conversation Examples

New Style using decorators

```python
from adapt.intent import IntentBuilder
from mycroft.skills.core import MycroftSkill, intent_handler
from mycroft.util.log import getLogger
from mycroft.skills.context import *

LOGGER = getLogger(__name__)


class ContextTestSkill(MycroftSkill):
    def __init__(self):
        super(ContextTestSkill, self).__init__(name="ContextTest")

    @intent_handler(IntentBuilder('TeaIntent').require("TeaKeyword"))
    @adds_context('TeaContext')
    def handle_tea_intent(self, message):
        self.speak('Very well, would you like some sugar with that',
                   expect_response=True)

    @intent_handler(IntentBuilder('NoIntent').require("NoKeyword").
                                  require('TeaContext').build())
    @removes_context('TeaContext')
    def handle_yes_intent(self, message):
        self.speak('all right, here you go')

    @intent_handler(IntentBuilder('YesIntent').require("YesKeyword").
                                  require('TeaContext').build())
    @removes_context('TeaContext')
    def handle_no_intent(self, message):
        self.speak('I see, straight up it is')
```

Old style
```python
from adapt.intent import IntentBuilder
from mycroft.skills.core import MycroftSkill
from mycroft.util.log import getLogger

LOGGER = getLogger(__name__)


class ContextTestSkill(MycroftSkill):
    def __init__(self):
        super(ContextTestSkill, self).__init__(name="ContextTest")

    def initialize(self):
        self.register_vocabulary(self.name, self.name + 'Keyword')
        tea_intent = IntentBuilder('TeaIntent'). \
            require("TeaKeyword").optionally(self.name + 'Keyword').build()
        no_intent = IntentBuilder('NoIntent'). \
            require("NoKeyword").require('TeaContext'). \
            optionally(self.name + 'Keyword').build()
        yes_intent = IntentBuilder('YesIntent'). \
            require("YesKeyword").require('TeaContext'). \
            optionally(self.name + 'Keyword').build()

        self.register_intent(tea_intent, self.handle_tea_intent)
        self.register_intent(no_intent, self.handle_no_intent)
        self.register_intent(yes_intent, self.handle_yes_intent)

    def handle_tea_intent(self, message):
        self.sugar_offer_given = True
        self.speak('Very well, would you like some sugar with that',
                   expect_response=True)
        # Add context TeaContext so intents requiring it can be triggered
        self.set_context('TeaContext')

    def handle_yes_intent(self, message):
        self.speak('all right, here you go')
        # Remove context preventing the intent handler to trigger
        self.remove_context('TeaContext')

    def handle_no_intent(self, message):
        self.speak('I see, straight up it is')
        # Remove context preventing the intent handler to trigger
        self.remove_context('TeaContext')
```

# Inner workings

The context manager is basically a stack of context keywords which are added to the current sentence when calculating the score of the intent matching. For each possible intent adapt checks for missing keywords and sends them into the context manager. The context manager searches for context frames with those keywords and returns the latest value for these along with a probability score. The score for the context frames decrease the further back in the frame stack a usable context was found.

The list is initially limited to the 3 last context frames and a timeout of 2 minutes to keep the number of matchings low.

# Settings

These are the defaults of the available settings.

```python
    "context": {
        "timeout": 2, # Timeout in minutes
        "max_frames": 3, # Maximum number of context keywords
        "keywords": ["Location"], # Keywords that will automatically added to context
        "greedy": false # Set to true to add all Keywords to context
    }
```