### PR TITLE
Remove volume parameter from default wav play cmd

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -41,7 +41,7 @@
   
   // Mechanism used to play WAV audio files
   // Override: SYSTEM
-  "play_wav_cmdline": "paplay %1 --client-name=mycroft-voice --volume=32000",
+  "play_wav_cmdline": "paplay %1 --client-name=mycroft-voice",
   
   // Mechanism used to play MP3 audio files
   // Override: SYSTEM


### PR DESCRIPTION
Remove volume parameter for _paplay_ committed by mistake. Resolves #943 