### PR TITLE
Fix a missing logger which caused a crash

### DIFF
--- a/mycroft/util/signal.py
+++ b/mycroft/util/signal.py
@@ -3,6 +3,9 @@ import os.path
 import tempfile
 import mycroft
 import time
+from logging import getLogger
+
+LOG = getLogger(__name__)
 
 
 def get_ipc_directory(domain=None):
@@ -45,7 +48,7 @@ def ensure_directory_exists(dir, domain=None):
             save = os.umask(0)
             os.makedirs(dir, 0777)  # give everyone rights to r/w here
         except OSError:
-            LOGGER.warn("Failed to create: " + dir)
+            LOG.warn("Failed to create: " + dir)
             pass
         finally:
             os.umask(save)

--- a/mycroft/util/signal.py
+++ b/mycroft/util/signal.py
@@ -3,7 +3,7 @@ import os.path
 import tempfile
 import mycroft
 import time
-from logging import getLogger
+from mycroft.util.logging import getLogger
 
 LOG = getLogger(__name__)
 


### PR DESCRIPTION
Some exception code was attempting to use the LOGGER, but one had
not been created for this file.  So when the exception occurred
it caused a crash.

NOTE: We need to standardize on log/LOG/LOGGER!