### PR TITLE
Fix the logger fix

### DIFF
--- a/mycroft/util/signal.py
+++ b/mycroft/util/signal.py
@@ -3,7 +3,7 @@ import os.path
 import tempfile
 import mycroft
 import time
-from mycroft.util.logging import getLogger
+from mycroft.util.log import getLogger
 
 LOG = getLogger(__name__)
 


### PR DESCRIPTION
Gotta slow down my fingers.  Mixed "logging" and "mycroft.util.log" into
the non-existent "mycroft.util.logging".  Fixed.