### PR TITLE
fallback order override

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1301,6 +1301,9 @@ class FallbackSkill(MycroftSkill):
         by their priority.
     """
     fallback_handlers = {}
+    skills_config = Configuration.get().get("skills", {})
+    override_order = skills_config.get("override", False)
+    fallback_order = skills_config.get("fallback_order", [])
 
     def __init__(self, name=None, bus=None):
         MycroftSkill.__init__(self, name, bus)
@@ -1378,7 +1381,15 @@ class FallbackSkill(MycroftSkill):
             return False
 
         self.instance_fallback_handlers.append(wrapper)
-        self._register_fallback(handler, priority)
+
+        if self.override_order:
+            folder = self.root_dir.split("/")[-1]
+            if folder in self.fallback_order:
+                priority = self.fallback_order.index(folder) + 1
+            else:
+                priority = 100
+
+        self._register_fallback(wrapper, priority)
 
     @classmethod
     def remove_fallback(cls, handler_to_del):

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1302,7 +1302,7 @@ class FallbackSkill(MycroftSkill):
     """
     fallback_handlers = {}
     skills_config = Configuration.get().get("skills", {})
-    override_order = skills_config.get("override", False)
+    override = skills_config.get("override", False)
     fallback_order = skills_config.get("fallback_order", [])
 
     def __init__(self, name=None, bus=None):
@@ -1382,7 +1382,7 @@ class FallbackSkill(MycroftSkill):
 
         self.instance_fallback_handlers.append(wrapper)
 
-        if self.override_order:
+        if self.override:
             folder = self.root_dir.split("/")[-1]
             if folder in self.fallback_order:
                 priority = self.fallback_order.index(folder) + 1


### PR DESCRIPTION
sometimes we may not agree with dev choices on fallback priority, an option to override the fallback order in config would be good, so we can get updates without git pull complaining of stashing changes, also good for dev purposes

This pr is more for discussion than a serious proposal

- add fallback override flag in config, default false
- add fallback order list with skill folder names, default empty
- on register fallback track folder to handler
- on handler if override flag try ordered list
- if entry missing in ordered list try it next by skill load order
- if no override flag behave normally
- on shutdown also remove handler from tracked folder handlers