### PR TITLE
Fix double __init__ in MycroftSkill

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -189,9 +189,6 @@ class MycroftSkill(object):
 
     def __init__(self, name=None, emitter=None):
         self.name = name or self.__class__.__name__
-
-    def __init__(self, name, emitter=None):
-        self.name = name
         self.bind(emitter)
         self.config_core = ConfigurationManager.get()
         self.config = self.config_core.get(self.name)


### PR DESCRIPTION
==== Fixed Issues ====
NONE

====  Tech Notes ====
During earlier rebase it seems like a double instance of `__init__` got
into MycroftSkill.

====  Documentation Notes ====
NONE

==== Localization Notes ====
NONE

==== Environment Notes ====
NONE

==== Protocol Notes ====
NONE