### PR TITLE
Make mycroft-core.sh invocable from outside

### DIFF
--- a/scripts/prepare-msm.sh
+++ b/scripts/prepare-msm.sh
@@ -18,7 +18,16 @@ mycroft_root_dir='/opt/mycroft'
 skills_dir="${mycroft_root_dir}"/skills
 # exit on any error
 set -Ee
-chmod +x msm/msm
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -h "$SOURCE" ]; do
+  DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+  SOURCE="$(readlink "$SOURCE")"
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+ 
+chmod +x ${DIR}/../msm/msm
 
 # Determine which user is running this script
 setup_user=$USER

--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SOURCE="${BASH_SOURCE[0]}"
+
 script=${0}
 script=${script##*/}
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"

--- a/stop-mycroft.sh
+++ b/stop-mycroft.sh
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SOURCE="${BASH_SOURCE[0]}"
+
 script=${0}
 script=${script##*/}
 DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"


### PR DESCRIPTION
mycroft-core.sh has a relative-path call (that itself also likes to be
called from inside mycroft-core) that prevents making a clean start of
mycroft from outside the mycroft-core directory.  This makes doing
things like adding it as a Ubuntu Unity startup application slightly
messy.