### PR TITLE
Fix skill container

### DIFF
--- a/mycroft/skills/container.py
+++ b/mycroft/skills/container.py
@@ -81,7 +81,8 @@ class SkillContainer(object):
             IntentService(self.ws)
 
         skill_descriptor = create_skill_descriptor(self.dir)
-        self.skill = load_skill(skill_descriptor, self.ws)
+        # skill_id set to -1 to not interfere with the normal skills
+        self.skill = load_skill(skill_descriptor, self.ws, -1)
 
     def run(self):
         try:

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -96,6 +96,15 @@ def open_intent_envelope(message):
 
 
 def load_skill(skill_descriptor, emitter, skill_id):
+    """
+        load skill from skill descriptor.
+
+        Args:
+            skill_descriptor: descriptor of skill to load
+            emitter:          messagebus emitter
+            skill_id:         id number for skill
+    """
+
     try:
         logger.info("ATTEMPTING TO LOAD SKILL: " + skill_descriptor["name"] +
                     " with ID " + str(skill_id))


### PR DESCRIPTION
==== Fixed Issues ====
#1007

====  Tech Notes ====
The converse system changed the api for the load_skill() function this
since the skill_container wasn't updated accordingly it stopped working.
This PR makes updates the container to use the new interface.