### PR TITLE
Bugfix/mute while speaking

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -37,7 +37,6 @@ def handle_speak(event):
 
     # Mild abuse of the signal system to allow other processes to detect
     # when TTS is happening.  See mycroft.util.is_speaking()
-    create_signal("isSpeaking")
 
     utterance = event.data['utterance']
     if event.data.get('expect_response', False):
@@ -66,9 +65,6 @@ def handle_speak(event):
                 break
     else:
         mute_and_speak(utterance)
-
-    # This check will clear the "signal"
-    check_for_signal("isSpeaking")
 
 
 def mute_and_speak(utterance):

--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -362,6 +362,13 @@ class Enclosure(object):
             self.serial.close()
             self.ws.close()
 
+    def _handle_pairing_complete(self, Message):
+        """
+            Handler for 'mycroft.paired', unmutes the mic after the pairing is
+            complete.
+        """
+        self.ws.emit(Message("mycroft.mic.unmute"))
+
     def _do_net_check(self):
         # TODO: This should live in the derived Enclosure, e.g. Enclosure_Mark1
         LOG.info("Checking internet connection")
@@ -382,7 +389,10 @@ class Enclosure(object):
                 # TODO: Enclosure/localization
 
                 # Don't listen to mic during this out-of-box experience
-                self.ws.emit(Message("mycroft.mic.mute", None))
+                self.ws.emit(Message("mycroft.mic.mute"))
+                # Setup handler to unmute mic at the end of on boarding
+                # i.e. after pairing is complete
+                self.ws.once('mycroft.paired', self._handle_pairing_complete)
 
                 # Kick off wifi-setup automatically
                 self.ws.emit(Message("mycroft.wifi.start",

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -79,13 +79,11 @@ def handle_wake_up(event):
 
 
 def handle_mic_mute(event):
-    if not loop.is_muted():
-        loop.mute()
+    loop.mute()
 
 
 def handle_mic_unmute(event):
-    if loop.is_muted():
-        loop.unmute()
+    loop.unmute()
 
 
 def handle_paired(event):

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -28,7 +28,7 @@ from mycroft.client.enclosure.api import EnclosureAPI
 from mycroft.configuration import ConfigurationManager
 from mycroft.messagebus.message import Message
 from mycroft.util.log import getLogger
-from mycroft.util import play_wav, play_mp3, check_for_signal
+from mycroft.util import play_wav, play_mp3, check_for_signal, create_signal
 import mycroft.util
 
 __author__ = 'jdorleans'
@@ -161,10 +161,14 @@ class TTS(object):
     def begin_audio(self):
         """Helper function for child classes to call in execute()"""
         self.ws.emit(Message("recognizer_loop:audio_output_start"))
+        create_signal("isSpeaking")
 
     def end_audio(self):
         """Helper function for child classes to call in execute()"""
         self.ws.emit(Message("recognizer_loop:audio_output_end"))
+
+        # This check will clear the "signal"
+        check_for_signal("isSpeaking")
 
     def init(self, ws):
         self.ws = ws


### PR DESCRIPTION
First commit:
The real issue was the handling of the signal `isSpeaking` in conjunction with the pairing skill.

Normally the tts audio output mutes the mic while speaking since the pairing skill tries to unmute the entire unboxing overall mute at the wrong time (since the `isSpeaking` signal was lowered too early)

This commit fixes the issue of Mycroft overhearing himself at the end of pairing by moving the raising/lowering of the `isSpeaking` signal to a more correct place.

Second commit:
Make mute a counting variable and not a boolean. This means two pieces of code can mute the mic without stepping on each-other's toes. This allows the mic to be muted during the whole of the unboxing procedure.

Third commit:
A bit of of refactoring, the enclosure should not rely on the pairing skill to unmute. Since the mic is muted here, it should also be unmuted here.