### PR TITLE
Fix expect response for speak_dialog

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -459,8 +459,7 @@ class MycroftSkill(object):
                                     for response.
         """
 
-        data['expect_response'] = expect_response
-        self.speak(self.dialog_renderer.render(key, data))
+        self.speak(self.dialog_renderer.render(key, data), expect_response)
 
     def init_dialog(self, root_directory):
         dialog_dir = join(root_directory, 'dialog', self.lang)


### PR DESCRIPTION
==== Fixed Issues ====
#1019 

====  Tech Notes ====
the expect_response pararmeter is now correctly passed along to
self.speak()

====  Documentation Notes ====
NONE - description of a new feature or notes on behavior changes

==== Localization Notes ====
NONE - point to new strings, language specific functions, etc.

==== Environment Notes ====
NONE - new package requirements, new files being written to disk, etc.

==== Protocol Notes ====
NONE - message types added or changed, new signals, APIs, etc.