### PR TITLE
Add manual page for msm

### DIFF
--- a/msm/man/man1/msm.1
+++ b/msm/man/man1/msm.1
@@ -1,0 +1,33 @@
+.TH msm 1 "2017-08-09" "" "Mycroft Skill Manager"
+.SH NAME
+msm \- The Mycroft Skill Manager
+.SH SYNOPSIS
+.B msm
+\fBoperation [\fIargument]
+
+.B msm
+\fBinstall \fBrss-skill
+
+.SH DESCRIPTION
+Msm is a command line tool for installing and updating Mycroft skills. The command performs a number of operations inclding installing all default skills
+
+.SH OPTIONS
+.TP
+\fBinstall \fISkill-name\fR
+Install the skill named \fISkill-name\fR.
+.TP
+\fBinstall \fIgit-repository\fR
+Install skill from the git repository \fIgit-repository\fR
+.TP
+\fBupdate\fR
+Update all installed skills
+.TP
+\fBdefault
+Install and update all default skills
+.TP
+\fBlist
+Lists available skills
+.TP
+\fBsearch
+Search for a skill without installing it
+.TP


### PR DESCRIPTION
Adds a manual page for msm, required for packaging for some OS'es. Resolves #966 

==== Fixed Issues ====
#966

====  Tech Notes ====
Adds a basic manual page for msm, required for packaging for some OS'es

====  Documentation Notes ====
NONE

==== Localization Notes ====
Might need translation at some point

==== Environment Notes ====
msm/man1/msm should be copied into the manual man1 directory
(/usr/local/share/man/man1) and mandb needs to be run after a package
install.

==== Protocol Notes ====
NONE