### PR TITLE
Fix message bus logging for audio service

### DIFF
--- a/mycroft/audio/main.py
+++ b/mycroft/audio/main.py
@@ -413,8 +413,7 @@ def main():
     def echo(message):
         try:
             _message = json.loads(message)
-
-            if 'mycroft.audio.service' in _message.get('type'):
+            if 'mycroft.audio.service' not in _message.get('type'):
                 return
             message = json.dumps(_message)
         except:


### PR DESCRIPTION
Resolves #969

==== Fixed Issues ====
#969

====  Tech Notes ====
The criteria for excluding messages were inverted and excluded all
messages containing 'mycroft.audio.service'. This criteria has been
fixed.

====  Documentation Notes ====
NONE

==== Localization Notes ====
NONE

==== Environment Notes ====
NONE

==== Protocol Notes ====
NONE