### PR TITLE
Ignore enclosure.mouth.display message by default

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -144,7 +144,7 @@
   
   // Messagebus types that will NOT be output to logs
   // Override: none
-  "ignore_logs": ["enclosure.mouth.viseme"],
+  "ignore_logs": ["enclosure.mouth.viseme", "enclosure.mouth.display"],
 
   // Settings related to remote sessions
   // Overrride: none


### PR DESCRIPTION
====  Tech Notes ====
Add 'enclosure.mouth.display' to ignore_logs default configuration since
it will get called alot and spam the skills log.