### PR TITLE
speak method improvements, mute and metadata

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -78,6 +78,7 @@ def mute_and_speak(utterance, mute):
 
         Args:
             utterance: The sentence to be spoken
+            mute:      Do not execute tts
     """
     global tts_hash
 

--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -42,6 +42,7 @@ def handle_speak(event):
     utterance = event.data['utterance']
     if event.data.get('expect_response', False):
         ws.once('recognizer_loop:audio_output_end', _trigger_expect_response)
+    mute = event.data.get('mute', False)
 
     # This is a bit of a hack for Picroft.  The analog audio on a Pi blocks
     # for 30 seconds fairly often, so we don't want to break on periods
@@ -65,13 +66,13 @@ def handle_speak(event):
             if _last_stop_signal > start or check_for_signal('buttonPress'):
                 break
     else:
-        mute_and_speak(utterance)
+        mute_and_speak(utterance, mute)
 
     # This check will clear the "signal"
     check_for_signal("isSpeaking")
 
 
-def mute_and_speak(utterance):
+def mute_and_speak(utterance, mute):
     """
         Mute mic and start speaking the utterance using selected tts backend.
 
@@ -94,7 +95,8 @@ def mute_and_speak(utterance):
 
     logger.info("Speak: " + utterance)
     try:
-        tts.execute(utterance)
+        if not mute:
+            tts.execute(utterance)
     finally:
         lock.release()
 

--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -42,7 +42,7 @@ def handle_speak(event):
     utterance = event.data['utterance']
     if event.data.get('expect_response', False):
         ws.once('recognizer_loop:audio_output_end', _trigger_expect_response)
-    mute = event.data.get('mute', False)
+    mute = event.context.get('mute', False)
 
     # This is a bit of a hack for Picroft.  The analog audio on a Pi blocks
     # for 30 seconds fairly often, so we don't want to break on periods

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -448,7 +448,7 @@ class MycroftSkill(object):
         re.compile(regex_str)  # validate regex
         self.emitter.emit(Message('register_vocab', {'regex': regex_str}))
 
-    def speak(self, utterance, expect_response=False):
+    def speak(self, utterance, expect_response=False, mute=False, metadata=None):
         """
             Speak a sentence.
 
@@ -457,14 +457,21 @@ class MycroftSkill(object):
                 expect_response:    set to True if Mycroft should expect a
                                     response from the user and start listening
                                     for response.
+                mute:               do not execute TTS
+                metadata:           arbitrary data, like source urls
         """
         # registers the skill as being active
         self.enclosure.register(self.name)
+        # add metadata
+        if metadata is None:
+          metadata = {}
         data = {'utterance': utterance,
-                'expect_response': expect_response}
+                'expect_response': expect_response,
+                'mute': mute,
+                'metadata': metadata}
         self.emitter.emit(Message("speak", data))
 
-    def speak_dialog(self, key, data={}, expect_response=False):
+    def speak_dialog(self, key, data={}, expect_response=False, mute=False, metadata=None):
         """
             Speak sentance based of dialog file.
 
@@ -474,9 +481,11 @@ class MycroftSkill(object):
                 expect_response:    set to True if Mycroft should expect a
                                     response from the user and start listening
                                     for response.
+                mute:               do not execute TTS
+                metadata:           arbitrary data, like source urls
         """
 
-        self.speak(self.dialog_renderer.render(key, data), expect_response)
+        self.speak(self.dialog_renderer.render(key, data), expect_response, mute, metadata)
 
     def init_dialog(self, root_directory):
         dialog_dir = join(root_directory, 'dialog', self.lang)

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -467,9 +467,9 @@ class MycroftSkill(object):
           metadata = {}
         data = {'utterance': utterance,
                 'expect_response': expect_response,
-                'mute': mute,
                 'metadata': metadata}
-        self.emitter.emit(Message("speak", data))
+        context = {"mute": mute}
+        self.emitter.emit(Message("speak", data, context))
 
     def speak_dialog(self, key, data={}, expect_response=False, mute=False, metadata=None):
         """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -22,7 +22,7 @@ import sys
 import operator
 import re
 from os.path import join, abspath, dirname, splitext, isdir, \
-                    basename, exists
+    basename, exists
 from os import listdir
 from functools import wraps
 
@@ -149,7 +149,8 @@ def load_skill(skill_descriptor, emitter, skill_id):
                     skill_descriptor["name"]))
     except:
         logger.error(
-            "Failed to load skill: " + skill_descriptor["name"], exc_info=True)
+            "Failed to load skill: " + skill_descriptor["name"],
+            exc_info=True)
     return None
 
 
@@ -179,12 +180,15 @@ def intent_handler(intent_parser):
 
 def intent_file_handler(intent_file):
     """ Decorator for adding a method as an intent file handler. """
+
     def real_decorator(func):
         @wraps(func)
         def handler_method(*args, **kwargs):
             return func(*args, **kwargs)
+
         _intent_file_list.append((intent_file, func))
         return handler_method
+
     return real_decorator
 
 
@@ -321,6 +325,7 @@ class MycroftSkill(object):
                                intent handler the function will need the self
                                variable passed as well.
         """
+
         def wrapper(message):
             try:
                 if need_self:
@@ -347,6 +352,7 @@ class MycroftSkill(object):
                 logger.error(
                     "An error occurred while processing a request in " +
                     self.name, exc_info=True)
+
         if handler:
             self.emitter.on(name, wrapper)
             self.events.append((name, wrapper))
@@ -448,7 +454,8 @@ class MycroftSkill(object):
         re.compile(regex_str)  # validate regex
         self.emitter.emit(Message('register_vocab', {'regex': regex_str}))
 
-    def speak(self, utterance, expect_response=False, mute=False, metadata=None):
+    def speak(self, utterance, expect_response=False, mute=False,
+              more_speech=False, metadata=None):
         """
             Speak a sentence.
 
@@ -458,20 +465,24 @@ class MycroftSkill(object):
                                     response from the user and start listening
                                     for response.
                 mute:               do not execute TTS
+                more_speech:        more speak messages expected
                 metadata:           arbitrary data, like source urls
+
         """
         # registers the skill as being active
         self.enclosure.register(self.name)
         # add metadata
         if metadata is None:
-          metadata = {}
+            metadata = {}
         data = {'utterance': utterance,
                 'expect_response': expect_response,
                 'metadata': metadata}
-        context = {"mute": mute}
+        context = {"mute": mute,
+                   "more_speech": more_speech}
         self.emitter.emit(Message("speak", data, context))
 
-    def speak_dialog(self, key, data={}, expect_response=False, mute=False, metadata=None):
+    def speak_dialog(self, key, data=None, expect_response=False, mute=False,
+                     more_speech=False, metadata=None):
         """
             Speak sentance based of dialog file.
 
@@ -482,17 +493,21 @@ class MycroftSkill(object):
                                     response from the user and start listening
                                     for response.
                 mute:               do not execute TTS
+                more_speech:        more speak messages expected
                 metadata:           arbitrary data, like source urls
         """
-
-        self.speak(self.dialog_renderer.render(key, data), expect_response, mute, metadata)
+        if data is None:
+            data = {}
+        self.speak(self.dialog_renderer.render(key, data), expect_response,
+                   mute, more_speech, metadata)
 
     def init_dialog(self, root_directory):
         dialog_dir = join(root_directory, 'dialog', self.lang)
         if exists(dialog_dir):
             self.dialog_renderer = DialogLoader().load(dialog_dir)
         else:
-            logger.debug('No dialog loaded, ' + dialog_dir + ' does not exist')
+            logger.debug(
+                'No dialog loaded, ' + dialog_dir + ' does not exist')
 
     def load_data_files(self, root_directory):
         self.init_dialog(root_directory)


### PR DESCRIPTION
changes to speak method message.data:
- add "metadata" dict to allow skills to send extra info #281 

changes to speak method message.context:
- add "mute" to allow skills to not trigger TTS execution (browser client/server architecture)
- add "more_speech" to allow listeners to know more speak is coming

changes audio service to take into account the mute flag
changed speak_dialog data={} argument to data = None and  if data is None data = {}

I believe mute/more_speech should be in context and not in data, same for expect_response