### PR TITLE
fix root path import bug in hacked core files

### DIFF
--- a/mycroft/__init__.py
+++ b/mycroft/__init__.py
@@ -1,11 +1,12 @@
+from os.path import abspath, dirname, join
+
+MYCROFT_ROOT_PATH = abspath(join(dirname(__file__), '..'))
+
 from mycroft.api import Api
 from mycroft.skills.core import MycroftSkill, FallbackSkill, \
     intent_handler, intent_file_handler
 from mycroft.skills.context import adds_context, removes_context
 from mycroft.messagebus.message import Message
 
-from os.path import abspath, dirname, join
 
 __author__ = 'seanfitz'
-
-MYCROFT_ROOT_PATH = abspath(join(dirname(__file__), '..'))


### PR DESCRIPTION
if we try to import MYCROFT_ROOT_PATH in some of the core files like i do messagebus service fails to load, this is a problem for me because i changed the file, so not sure this is desired as a PR

`Traceback (most recent call last):
  File "/home/user/jarbas_stable/JarbasAI/mycroft/messagebus/service/main.py", line 22, in <module>
    from mycroft.configuration import ConfigurationManager
  File "/home/user/jarbas_stable/JarbasAI/mycroft/__init__.py", line 2, in <module>
    from mycroft.skills.core import MycroftSkill, FallbackSkill, \
  File "/home/user/jarbas_stable/JarbasAI/mycroft/skills/core.py", line 42, in <module>
    from mycroft import MYCROFT_ROOT_PATH
ImportError: cannot import name MYCROFT_ROOT_PATH`