### PR TITLE
Add useful imports to mycroft and mycroft.util modules

### DIFF
--- a/mycroft/__init__.py
+++ b/mycroft/__init__.py
@@ -1,3 +1,9 @@
+from mycroft.api import Api
+from mycroft.skills.core import MycroftSkill, FallbackSkill, \
+    intent_handler, intent_file_handler
+from mycroft.skills.context import adds_context, removes_context
+from mycroft.messagebus.message import Message
+
 from os.path import abspath, dirname, join
 
 __author__ = 'seanfitz'

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -15,6 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with Mycroft Core.  If not, see <http://www.gnu.org/licenses/>.
 
+# Officially exported methods from this file:
+# play_wav, play_mp3, get_cache_directory,
+# resolve_resource_file, wait_while_speaking
+from mycroft.util.log import getLogger
+from mycroft.util.parse import extract_datetime, extractnumber, normalize
+from mycroft.util.format import nice_number, convert_number
 
 import socket
 import subprocess
@@ -26,7 +32,6 @@ import os.path
 import time
 from stat import S_ISREG, ST_MTIME, ST_MODE, ST_SIZE
 import psutil
-from mycroft.util.log import getLogger
 from mycroft.util.signal import *
 import mycroft.configuration
 import mycroft.audio


### PR DESCRIPTION
This brings in a few classes to the `mycroft` and `mycroft.util` modules to show what is officially available  for skill developers to use. We should also consider moving everything in `mycroft.util.__init__` into a separate file so that skill developers can't do things like `from mycroft.util import os`. This fixes #994 