### PR TITLE
Centralize APIS section

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -205,6 +205,12 @@
     "intent_cache": "~/.mycroft/intent_cache",
     "train_delay": 4
   },
+
+  // Centralized API section
+  "APIS": {
+      "WolframAlphaSkill": "",
+      "WeatherSkill": ""
+  },
   // =================================================================
   // All of the follow are specific to particular skills and will soon
   // be removed from this file.

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -213,7 +213,7 @@ class MycroftSkill(object):
         self.bind(emitter)
         self.config_core = ConfigurationManager.get()
         self.config = self.config_core.get(self.name)
-        self.APIS_config = self.config_core.get(self.name, {)
+        self.APIS_config = self.config_core.get(self.name, {})
         self.API = self.APIS_config.get(self.name)
         self.dialog_renderer = None
         self.vocab_dir = None

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -213,6 +213,8 @@ class MycroftSkill(object):
         self.bind(emitter)
         self.config_core = ConfigurationManager.get()
         self.config = self.config_core.get(self.name)
+        self.APIS_config = self.config_core.get(self.name, {)
+        self.API = self.APIS_config.get(self.name)
         self.dialog_renderer = None
         self.vocab_dir = None
         self.file_system = FileSystemAccess(join('skills', self.name))

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -213,7 +213,7 @@ class MycroftSkill(object):
         self.bind(emitter)
         self.config_core = ConfigurationManager.get()
         self.config = self.config_core.get(self.name)
-        self.APIS_config = self.config_core.get(self.name, {})
+        self.APIS_config = self.config_core.get("APIS", {})
         self.API = self.APIS_config.get(self.name)
         self.dialog_renderer = None
         self.vocab_dir = None


### PR DESCRIPTION


This adds two variables to MycroftSkill class

self.APIS_config = self.config_core.get("APIS", {}) # exposes all API keys

self.API = self.APIS_config.get(self.name) # api field with SkillName

API keys can often used in more than one skill, to use same key in more than one skill requires developer to know in which part of config file it is stored and manually accessing it, or to duplicate the key entry

in long term this makes it messy for user-setup and dev-usage

issue #540

my use-case:

´´´
"APIS": {
"WolframAlphaAPI": "key",
"WeatherAPI": "key",
"GraphAPI": "key",
"MashapeAPI": "key",
"WikimapiaAPI": "key",
"CloudsightAPI": "key",
"RedditAPI": "key",
"CloudsightSecret": "secret",
"RedditSecret": "secret"
},
´´´