### PR TITLE
Catch exceptions in user provided stop() method

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -360,8 +360,16 @@ class MycroftSkill(object):
         load_regex(regex_dir, self.emitter)
 
     def __handle_stop(self, event):
+        """
+            Handler for the "mycroft.stop" signal. Runs the user defined
+            `stop()` method.
+        """
         self.stop_time = time.time()
-        self.stop()
+        try:
+            self.stop()
+        except:
+            logger.error("Failed to stop skill: {}".format(self.name),
+                         exc_info=True)
 
     @abc.abstractmethod
     def stop(self):
@@ -386,4 +394,8 @@ class MycroftSkill(object):
 
         self.emitter.emit(
             Message("detach_skill", {"skill_name": self.name + ":"}))
-        self.stop()
+        try:
+            self.stop()
+        except:
+            logger.error("Failed to stop skill: {}".format(self.name),
+                         exc_info=True)


### PR DESCRIPTION
==== Fixed Issues ====
#960

====  Tech Notes ====
The messagebus handler for "mycroft.stop" halts and exits if an
exception occurs in any methods that are registered to that name. The
handler executes the stop() method that's provided by the user and is
not verified. To ensure that other skills are unaffected exceptions in
the user provided method are caught.

====  Documentation Notes ====
NONE - things like description of a new feature or notes on behavior
changes

==== Localization Notes ====
NONE - point out new strings, functions needing international versions,
etc.

==== Environment Notes ====
NONE - new package requirements, new files being written to disk,
etc.

==== Protocol Notes ====
NONE - message types added or changed, new signals, etc.