### PR TITLE
Bugfix/localization

### DIFF
--- a/mycroft/client/speech/recognizer/pocketsphinx_recognizer.py
+++ b/mycroft/client/speech/recognizer/pocketsphinx_recognizer.py
@@ -20,7 +20,7 @@ import os
 import tempfile
 import time
 
-from os.path import join, dirname, abspath
+from os.path import join, dirname, abspath, exists
 from pocketsphinx import Decoder
 
 from mycroft.client.speech.recognizer.local_recognizer import LocalRecognizer
@@ -52,7 +52,12 @@ class PocketsphinxRecognizer(LocalRecognizer):
 
     def create_config(self, dict_name):
         config = Decoder.default_config()
-        config.set_string('-hmm', join(BASEDIR, 'model', self.lang, 'hmm'))
+        model_file = join(BASEDIR, 'model', self.lang, 'hmm')
+        if not exists(model_file):
+            LOG.error('PocketSphinx model not found for {}', self.lang)
+            model_file = join(BASEDIR, 'model', 'en-us', 'hmm')
+
+        config.set_string('-hmm', model_file)
         config.set_string('-dict', dict_name)
         config.set_string('-keyphrase', self.key_phrase)
         config.set_float('-kws_threshold', float(self.threshold))

--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -17,6 +17,7 @@
 
 
 import pystache
+from io import open
 import os
 import random
 from mycroft.util import log, resolve_resource_file

--- a/mycroft/skills/time_rules.py
+++ b/mycroft/skills/time_rules.py
@@ -167,5 +167,5 @@ KEY_MAP = {
 def create(lang):
     clazz = KEY_MAP.get(lang)
     if not clazz:
-        clazz = TimeRulesEnUs()
+        clazz = TimeRulesEnUs
     return clazz()


### PR DESCRIPTION
Minor bugfixes to some problems when running in localizations that are non-english. Most important would probably be using `io.open` instead of ` open` when loading dialog files. Resolves #1027 

- Fixes loading dialog files with utf-8 encoding
- Fixes using time_rules.py
- Adds useful warning when pocketsphinx model isn't found
- Localizes 'I didn't catch that'