### PR TITLE
Run requirements.sh when installing skills if exists

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -344,6 +344,14 @@ function install() {
       fi
     fi
 
+    if [[ -f "requirements.sh" ]]; then
+      echo "Setting up native environment..."
+      if ! bash requirements.sh; then
+        echo "Running requirements.sh failed!"
+        return 122
+      fi
+    fi
+
     echo "Installed: ${name}"
     send_install_success "${name}"
     return 0


### PR DESCRIPTION
This brings in support for running a `requirements.sh` file to setup things like native dependencies for skills.