### PR TITLE
#984 -- no need to clone all mimic branches for the dev_setup

### DIFF
--- a/scripts/install-mimic.sh
+++ b/scripts/install-mimic.sh
@@ -12,7 +12,7 @@ pkg-config --exists icu-i18n || export LDFLAGS="$LDFLAGS -licui18n -licuuc -licu
 
 # download and install mimic
 if [ ! -d ${MIMIC_DIR} ]; then
-    git clone --branch ${MIMIC_VERSION} https://github.com/MycroftAI/mimic.git
+    git clone --branch ${MIMIC_VERSION} https://github.com/MycroftAI/mimic.git --depth=1
     cd ${MIMIC_DIR}
     ./autogen.sh
     ./configure --with-audio=alsa --enable-shared --prefix=$(pwd)


### PR DESCRIPTION
Referenced issue:#984
--
==== Fixed Issues ====
984 - install_mimic.sh -- Mimic shouldn't have to clone all branches
====  Tech Notes ====
This modification clones the mimic repository with a depth of one in
order to reduce download times and local size. A side affect might be
that this would make it harder for developers to checkout different
mimic branches, as they would have to tech them first.