### PR TITLE
Implement Padatious support (examples based intent parser)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq mpg123 portaudio19-dev libglib2.0-dev swig bison libtool autoconf libglib2.0-dev libicu-dev
+ - sudo apt-get install -qq mpg123 portaudio19-dev libglib2.0-dev swig bison libtool autoconf libglib2.0-dev libicu-dev libfann-dev
 python:
   - "2.7"
 # don't rebuild pocketsphinx for every build

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following packages are required for setting up the development environment a
  - `mpg123`
  - `flac`
  - `curl`
+ - `fann`
 
 ## Home Device and Account Manager
 Mycroft AI, Inc. maintains a device and account management system known as Mycroft Home. Developers may sign up at: https://home.mycroft.ai

--- a/build_host_setup_debian.sh
+++ b/build_host_setup_debian.sh
@@ -25,5 +25,6 @@ sudo apt-get install -y \
     libicu-dev \
     pkg-config \
     automake \
-    libjpeg-dev
+    libjpeg-dev \
+    libfann-dev
 

--- a/build_host_setup_docker.sh
+++ b/build_host_setup_docker.sh
@@ -26,5 +26,6 @@ apt-get install -y \
     libicu-dev \
     pkg-config \
     automake \
-    libjpeg-dev
+    libjpeg-dev \
+    libfann-dev
     

--- a/build_host_setup_fedora.sh
+++ b/build_host_setup_fedora.sh
@@ -25,7 +25,8 @@ sudo dnf install -y \
     pkgconfig \
     libicu-devel \
     automake \
-    libjpeg-turbo-devel
+    libjpeg-turbo-devel \
+    fann-devel
 
 # upgrade virtualenv to latest from pypi
 sudo pip install --upgrade virtualenv

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -96,7 +96,14 @@ fi
 
 # install requirements (except pocketsphinx)
 # removing the pip2 explicit usage here for consistency with the above use.
-pip install -r requirements.txt
+
+if ! pip install -r requirements.txt; then
+    echo "Warning: Failed to install all requirements. Continue? y/N"
+    read -n1 continue
+    if [[ "$continue" != "y" ]] ; then
+        exit 1
+    fi
+fi
 
 SYSMEM=$(free|awk '/^Mem:/{print $2}')
 MAXCORES=$(($SYSMEM / 512000))

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -177,6 +177,11 @@
     }
   },
 
+  "padatious": {
+    "intent_cache": "~/.mycroft/intent_cache",
+    "train_delay": 4
+  },
+
   // =================================================================
   // All of the follow are specific to particular skills and will soon
   // be removed from this file.

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -198,6 +198,7 @@ class MycroftSkill(object):
         self.config_core = ConfigurationManager.get()
         self.config = self.config_core.get(self.name)
         self.dialog_renderer = None
+        self.vocab_dir = None
         self.file_system = FileSystemAccess(join('skills', self.name))
         self.registered_intents = []
         self.log = getLogger(self.name)
@@ -285,29 +286,8 @@ class MycroftSkill(object):
             self.register_intent(intent_parser, handler, need_self=True)
         _intent_list = []
 
-    def register_intent(self, intent_parser, handler, need_self=False):
-        """
-            Register an Intent with the intent service.
-
-            Args:
-                intent_parser: Intent or IntentBuilder object to parse
-                               utterance for the handler.
-                handler:       handler_function
-                need_self:     optional parameter, when called from a decorated
-                               intent handler the function will need the self
-                               variable passed as well.
-        """
-        if type(intent_parser) == IntentBuilder:
-            intent_parser = intent_parser.build()
-        elif type(intent_parser) != Intent:
-            raise ValueError('intent_parser is not an Intent')
-
-        name = intent_parser.name
-        intent_parser.name = str(self.skill_id) + ':' + intent_parser.name
-        self.emitter.emit(Message("register_intent", intent_parser.__dict__))
-        self.registered_intents.append((name, intent_parser))
-
-        def receive_handler(message):
+    def add_event(self, name, handler, need_self=False):
+        def wrapper(message):
             try:
                 if need_self:
                     # When registring from decorator self is required
@@ -322,10 +302,48 @@ class MycroftSkill(object):
                 logger.error(
                     "An error occurred while processing a request in " +
                     self.name, exc_info=True)
-
         if handler:
-            self.emitter.on(intent_parser.name, receive_handler)
-            self.events.append((intent_parser.name, receive_handler))
+            self.emitter.on(name, wrapper)
+            self.events.append((name, wrapper))
+
+    def register_intent(self, intent_parser, handler, need_self=False):
+        """
+            Register an Intent with the intent service.
+
+            Args:
+                intent_parser: Intent or IntentBuilder object to parse
+                               utterance for the handler.
+                handler:       function to register with intent
+                need_self:     optional parameter, when called from a decorated
+                               intent handler the function will need the self
+                               variable passed as well.
+        """
+        if type(intent_parser) == IntentBuilder:
+            intent_parser = intent_parser.build()
+        elif type(intent_parser) != Intent:
+            raise ValueError('intent_parser is not an Intent')
+
+        name = intent_parser.name
+        intent_parser.name = self.name + ':' + intent_parser.name
+        self.emitter.emit(Message("register_intent", intent_parser.__dict__))
+        self.registered_intents.append((name, intent_parser))
+        self.add_event(intent_parser.name, handler)
+
+    def register_intent_file(self, intent_file, handler):
+        """
+            Register an Intent file with the intent service.
+
+            Args:
+                intent_file: name of file that contains example queries
+                             that should activate the intent
+                handler:     function to register with intent
+        """
+        intent_name = self.name + ':' + intent_file
+        self.emitter.emit(Message("padatious:register_intent", {
+            "file_name": join(self.vocab_dir, intent_file),
+            "intent_name": intent_name
+        }))
+        self.add_event(intent_name, handler)
 
     def disable_intent(self, intent_name):
         """Disable a registered intent"""
@@ -404,6 +422,7 @@ class MycroftSkill(object):
             self.load_regex_files(regex_path)
 
     def load_vocab_files(self, vocab_dir):
+        self.vocab_dir = vocab_dir
         if os.path.exists(vocab_dir):
             load_vocabulary(vocab_dir, self.emitter)
         else:

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -32,6 +32,7 @@ from mycroft.messagebus.message import Message
 from mycroft.skills.core import load_skill, create_skill_descriptor, \
     MainModule, SKILLS_DIR, FallbackSkill
 from mycroft.skills.intent_service import IntentService
+from mycroft.skills.padatious_service import PadatiousService
 from mycroft.util import connected
 from mycroft.util.log import getLogger
 from mycroft.api import is_paired
@@ -127,6 +128,8 @@ def _load_skills():
 
     # Create the Intent manager, which converts utterances to intents
     # This is the heart of the voice invoked skill system
+
+    PadatiousService(ws)
     IntentService(ws)
 
     # Create a thread that monitors the loaded skills, looking for updates

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -1,0 +1,92 @@
+# Copyright 2017 Mycroft AI, Inc.
+#
+# This file is part of Mycroft Core.
+#
+# Mycroft Core is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Mycroft Core is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Mycroft Core.  If not, see <http://www.gnu.org/licenses/>.
+from time import time as get_time, sleep
+
+from threading import Event
+from os.path import expanduser, isfile
+
+from mycroft.configuration import ConfigurationManager
+from mycroft.messagebus.message import Message
+from mycroft.skills.core import FallbackSkill
+from mycroft.util.log import getLogger
+from mycroft.util.parse import normalize
+
+from padatious import IntentContainer
+
+__author__ = 'matthewscholefield'
+
+logger = getLogger(__name__)
+
+
+class PadatiousService(object):
+    def __init__(self, emitter):
+        self.config = ConfigurationManager.get()['padatious']
+        intent_cache = expanduser(self.config['intent_cache'])
+        self.container = IntentContainer(intent_cache)
+
+        self.train_delay = self.config['train_delay']
+        self.train_time = -1.0
+
+        self.emitter = emitter
+        self.emitter.on('padatious:register_intent', self.register_intent)
+        FallbackSkill.register_fallback(self.handle_fallback, 5)
+        self.finished_training_event = Event()
+
+    def wait_and_train(self):
+        sleep(self.train_delay)
+        if self.train_time < 0.0:
+            return
+
+        if self.train_time <= get_time() + 0.01:
+            self.train_time = -1.0
+
+            self.finished_training_event.clear()
+            logger.info('Training...')
+            self.container.train(print_updates=False)
+            logger.info('Training complete.')
+            self.finished_training_event.set()
+
+    def register_intent(self, message):
+        logger.debug('Registering Padatious intent: ' +
+                     message.data['intent_name'])
+
+        file_name = message.data['file_name']
+        intent_name = message.data['intent_name']
+        if not isfile(file_name):
+            return
+
+        self.container.load_file(intent_name, file_name)
+        self.train_time = get_time() + self.train_delay
+        self.wait_and_train()
+
+    def handle_fallback(self, message):
+        utt = message.data.get('utterance')
+        logger.debug("Padatious fallback attempt: " + utt)
+
+        utt = normalize(utt, message.data.get('lang', 'en-us'))
+
+        if not self.finished_training_event.is_set():
+            logger.debug('Waiting for training to finish...')
+            self.finished_training_event.wait()
+
+        data = self.container.calc_intent(utt)
+
+        if data.conf < 0.5:
+            return False
+
+        self.emitter.emit(Message(data.name, data=data.matches))
+        return True

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Mycroft Core.  If not, see <http://www.gnu.org/licenses/>.
+from subprocess import call
 from time import time as get_time, sleep
 
 from threading import Event
@@ -25,8 +26,6 @@ from mycroft.skills.core import FallbackSkill
 from mycroft.util.log import getLogger
 from mycroft.util.parse import normalize
 
-from padatious import IntentContainer
-
 __author__ = 'matthewscholefield'
 
 logger = getLogger(__name__)
@@ -36,10 +35,24 @@ class PadatiousService(object):
     def __init__(self, emitter):
         self.config = ConfigurationManager.get()['padatious']
         intent_cache = expanduser(self.config['intent_cache'])
+
+        try:
+            from padatious import IntentContainer
+        except ImportError:
+            logger.error('Padatious not installed. Please re-run dev_setup.sh')
+            try:
+                call(['notify-send', 'Padatious not installed',
+                      'Please run build_host_setup and dev_setup again'])
+            except OSError:
+                pass
+            return
+
         self.container = IntentContainer(intent_cache)
 
         self.train_delay = self.config['train_delay']
         self.train_time = -1.0
+
+
 
         self.emitter = emitter
         self.emitter.on('padatious:register_intent', self.register_intent)

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -49,15 +49,14 @@ class PadatiousService(object):
 
         self.container = IntentContainer(intent_cache)
 
-        self.train_delay = self.config['train_delay']
-        self.train_time = -1.0
-
-
-
         self.emitter = emitter
         self.emitter.on('padatious:register_intent', self.register_intent)
         FallbackSkill.register_fallback(self.handle_fallback, 5)
         self.finished_training_event = Event()
+
+        self.train_delay = self.config['train_delay']
+        self.train_time = get_time() + self.train_delay
+        self.wait_and_train()
 
     def wait_and_train(self):
         sleep(self.train_delay)

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -31,8 +31,9 @@ __author__ = 'matthewscholefield'
 logger = getLogger(__name__)
 
 
-class PadatiousService(object):
+class PadatiousService(FallbackSkill):
     def __init__(self, emitter):
+        FallbackSkill.__init__(self)
         self.config = ConfigurationManager.get()['padatious']
         intent_cache = expanduser(self.config['intent_cache'])
 
@@ -51,7 +52,7 @@ class PadatiousService(object):
 
         self.emitter = emitter
         self.emitter.on('padatious:register_intent', self.register_intent)
-        FallbackSkill.register_fallback(self.handle_fallback, 5)
+        self.register_fallback(self.handle_fallback, 5)
         self.finished_training_event = Event()
 
         self.train_delay = self.config['train_delay']

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,4 @@ python-dateutil==2.6.0
 pychromecast==0.7.7
 python-vlc==1.1.2
 pulsectl==17.7.4
+padatious

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,4 +37,4 @@ python-dateutil==2.6.0
 pychromecast==0.7.7
 python-vlc==1.1.2
 pulsectl==17.7.4
-padatious
+padatious==0.1.4

--- a/skills-sdk-setup.py
+++ b/skills-sdk-setup.py
@@ -14,6 +14,7 @@ setup(
         "configobj==5.0.6",
         "pyee==1.0.1",
         "adapt-parser==0.2.1",
+        "padatious==0.1.4"
         "websocket-client==0.32.0"
     ],
     packages=[


### PR DESCRIPTION
This brings in Padatious support for Mycroft. Usage in a skill is as follows:

\_\_init\_\_.py:
```Python
from mycroft.skills.core import MycroftSkill
class TomatoSkill(MycroftSkill):
    def __init__(self):
        MycroftSkill.__init__(self)

    def initialize(self):
        self.register_intent_file('what.is.intent', self.handle_what_is)
        self.register_intent_file('do.you.like.intent', self.handle_do_you_like)

    def handle_what_is(self, message):
        self.speak('A tomato is a big red thing')

    def handle_do_you_like(self, message):
        tomato_type = message.get('type')
        if tomato_type is not None:
            self.speak("Well, I'm not sure if I like " + tomato_type + " tomatoes.")
        else:
            self.speak('Of course I like tomatoes!')
```

vocab/en-us/what.is.intent:
```
What would you say a tomato is?
What's a tomato?
Describe a tomato.
What defines a tomato?
```

vocab/en-us/do.you.like.intent:
```
Are you fond of tomatoes?
Do you like tomatoes?
What are your thoughts on tomatoes?

Are you fond of {type} tomatoes?
Do you like {type} tomatoes?
What are your thoughts on {type} tomatoes?
```

For debugging, you can use `./mycroft.sh start && tail -f scripts/logs/mycroft-* | grep -i padatious`