### PR TITLE
Reduce configuration loading in module scope

### DIFF
--- a/mycroft/client/enclosure/display_manager.py
+++ b/mycroft/client/enclosure/display_manager.py
@@ -27,7 +27,6 @@ __author__ = 'connorpenrod', 'michaelnguyen'
 
 
 LOG = getLogger("Display Manager (mycroft.client.enclosure)")
-managerIPCDir = os.path.join(get_ipc_directory(), "managers")
 
 
 def _write_data(dictionary):
@@ -37,6 +36,7 @@ def _write_data(dictionary):
             dict: dictionary
     """
 
+    managerIPCDir = os.path.join(get_ipc_directory(), "managers")
     # change read/write permissions based on if file exists or not
     path = os.path.join(managerIPCDir, "disp_info")
     permission = "r+" if os.path.isfile(path) else "w+"
@@ -76,6 +76,7 @@ def _read_data():
     """ Reads the file in (/tmp/mycroft/ipc/managers/disp_info)
         and returns the the data as python dict
     """
+    managerIPCDir = os.path.join(get_ipc_directory(), "managers")
 
     path = os.path.join(managerIPCDir, "disp_info")
     permission = "r" if os.path.isfile(path) else "w+"

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -39,8 +39,6 @@ from mycroft.util import (
 )
 from mycroft.util.log import getLogger
 
-config = ConfigurationManager.instance()
-listener_config = config.get('listener')
 logger = getLogger(__name__)
 __author__ = 'seanfitz'
 
@@ -154,6 +152,9 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
     SEC_BETWEEN_WW_CHECKS = 0.2
 
     def __init__(self, wake_word_recognizer):
+
+        self.config = ConfigurationManager.instance()
+        listener_config = self.config.get('listener')
         # The maximum audio in seconds to keep for transcribing a phrase
         # The wake word must fit in this time
         num_phonemes = len(listener_config.get('phonemes').split())
@@ -434,9 +435,9 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
         # If enabled, play a wave file with a short sound to audibly
         # indicate recording has begun.
-        if config.get('confirm_listening'):
+        if self.config.get('confirm_listening'):
             file = resolve_resource_file(
-                config.get('sounds').get('start_listening'))
+                self.config.get('sounds').get('start_listening'))
             if file:
                 play_wav(file)
 

--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -31,13 +31,16 @@ from mycroft.util.log import getLogger
 __author__ = 'seanfitz', 'jdorleans'
 
 LOG = getLogger(__name__)
-config = ConfigurationManager.get().get("websocket")
 
 
 class WebsocketClient(object):
-    def __init__(self, host=config.get("host"), port=config.get("port"),
-                 route=config.get("route"), ssl=config.get("ssl")):
+    def __init__(self, host=None, port=None, route=None, ssl=None):
 
+        config = ConfigurationManager.get().get("websocket")
+        host = host or config.get("host")
+        port = port or config.get("port")
+        route = route or config.get("route")
+        ssl = ssl or config.get("ssl")
         validate_param(host, "websocket.host")
         validate_param(port, "websocket.port")
         validate_param(route, "websocket.route")

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -40,8 +40,6 @@ from inspect import getargspec
 
 __author__ = 'seanfitz'
 
-skills_config = ConfigurationManager.instance().get("skills")
-BLACKLISTED_SKILLS = skills_config.get("blacklisted_skills", [])
 
 MainModule = '__init__'
 
@@ -113,7 +111,7 @@ def open_intent_envelope(message):
                   intent_dict.get('optional'))
 
 
-def load_skill(skill_descriptor, emitter, skill_id):
+def load_skill(skill_descriptor, emitter, skill_id, BLACKLISTED_SKILLS=None):
     """
         load skill from skill descriptor.
 
@@ -122,7 +120,7 @@ def load_skill(skill_descriptor, emitter, skill_id):
             emitter:          messagebus emitter
             skill_id:         id number for skill
     """
-
+    BLACKLISTED_SKILLS = BLACKLISTED_SKILLS or []
     try:
         logger.info("ATTEMPTING TO LOAD SKILL: " + skill_descriptor["name"] +
                     " with ID " + str(skill_id))

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -47,6 +47,10 @@ loaded_skills = {}
 last_modified_skill = 0
 skill_reload_thread = None
 skills_manager_timer = None
+
+skills_config = ConfigurationManager.instance().get("skills")
+BLACKLISTED_SKILLS = skills_config.get("blacklisted_skills", [])
+
 SKILLS_DIR = '/opt/mycroft/skills'
 
 installer_config = ConfigurationManager.instance().get("SkillInstallerSkill")
@@ -257,7 +261,8 @@ class WatchSkills(Thread):
                     skill["loaded"] = True
                     skill["instance"] = load_skill(
                         create_skill_descriptor(skill["path"]),
-                        ws, skill["id"])
+                        ws, skill["id"],
+                        BLACKLISTED_SKILLS)
             # get the last modified skill
             modified_dates = map(lambda x: x.get("last_modified"),
                                  loaded_skills.values())


### PR DESCRIPTION
====  Tech Notes ====
Autoloading configuration in submodules is bad for testing purposes and
should be reduced. It takes time and adds the possibility of altering
the base conditions for the tests

- mycroft/skills/core: global configuration moved to main.py
- mycroft/messagebus/client/ws.py global config moved to __init__ of
Websocket
- client/speech/mic.py global config moved to ResponsiveRecognizer
__init__() method
- client/enclosure/display_manager.py
 - get_ipc_directory() called in methods where used