### PR TITLE
Mimic cpu calc rebase by el-tocino

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -82,15 +82,6 @@ pip install --upgrade virtualenv
 # removing the pip2 explicit usage here for consistency with the above use.
 pip install -r requirements.txt 
 
-SYSMEM=$(free|awk '/^Mem:/{print $2}')
-MAXCORES=$(($SYSMEM / 512000))
-CORES=$(nproc)
-
-if [[ ${MAXCORES} -lt ${CORES} ]]; then
-  CORES=${MAXCORES}  
-fi
-echo "Building with $CORES cores."
-
 #build and install pocketsphinx
 #cd ${TOP}
 #${TOP}/scripts/install-pocketsphinx.sh -q

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -82,6 +82,15 @@ pip install --upgrade virtualenv
 # removing the pip2 explicit usage here for consistency with the above use.
 pip install -r requirements.txt 
 
+SYSMEM=$(free|awk '/^Mem:/{print $2}')
+MAXCORES=$(($SYSMEM / 512000))
+CORES=$(nproc)
+
+if [[ ${MAXCORES} -lt ${CORES} ]]; then
+  CORES=${MAXCORES}  
+fi
+echo "Building with $CORES cores."
+
 #build and install pocketsphinx
 #cd ${TOP}
 #${TOP}/scripts/install-pocketsphinx.sh -q
@@ -90,10 +99,10 @@ cd "${TOP}"
 
 if [[ "$build_mimic" == 'y' ]] || [[ "$build_mimic" == 'Y' ]]; then
   echo "WARNING: The following can take a long time to run!"
-  "${TOP}/scripts/install-mimic.sh"
+  "${TOP}/scripts/install-mimic.sh" " ${CORES}"
 else
   echo "Skipping mimic build."
 fi
 
 # install pygtk for desktop_launcher skill
-"${TOP}/scripts/install-pygtk.sh"
+"${TOP}/scripts/install-pygtk.sh" " ${CORES}"

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -82,10 +82,12 @@ pip install --upgrade virtualenv
 # removing the pip2 explicit usage here for consistency with the above use.
 pip install -r requirements.txt 
 
-if  [[ $(free|awk '/^Mem:/{print $2}') -lt  1572864 ]] ; then
-  CORES=1
-else 
-  CORES=$(nproc)
+SYSMEM=$(free|awk '/^Mem:/{print $2}')
+MAXCORES=$(($SYSMEM / 512000))
+CORES=$(nproc)
+
+if [[ ${MAXCORES} -lt ${CORES} ]]; then
+  CORES=${MAXCORES}  
 fi
 echo "Building with $CORES cores."
 

--- a/scripts/install-mimic.sh
+++ b/scripts/install-mimic.sh
@@ -3,15 +3,8 @@
 set -Ee
 
 MIMIC_DIR=mimic
+CORES=$1
 MIMIC_VERSION=1.2.0.2
-SYSMEM=$(free|awk '/^Mem:/{print $2}')
-MAXCORES=$(($SYSMEM / 512000))
-CORES=$(nproc)
-
-if [[ ${MAXCORES} -lt ${CORES} ]]; then
-  CORES=${MAXCORES}  
-fi
-echo "Building with $CORES cores."
 
 # for ubuntu precise in travis, that does not provide pkg-config:
 pkg-config --exists icu-i18n || export CFLAGS="$CFLAGS -I/usr/include/x86_64-linux-gnu"
@@ -23,7 +16,7 @@ if [ ! -d ${MIMIC_DIR} ]; then
     cd ${MIMIC_DIR}
     ./autogen.sh
     ./configure --with-audio=alsa --enable-shared --prefix=$(pwd)
-    make -j$CORES
+    make -j${CORES}
     make install
 else
     # ensure mimic is up to date
@@ -35,6 +28,6 @@ else
     ./autogen.sh
     ./configure --with-audio=alsa --enable-shared --prefix=$(pwd)
     make clean
-    make -j$CORES
+    make -j${CORES}
     make install
 fi

--- a/scripts/install-mimic.sh
+++ b/scripts/install-mimic.sh
@@ -3,8 +3,15 @@
 set -Ee
 
 MIMIC_DIR=mimic
-CORES=$(nproc)
 MIMIC_VERSION=1.2.0.2
+SYSMEM=$(free|awk '/^Mem:/{print $2}')
+MAXCORES=$(($SYSMEM / 512000))
+CORES=$(nproc)
+
+if [[ ${MAXCORES} -lt ${CORES} ]]; then
+  CORES=${MAXCORES}  
+fi
+echo "Building with $CORES cores."
 
 # for ubuntu precise in travis, that does not provide pkg-config:
 pkg-config --exists icu-i18n || export CFLAGS="$CFLAGS -I/usr/include/x86_64-linux-gnu"

--- a/scripts/install-pygtk.sh
+++ b/scripts/install-pygtk.sh
@@ -8,7 +8,7 @@ fi
 
 # Setup variables.
 CACHE="/tmp/install-pygtk-$$"
-CORES=$(nproc)
+CORES=$1
 
 # Make temp directory.
 mkdir -p $CACHE
@@ -29,7 +29,7 @@ then
         (   cd py2cairo*
             autoreconf -ivf
             ./configure --prefix=$VIRTUAL_ENV --disable-dependency-tracking
-            make -j$CORES
+            make -j${CORES}
             make install
         )
     )
@@ -50,7 +50,7 @@ then
         tar -xvf pygobject.tar.bz2
         (   cd pygobject*
             ./configure --prefix=$VIRTUAL_ENV --disable-introspection
-            make -j$CORES
+            make -j${CORES}
             make install
         )
     )
@@ -71,7 +71,7 @@ then
         tar -xvf pygtk.tar.bz2
         (   cd pygtk-*
             ./configure --prefix=$VIRTUAL_ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig:$VIRTUAL_ENV/lib/pkgconfig
-            make -j$CORES
+            make -j${CORES}
             make install
         )
     )


### PR DESCRIPTION
==== Fixed Issues ====
Partially resolves #982

====  Tech Notes ==== 
Handles an error which may occur when checking for mimic
Automatically determines how many cores can be use to compile mimic depending on system memory. The system approximates that the maximum memory required will be ~500MB