### PR TITLE
Add event scheduler

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -452,7 +452,7 @@ class MycroftSkill(object):
                 'expect_response': expect_response}
         self.emitter.emit(Message("speak", data))
 
-    def speak_dialog(self, key, data={}, expect_response=False):
+    def speak_dialog(self, key, data=None, expect_response=False):
         """
             Speak sentance based of dialog file.
 
@@ -463,7 +463,7 @@ class MycroftSkill(object):
                                     response from the user and start listening
                                     for response.
         """
-
+        data = data or {}
         self.speak(self.dialog_renderer.render(key, data), expect_response)
 
     def init_dialog(self, root_directory):
@@ -532,12 +532,13 @@ class MycroftSkill(object):
             logger.error("Failed to stop skill: {}".format(self.name),
                          exc_info=True)
 
-    def _schedule_event(self, handler, when, data={}, name=None,
+    def _schedule_event(self, handler, when, data=None, name=None,
                         repeat=None):
         """
             Underlying method for schedle_event and schedule_repeating_event.
             Takes scheduling information and sends it of on the message bus.
         """
+        data = data or {}
         if not name:
             name = self.name + handler.__name__
         name = str(self.skill_id) + ':' + name
@@ -550,7 +551,7 @@ class MycroftSkill(object):
         self.emitter.emit(Message('mycroft.scheduler.schedule_event',
                                   data=event_data))
 
-    def schedule_event(self, handler, when, data={}, name=None):
+    def schedule_event(self, handler, when, data=None, name=None):
         """
             Schedule a single event.
 
@@ -560,10 +561,11 @@ class MycroftSkill(object):
                 data (dict, optional): data to send when the handler is called
                 name (str, optional):  friendly name parameter
         """
+        data = data or {}
         self._schedule_event(handler, when, data, name)
 
     def schedule_repeating_event(self, handler, when, frequency,
-                                 data={}, name=None):
+                                 data=None, name=None):
         """
             Schedule a repeating event.
 
@@ -574,15 +576,17 @@ class MycroftSkill(object):
                 data (dict, optional):  data to send along to the handler
                 name (str, optional):   friendly name parameter
         """
+        data = data or {}
         self._schedule_event(handler, when, data, name, frequency)
 
-    def update_event(self, name):
+    def update_event(self, name, data=None):
         """
             Change data of event.
 
             Args:
                 name (str):   Name of event
         """
+        data = data or {}
         data = {
             'event': name,
             'data': data

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -532,6 +532,73 @@ class MycroftSkill(object):
             logger.error("Failed to stop skill: {}".format(self.name),
                          exc_info=True)
 
+    def _schedule_event(self, handler, datetime, data={}, name=None,
+                        repeat=None):
+        """
+            Underlying method for schedle_event and schedule_repeating_event.
+            Takes scheduling information and sends it of on the message bus
+        """
+        if not name:
+            name = self.name + handler.__name__
+        name = str(self.skill_id) + ':' + name
+        self.add_event(name, handler, False)
+        event_data = {}
+        event_data['time'] = time.mktime(datetime.timetuple())
+        event_data['event'] = name
+        event_data['repeat'] = repeat
+        event_data['data'] = data
+        self.emitter.emit(Message('mycroft.scheduler.schedule_event',
+                                  data=event_data))
+
+    def schedule_event(self, handler, datetime, data={}, name=None):
+        """
+            schedule a single event
+
+            Args:
+                handler:    method to be called
+                datetime:   time for calling the handler
+                data:       optional data to send along to the handler
+                name:       Optional name parameter
+        """
+        self._schedule_event(handler, datetime, data, name)
+
+    def schedule_repeating_event(self, handler, datetime, frequency,
+                                 data={}, name=None):
+        """
+            schedule a repeating event
+
+            Args:
+                handler:    method to be called
+                datetime:   time for calling the handler
+                frequency:  time in sconds between calls
+                data:       optional data to send along to the handler
+                name:       Optional name parameter
+        """
+        self._schedule_event(handler, datetime, data, name, frequency)
+
+    def update_event(self, name):
+        """
+            Change data of event
+
+            Args:
+                name:   Name of event
+        """
+        data = {
+            'event': name,
+            'data': data
+        }
+        self.emitter.emit(Message('mycroft.schedule.update_event',
+                                  data=data))
+
+    def cancel_event(self, name):
+        """
+            Cancel a pending event. The event will no longer be scheduled
+            to be executed
+        """
+        data = {'event': name}
+        self.emitter.emit(Message('mycroft.scheduler.remove_event',
+                                  data=data))
+
 
 class FallbackSkill(MycroftSkill):
     """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -532,56 +532,56 @@ class MycroftSkill(object):
             logger.error("Failed to stop skill: {}".format(self.name),
                          exc_info=True)
 
-    def _schedule_event(self, handler, datetime, data={}, name=None,
+    def _schedule_event(self, handler, when, data={}, name=None,
                         repeat=None):
         """
             Underlying method for schedle_event and schedule_repeating_event.
-            Takes scheduling information and sends it of on the message bus
+            Takes scheduling information and sends it of on the message bus.
         """
         if not name:
             name = self.name + handler.__name__
         name = str(self.skill_id) + ':' + name
         self.add_event(name, handler, False)
         event_data = {}
-        event_data['time'] = time.mktime(datetime.timetuple())
+        event_data['time'] = time.mktime(when.timetuple())
         event_data['event'] = name
         event_data['repeat'] = repeat
         event_data['data'] = data
         self.emitter.emit(Message('mycroft.scheduler.schedule_event',
                                   data=event_data))
 
-    def schedule_event(self, handler, datetime, data={}, name=None):
+    def schedule_event(self, handler, when, data={}, name=None):
         """
-            schedule a single event
+            Schedule a single event.
 
             Args:
-                handler:    method to be called
-                datetime:   time for calling the handler
-                data:       optional data to send along to the handler
-                name:       Optional name parameter
+                handler:               method to be called
+                when (datetime):       when the handler should be called
+                data (dict, optional): data to send when the handler is called
+                name (str, optional):  friendly name parameter
         """
-        self._schedule_event(handler, datetime, data, name)
+        self._schedule_event(handler, when, data, name)
 
-    def schedule_repeating_event(self, handler, datetime, frequency,
+    def schedule_repeating_event(self, handler, when, frequency,
                                  data={}, name=None):
         """
-            schedule a repeating event
+            Schedule a repeating event.
 
             Args:
-                handler:    method to be called
-                datetime:   time for calling the handler
-                frequency:  time in sconds between calls
-                data:       optional data to send along to the handler
-                name:       Optional name parameter
+                handler:                method to be called
+                when (datetime):        time for calling the handler
+                frequency (float/int):  time in seconds between calls
+                data (dict, optional):  data to send along to the handler
+                name (str, optional):   friendly name parameter
         """
-        self._schedule_event(handler, datetime, data, name, frequency)
+        self._schedule_event(handler, when, data, name, frequency)
 
     def update_event(self, name):
         """
-            Change data of event
+            Change data of event.
 
             Args:
-                name:   Name of event
+                name (str):   Name of event
         """
         data = {
             'event': name,
@@ -594,6 +594,9 @@ class MycroftSkill(object):
         """
             Cancel a pending event. The event will no longer be scheduled
             to be executed
+
+            Args:
+                name (str):   Name of event
         """
         data = {'event': name}
         self.emitter.emit(Message('mycroft.scheduler.remove_event',

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -1,0 +1,171 @@
+from mycroft.messagebus.message import Message
+from mycroft.util.log import getLogger
+
+from threading import Thread
+from Queue import Queue
+import time
+import json
+from os.path import isfile
+
+
+logger = getLogger(__name__)
+
+
+class EventScheduler(Thread):
+    def __init__(self, emitter, schedule_file='/opt/mycroft/schedule.json'):
+        super(EventScheduler, self).__init__()
+        self.events = {}
+        self.emitter = emitter
+        self.isRunning = True
+        self.schedule_file = schedule_file
+        if self.schedule_file:
+            self.load()
+
+        self.add = Queue()
+        self.remove = Queue()
+        self.update = Queue()
+        self.emitter.on('mycroft.scheduler.schedule_event',
+                        self.schedule_event_handler)
+        self.emitter.on('mycroft.scheduler.remove_event',
+                        self.remove_event_handler)
+        self.emitter.on('mycroft.scheduler.update_event',
+                        self.update_event_handler)
+        self.start()
+
+    def load(self):
+        """
+            Load json data with active events from json file
+        """
+        if isfile(self.schedule_file):
+            with open(self.schedule_file) as f:
+                try:
+                    json_data = json.load(f)
+                except Exception as e:
+                    logger.error(e)
+            current_time = time.time()
+            for key in json_data:
+                event_list = json_data[key]
+                # discard non repeating events that has already happened
+                self.events[key] = [tuple(e) for e in event_list
+                                    if e[0] > current_time or e[1]]
+
+    def fetch_new_events(self):
+        """
+            Fetch new events and add to list of pending events
+        """
+        while not self.add.empty():
+            event, sched_time, repeat, data = self.add.get(timeout=1)
+            # get current list of scheduled times for event, [] if missing
+            event_list = self.events.get(event, [])
+            # add received event and time
+            event_list.append((sched_time, repeat, data))
+            self.events[event] = event_list
+
+    def remove_events(self):
+        """
+            remove event from event list
+        """
+        while not self.remove.empty():
+            event = self.remove.get()
+            if event in self.events:
+                self.events.pop(event)
+
+    def update_events(self):
+        """
+            update event list with new data
+        """
+        while not self.remove.empty():
+            event, data = self.update.get()
+            # if there is an active event with this name
+            if len(self.events.get(event, [])) > 0:
+                time, repeat, _ = self.events[event][0]
+                self.events[event][0] = (time, repeat, data)
+
+    def run(self):
+        while self.isRunning:
+            # Fetch newly scheduled events
+            self.fetch_new_events()
+            # Remove events
+            self.remove_events()
+            # Update events
+            self.update_events()
+
+            # Check all events
+            for event in self.events:
+                current_time = time.time()
+                e = self.events[event]
+                # Get scheduled times that has passed
+                passed = [(t, r, d) for (t, r, d) in e if t <= current_time]
+                # and remaining times that we're still waiting for
+                remaining = [(t, r, d) for t, r, d in e if t > current_time]
+                # Trigger registered methods
+                for sched_time, repeat, data in passed:
+                    self.emitter.emit(Message(event, data))
+                    # if this is a repeated event add a new trigger time
+                    if repeat:
+                        remaining.append((sched_time + repeat, repeat, data))
+                # update list of events
+                self.events[event] = remaining
+            time.sleep(0.5)
+
+    def schedule_event(self, event, sched_time, repeat=None, data={}):
+        """ Send event to thread using thread safe queue """
+        self.add.put((event, sched_time, repeat, data))
+
+    def schedule_event_handler(self, message):
+        """
+            Messagebus interface to the schedule_event method.
+            Required data in the message envelope is
+                event: event to emit
+                time:  time to emit the event
+
+            optional data is
+                repeat: repeat interval
+                data:   data to send along with the event
+
+        """
+        event = message.data.get('event')
+        sched_time = message.data.get('time')
+        repeat = message.data.get('repeat')
+        data = message.data.get('data')
+        if event and sched_time:
+            self.schedule_event(event, sched_time, repeat, data)
+        elif not event:
+            logger.error('Scheduled event name not provided')
+        else:
+            logger.error('Scheduled event time not provided')
+
+    def remove_event(self, event):
+        """ Remove event using thread safe queue """
+        self.remove.put(event)
+
+    def remove_event_handler(self, message):
+        """ Messagebus interface to the remove_event method """
+        event = message.data.get('event')
+        self.remove_event(event)
+
+    def update_event(self, event, data):
+        self.update((event, data))
+
+    def update_event_handler(self, message):
+        """ Messagebus interface to the update_event method """
+        event = message.data.get('event')
+
+    def store(self):
+        """
+            Write current schedule to disk
+        """
+        with open(self.schedule_file, 'w') as f:
+            json.dump(self.events, f)
+
+    def shutdown(self):
+        """ Stop the running thread """
+        self.isRunning = False
+        # Remove listeners
+        self.emitter.remove_all_listeners('mycroft.scheduler.schedule_event')
+        self.emitter.remove_all_listeners('mycroft.scheduler.remove_event')
+        self.emitter.remove_all_listeners('mycroft.scheduler.update_event')
+        # Wait for thread to finish
+        self.join()
+        # Store all pending scheduled events
+        self.store()

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -108,8 +108,9 @@ class EventScheduler(Thread):
                 self.events[event] = remaining
             time.sleep(0.5)
 
-    def schedule_event(self, event, sched_time, repeat=None, data={}):
+    def schedule_event(self, event, sched_time, repeat=None, data=None):
         """ Send event to thread using thread safe queue. """
+        data = data or {}
         self.add.put((event, sched_time, repeat, data))
 
     def schedule_event_handler(self, message):
@@ -150,6 +151,8 @@ class EventScheduler(Thread):
     def update_event_handler(self, message):
         """ Messagebus interface to the update_event method. """
         event = message.data.get('event')
+        data = message.data.get('data')
+        self.update_event(event, data)
 
     def store(self):
         """

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -34,7 +34,7 @@ class EventScheduler(Thread):
 
     def load(self):
         """
-            Load json data with active events from json file
+            Load json data with active events from json file.
         """
         if isfile(self.schedule_file):
             with open(self.schedule_file) as f:
@@ -51,7 +51,7 @@ class EventScheduler(Thread):
 
     def fetch_new_events(self):
         """
-            Fetch new events and add to list of pending events
+            Fetch new events and add to list of pending events.
         """
         while not self.add.empty():
             event, sched_time, repeat, data = self.add.get(timeout=1)
@@ -63,7 +63,7 @@ class EventScheduler(Thread):
 
     def remove_events(self):
         """
-            remove event from event list
+            Remove event from event list.
         """
         while not self.remove.empty():
             event = self.remove.get()
@@ -72,7 +72,7 @@ class EventScheduler(Thread):
 
     def update_events(self):
         """
-            update event list with new data
+            Update event list with new data.
         """
         while not self.remove.empty():
             event, data = self.update.get()
@@ -109,7 +109,7 @@ class EventScheduler(Thread):
             time.sleep(0.5)
 
     def schedule_event(self, event, sched_time, repeat=None, data={}):
-        """ Send event to thread using thread safe queue """
+        """ Send event to thread using thread safe queue. """
         self.add.put((event, sched_time, repeat, data))
 
     def schedule_event_handler(self, message):
@@ -136,11 +136,11 @@ class EventScheduler(Thread):
             logger.error('Scheduled event time not provided')
 
     def remove_event(self, event):
-        """ Remove event using thread safe queue """
+        """ Remove event using thread safe queue. """
         self.remove.put(event)
 
     def remove_event_handler(self, message):
-        """ Messagebus interface to the remove_event method """
+        """ Messagebus interface to the remove_event method. """
         event = message.data.get('event')
         self.remove_event(event)
 
@@ -148,18 +148,18 @@ class EventScheduler(Thread):
         self.update((event, data))
 
     def update_event_handler(self, message):
-        """ Messagebus interface to the update_event method """
+        """ Messagebus interface to the update_event method. """
         event = message.data.get('event')
 
     def store(self):
         """
-            Write current schedule to disk
+            Write current schedule to disk.
         """
         with open(self.schedule_file, 'w') as f:
             json.dump(self.events, f)
 
     def shutdown(self):
-        """ Stop the running thread """
+        """ Stop the running thread. """
         self.isRunning = False
         # Remove listeners
         self.emitter.remove_all_listeners('mycroft.scheduler.schedule_event')

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -33,6 +33,7 @@ from mycroft.skills.core import load_skill, create_skill_descriptor, \
     MainModule, FallbackSkill
 from mycroft.skills.intent_service import IntentService
 from mycroft.skills.padatious_service import PadatiousService
+from mycroft.skills.event_scheduler import EventScheduler
 from mycroft.util import connected
 from mycroft.util.log import getLogger
 from mycroft.api import is_paired
@@ -43,6 +44,7 @@ logger = getLogger("Skills")
 __author__ = 'seanfitz'
 
 ws = None
+event_scheduler = None
 loaded_skills = {}
 last_modified_skill = 0
 skill_reload_thread = None
@@ -128,7 +130,7 @@ def _starting_up():
         - adapt intent service
         - padatious intent service
     """
-    global ws, skill_reload_thread
+    global ws, skill_reload_thread, event_scheduler
 
     check_connection()
 
@@ -144,7 +146,7 @@ def _starting_up():
 
     PadatiousService(ws)
     IntentService(ws)
-
+    event_scheduler = EventScheduler(ws)
     # Create a thread that monitors the loaded skills, looking for updates
     skill_reload_thread = WatchSkills()
     skill_reload_thread.daemon = True
@@ -340,6 +342,8 @@ if __name__ == "__main__":
     try:
         main()
     except KeyboardInterrupt:
+        if event_scheduler:
+            event_scheduler.shutdown()
         # Do a clean shutdown of all skills and terminate all running threads
         for skill in loaded_skills:
             try:


### PR DESCRIPTION
====  Tech Notes ====
A single thread handling scheduled events. The skills interact with this
using the self.schedule_event() self.schedule_repeating_event
self.update_event() and self.remove_event().

This is an improvement over scheduledSkill since each skill creates
their own Thread and has to handle storing/restoring scheduled events
between starts.

All pending events are stored in a json file at shutdown for future
sessions.

====  Documentation Notes ====
Needs to be documented

==== Protocol Notes ====
new messagebus event handlers:
- mycroft.scheduler.schedule_event
- mycroft.scheduler.remove_event
- mycroft.scheduler.update_event


@penrods can you check so I touched all the parts you imagined.