### PR TITLE
Add intent fallback system

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -46,7 +46,7 @@ else
   fi
 fi
 
-default_skills="skill-alarm skill-audio-record skill-configuration skill-date-time skill-desktop-launcher skill-ip skill-joke skill-hello-world skill-media skill-npr-news skill-naptime skill-pairing skill-personal skill-playback-control skill-reminder skill-installer skill-singing skill-speak skill-spelling skill-stop skill-stock skill-volume skill-weather skill-wiki skill-wolfram-alpha skill-mark1-demo"
+default_skills="skill-alarm skill-audio-record skill-configuration skill-date-time skill-desktop-launcher skill-ip skill-joke skill-hello-world skill-media skill-npr-news skill-naptime skill-pairing skill-personal skill-playback-control skill-reminder skill-installer skill-singing skill-speak skill-spelling skill-stop skill-stock skill-volume skill-weather skill-wiki fallback-wolfram-alpha skill-mark1-demo"
 
 echo "#######  Mycroft Skill Manager #######"
 

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -62,7 +62,7 @@ def handle_utterance(event):
     ws.emit(Message('recognizer_loop:utterance', event))
 
 
-def handle_intent_failure(event):
+def handle_complete_intent_failure(event):
     logger.info("Failed to find intent.")
     # TODO: Localize
     data = {'utterance':
@@ -126,14 +126,7 @@ def main():
     loop.on('recognizer_loop:record_end', handle_record_end)
     loop.on('recognizer_loop:no_internet', handle_no_internet)
     ws.on('open', handle_open)
-<<<<<<< HEAD
-    ws.on(
-        'multi_utterance_intent_failure',
-        handle_multi_utterance_intent_failure)
-=======
-    ws.on('speak', handle_speak)
-    ws.on('intent_failure', handle_intent_failure)
->>>>>>> Add intent fallback system
+    ws.on('complete_intent_failure', handle_complete_intent_failure)
     ws.on('recognizer_loop:sleep', handle_sleep)
     ws.on('recognizer_loop:wake_up', handle_wake_up)
     ws.on('mycroft.mic.mute', handle_mic_mute)

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -62,8 +62,8 @@ def handle_utterance(event):
     ws.emit(Message('recognizer_loop:utterance', event))
 
 
-def handle_multi_utterance_intent_failure(event):
-    logger.info("Failed to find intent on multiple intents.")
+def handle_intent_failure(event):
+    logger.info("Failed to find intent.")
     # TODO: Localize
     data = {'utterance':
             "Sorry, I didn't catch that. Please rephrase your request."}
@@ -126,9 +126,14 @@ def main():
     loop.on('recognizer_loop:record_end', handle_record_end)
     loop.on('recognizer_loop:no_internet', handle_no_internet)
     ws.on('open', handle_open)
+<<<<<<< HEAD
     ws.on(
         'multi_utterance_intent_failure',
         handle_multi_utterance_intent_failure)
+=======
+    ws.on('speak', handle_speak)
+    ws.on('intent_failure', handle_intent_failure)
+>>>>>>> Add intent fallback system
     ws.on('recognizer_loop:sleep', handle_sleep)
     ws.on('recognizer_loop:wake_up', handle_wake_up)
     ws.on('mycroft.mic.mute', handle_mic_mute)

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -84,7 +84,7 @@
     // TODO: Old unused kludge, remove from code
     "stop_threshold": 2.0,
     // blacklisted skills to not load
-    "blacklisted_skills": ["skill-media", "send_sms"]
+    "blacklisted_skills": ["skill-media", "send_sms", "skill-wolfram-alpha"]
   },
   
   // Address of the REMOTE server

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -408,12 +408,12 @@ class FallbackSkill(MycroftSkill):
     def __init__(self, name, emitter=None):
         MycroftSkill.__init__(self, name, emitter)
 
-    @staticmethod
-    def make_intent_failure_handler(ws):
+    @classmethod
+    def make_intent_failure_handler(cls, ws):
         """Goes through all fallback handlers until one returns true"""
 
         def handler(message):
-            for _, handler in sorted(FallbackSkill.fallback_handlers.items(),
+            for _, handler in sorted(cls.fallback_handlers.items(),
                                      key=operator.itemgetter(0)):
                 try:
                     if handler(message):
@@ -425,8 +425,8 @@ class FallbackSkill(MycroftSkill):
 
         return handler
 
-    @staticmethod
-    def register_fallback(handler, priority):
+    @classmethod
+    def register_fallback(cls, handler, priority):
         """
         Register a function to be called as a general info fallback
         Fallback should receive message and return
@@ -435,15 +435,15 @@ class FallbackSkill(MycroftSkill):
         Lower priority gets run first
         0 for high priority 100 for low priority
         """
-        while priority in FallbackSkill.fallback_handlers:
+        while priority in cls.fallback_handlers:
             priority += 1
 
-        FallbackSkill.fallback_handlers[priority] = handler
+        cls.fallback_handlers[priority] = handler
 
-    @staticmethod
-    def remove_fallback(handler_to_del):
-        for priority, handler in FallbackSkill.fallback_handlers.items():
+    @classmethod
+    def remove_fallback(cls, handler_to_del):
+        for priority, handler in cls.fallback_handlers.items():
             if handler == handler_to_del:
-                del FallbackSkill.fallback_handlers[priority]
+                del cls.fallback_handlers[priority]
                 return
         logger.warn('Could not remove fallback!')

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -63,14 +63,9 @@ class IntentService(object):
             reply = message.reply(
                 best_intent.get('intent_type'), best_intent)
             self.emitter.emit(reply)
-        elif len(utterances) == 1:
+        else:
             self.emitter.emit(Message("intent_failure", {
                 "utterance": utterances[0],
-                "lang": lang
-            }))
-        else:
-            self.emitter.emit(Message("multi_utterance_intent_failure", {
-                "utterances": utterances,
                 "lang": lang
             }))
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -117,7 +117,7 @@ def _load_skills():
 
     check_connection()
 
-    ws.on('intent_failure', MycroftSkill.on_intent_failure)
+    ws.on('intent_failure', MycroftSkill.make_intent_failure_handler(ws))
 
     # Create skill_manager listener and invoke the first time
     ws.on('skill_manager', skills_manager)

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -30,7 +30,7 @@ from mycroft.lock import Lock  # Creates PID file for single instance
 from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import load_skill, create_skill_descriptor, \
-    MainModule, SKILLS_DIR, MycroftSkill
+    MainModule, SKILLS_DIR, FallbackSkill
 from mycroft.skills.intent_service import IntentService
 from mycroft.util import connected
 from mycroft.util.log import getLogger
@@ -117,7 +117,7 @@ def _load_skills():
 
     check_connection()
 
-    ws.on('intent_failure', MycroftSkill.make_intent_failure_handler(ws))
+    ws.on('intent_failure', FallbackSkill.make_intent_failure_handler(ws))
 
     # Create skill_manager listener and invoke the first time
     ws.on('skill_manager', skills_manager)

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -30,7 +30,7 @@ from mycroft.lock import Lock  # Creates PID file for single instance
 from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import load_skill, create_skill_descriptor, \
-    MainModule, SKILLS_DIR
+    MainModule, SKILLS_DIR, MycroftSkill
 from mycroft.skills.intent_service import IntentService
 from mycroft.util import connected
 from mycroft.util.log import getLogger
@@ -116,6 +116,8 @@ def _load_skills():
         skill_reload_thread
 
     check_connection()
+
+    ws.on('intent_failure', MycroftSkill.on_intent_failure)
 
     # Create skill_manager listener and invoke the first time
     ws.on('skill_manager', skills_manager)


### PR DESCRIPTION
This is the same pull request from 3 weeks ago, but with `skill-wolfram-alpha` blacklisted and a new `fallback-wolfram-alpha` added to the default skills. Note: since Wolfram's API key is currently not working, we this cannot be tested.

**Original description:**
This is a new system that allows other skills to register as fallbacks to handle general knowledge queries. For now, each skill self-assigns a priority where 0 is the highest and 100 is very low priority. When an intent failure occurs, each fallback gets run until one returns True meaning it found a response to speak to the user. Example usage:

skill-my-fallback/\_\_init\_\_.py:

```Python
from mycroft.skills.core import MycroftSkill
class MyFallbackSkilll(MycroftSkill):
    def __init__(self):
        MycroftSkill.__init__(self, name="MyFallbackSkill")

    def initialize(self):
        self.register_fallback(self.handle_fallback, 80)

    def handle_fallback(self, message):
        if 'what is' in message.data['utterance']:
            self.speak_dialog('the answer is always 42')
            return True
        return False
```
This PR also removes the multi utterance intent fail. It only makes sense to emit an intent_failure regardless of the amount of intents, especially since we only ever receive one utterance anymore.

When testing, check functionality of Wolfram Alpha for questions like what is a fox (and maybe wolfram skill reloading when /opt/mycroft/skill-wolfram-alpha/__init__.py is edited).