### PR TITLE
Write settings dict to disk more frequently

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -517,7 +517,7 @@ class MycroftSkill(object):
         shutdown all processes and operations in execution.
         """
         # Store settings
-        self.settings.store(force=True)  # Force saving of settings
+        self.settings.store()
 
         # removing events
         for e, f in self.events:

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -326,6 +326,7 @@ class MycroftSkill(object):
                     handler(self, message)
                 else:
                     handler(message)
+                self.settings.store()  # Store settings if they've changed
             except:
                 # TODO: Localize
                 self.speak(
@@ -516,7 +517,7 @@ class MycroftSkill(object):
         shutdown all processes and operations in execution.
         """
         # Store settings
-        self.settings.store()
+        self.settings.store(force=True)  # Force saving of settings
 
         # removing events
         for e, f in self.events:

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -79,7 +79,7 @@ class SkillSettings(dict):
 
     def __setitem__(self, key, value):
         """
-            Add/Update key and note that the file needs saving.
+            Add/Update key.
         """
         return super(SkillSettings, self).__setitem__(key, value)
 
@@ -128,9 +128,7 @@ class SkillSettings(dict):
                                 self.__setitem__(field["name"], field["value"])
 
                 # store value if settings has changed from backend
-                if not self._is_stored:
-                    self.store()
-                    self.loaded_hash = hash(str(self))
+                self.store()
 
             except Exception as e:
                 logger.error(e)
@@ -183,9 +181,14 @@ class SkillSettings(dict):
             "json": settings_meta
         })
 
-    def store(self):
+    def store(self, force=False):
         """
-            Store dictionary to file
+            Store dictionary to file if a change has occured.
+
+            Args:
+                force:  Force write despite no change
         """
-        with open(self._settings_path, 'w') as f:
-            json.dump(self, f)
+        if force or not self._is_stored:
+            with open(self._settings_path, 'w') as f:
+                json.dump(self, f)
+            self.loaded_hash = hash(str(self))


### PR DESCRIPTION
====  Tech Notes ====
After an intent has been handled the settings will be stored if any changes are detected.

A force option was added to the .store method of the settings class which always writes the dict to disk even if no changes has been made. This is used during shutdown.