### PR TITLE
Automatically find skill directory in __init__

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -17,10 +17,12 @@
 import abc
 import imp
 import time
+import sys
 
 import operator
 import re
-from os.path import join, dirname, splitext, isdir, basename, exists
+from os.path import join, abspath, dirname, splitext, isdir, \
+                    basename, exists
 from os import listdir
 from functools import wraps
 
@@ -133,7 +135,6 @@ def load_skill(skill_descriptor, emitter, skill_id):
             skill = skill_module.create_skill()
             skill.bind(emitter)
             skill.skill_id = skill_id
-            skill._dir = dirname(skill_descriptor['info'][1])
             skill.load_data_files(dirname(skill_descriptor['info'][1]))
             # Set up intent handlers
             skill.initialize()
@@ -193,6 +194,9 @@ class MycroftSkill(object):
 
     def __init__(self, name=None, emitter=None):
         self.name = name or self.__class__.__name__
+        # Get directory of skill
+        self._dir = dirname(abspath(sys.modules[self.__module__].__file__))
+
         self.bind(emitter)
         self.config_core = ConfigurationManager.get()
         self.config = self.config_core.get(self.name)


### PR DESCRIPTION
====  Tech Notes ====
Previously the _dir parameter was poplated from the skill loader between calling __init__() and initialize(). The skill path can however be gleaned from with in the __init__() of MycroftSkill.

Doing this makes the settings accessable from __init__() as well and will allow a more straight forward usage.