### PR TITLE
Fix msm from pulling back commits on another branch

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -223,8 +223,13 @@ function update() {
         echo "*.pyc" >> .git/info/exclude
       fi
 
-      # Check if the repo is dirty or has commits to push
-      if [[ (-z $(git status --porcelain --untracked-files=no)) && !($LOCAL != $REMOTE && $REMOTE = $BASE) ]]; then
+      BRANCH="$(git symbolic-ref HEAD 2>/dev/null)"
+      BRANCH="${BRANCH##refs/heads/}"
+
+      if [[ (-z $(git status --porcelain --untracked-files=no)) &&  # No Modified files
+            !($LOCAL != $REMOTE && $REMOTE = $BASE) &&  # No new commits
+            "$BRANCH" = "master" ]]  # On master branch
+      then
         echo "Updating ${d}..."
         echo -n "  "
         git fetch


### PR DESCRIPTION
Often, to do dev work on a skill, I go through the process:
```
git checkout -b feature/my-feature
git add __init__.py
git commit -m "Add my new feature!"
git push -u origin feature/my-feature
```
Unfortunately, as it is right now, msm will get rid of this new `Add my new feature` commit because it does a hard reset to `origin/master`. As goes without saying, this shouldn't happen. To solve this, we can check if we are currently on the master branch and not update unless that is so.