### PR TITLE
Allow any bitrate of audio to the MycroftSTT

### DIFF
--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -107,7 +107,11 @@ class MycroftSTT(STT):
 
     def execute(self, audio, language=None):
         self.lang = language or self.lang
-        return self.api.stt(audio.get_flac_data(), self.lang, 1)[0]
+        try:
+            return self.api.stt(audio.get_flac_data(convert_rate=16000),
+                                self.lang, 1)[0]
+        except:
+            return self.api.stt(audio.get_flac_data(), self.lang, 1)[0]
 
 
 class KaldiSTT(STT):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@ requests==2.13.0
 gTTS==1.1.7
 gTTS-token==1.1.1
 backports.ssl-match-hostname==3.4.0.2
-PyAudio==0.2.8
+PyAudio==0.2.11
 pyee==1.0.1
-SpeechRecognition==3.1.3
+SpeechRecognition==3.7.1
 tornado==4.2.1
 websocket-client==0.32.0
 adapt-parser==0.3.0


### PR DESCRIPTION
====  Tech Notes ====
Setting the convert_rate enforces the output bitrate of the FLAC audio. allowing any bitrate on input.

This requires update of speechrecognition (3.7.1) and PyAudio (0.2.11)

==== Environment Notes ====
Packages that will require upgrade:
PyAudio => 0.2.11
speechrecognition => 3.7.1