### PR TITLE
Make visime stream end together with audio

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -106,6 +106,7 @@ def handle_stop(event):
     global _last_stop_signal
     _last_stop_signal = time.time()
     tts.playback.clear_queue()
+    tts.playback.clear_visimes()
     stop_speaking()
 
 

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -47,6 +47,7 @@ class PlaybackThread(Thread):
         self.queue = queue
         self._terminated = False
         self._processing_queue = False
+        self._clear_visimes = False
 
     def init(self, tts):
         self.tts = tts
@@ -111,9 +112,8 @@ class PlaybackThread(Thread):
         """
         start = time()
         for code, duration in pairs:
-            if check_for_signal('stoppingTTS', -1):
-                return True
-            if check_for_signal('buttonPress'):
+            if self._clear_visimes:
+                self._clear_visimes = False
                 return True
             if self.enclosure:
                 self.enclosure.mouth_viseme(code)
@@ -121,6 +121,9 @@ class PlaybackThread(Thread):
             if delta < duration:
                 sleep(duration - delta)
         return False
+
+    def clear_visimes(self):
+        self._clear_visimes = True
 
     def blink(self, rate=1.0):
         """ Blink mycroft's eyes """


### PR DESCRIPTION
===Fixed issues ====
#958

====  Tech Notes ====
Adds method clear_visimes() to voice playback thread to stop visime stream
instead of having the visime stream check for signals.

====  Documentation Notes ====
NONE - things like description of a new feature or notes on behavior
changes

==== Localization Notes ====
NONE - point out new strings, functions needing international versions,
     etc.

==== Environment Notes ====
NONE - new package requirements, new files being written to disk,
etc.

==== Protocol Notes ====
NONE - message types added or changed, new signals, etc.