### PR TITLE
Notification on dependency changes + Padatious upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ logs/*
 mycroft/audio-accuracy-test/data/*
 scripts/*.screen
 doc/_build/
+.installed

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -129,3 +129,5 @@ fi
 
 # install pygtk for desktop_launcher skill
 "${TOP}/scripts/install-pygtk.sh" " ${CORES}"
+
+md5sum requirements.txt dev_setup.sh > .installed

--- a/mycroft.sh
+++ b/mycroft.sh
@@ -139,10 +139,22 @@ function stop-mycroft {
     stop-screen "mycroft-$1"
 }
 
+function found_exe {
+    hash "$1" 2>/dev/null
+}
+
 set -e
 
 case "$1" in
 "start")
+
+  if [ ! -f .installed ] || ! md5sum -c &>/dev/null < .installed; then
+    echo "Please update dependencies by running ./dev_setup.sh again."
+    if found_exe notify-send; then
+      notify-send "Please Update Dependencies" "Run ./dev_setup.sh again"
+    fi
+  fi
+
   $0 stop
   start-mycroft service
   start-mycroft audio

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -19,6 +19,7 @@ from time import time as get_time, sleep
 
 from threading import Event
 from os.path import expanduser, isfile
+from pkg_resources import get_distribution
 
 from mycroft.configuration import ConfigurationManager
 from mycroft.messagebus.message import Message
@@ -29,6 +30,8 @@ from mycroft.util.parse import normalize
 __author__ = 'matthewscholefield'
 
 logger = getLogger(__name__)
+
+PADATIOUS_VERSION = '0.2.2'  # Also update in requirements.txt
 
 
 class PadatiousService(FallbackSkill):
@@ -47,6 +50,11 @@ class PadatiousService(FallbackSkill):
             except OSError:
                 pass
             return
+        ver = get_distribution('padatious').version
+        logger.warning('VERSION: ' + ver)
+        if ver != PADATIOUS_VERSION:
+            logger.warning('Using Padatious v' + ver + '. Please re-run ' +
+                           'dev_setup.sh to install ' + PADATIOUS_VERSION)
 
         self.container = IntentContainer(intent_cache)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,5 +37,7 @@ python-dateutil==2.6.0
 pychromecast==0.7.7
 python-vlc==1.1.2
 pulsectl==17.7.4
-padatious==0.1.4
 aiml==0.8.6
+
+# Also update in mycroft/skills/padatious_service.py
+padatious==0.2.2


### PR DESCRIPTION
This update hashes `requirements.txt` and `dev_setup.sh` in the `.installed` file to notify the user when there is a change to the dependencies. This also upgrades Padatious to both test the feature, and so that users won't have to run `dev_setup.sh` a second time for the upgrade.

Regardless of the current state, the first time it is required to run `dev_setup.sh` to generate the hash file.

To test:
```Bash
git fetch
git checkout feature/notify-update
git reset --hard HEAD~1
./dev_setup.sh -sm  # Simulate having an already setup git clone from another version
git pull  # Pull down the commit to increment Padatious version number
./mycroft.sh start  # Should get notification to update dependencies
./dev_setup.sh -sm
./mycroft.sh start  # Should no longer get notification
```