### PR TITLE
Make test_api slightly more robust

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -25,7 +25,7 @@ from mycroft.identity import IdentityManager
 from mycroft.version import VersionManager
 
 __author__ = 'jdorleans'
-__paired_cache = False
+_paired_cache = False
 
 
 class Api(object):
@@ -124,7 +124,11 @@ class Api(object):
 
     def build_url(self, params):
         path = params.get("path", "")
+        print "PATH"
+        print path
+        print "VERSION"
         version = params.get("version", self.version)
+        print version
         return self.url + "/" + version + "/" + path
 
 
@@ -259,8 +263,8 @@ def is_paired():
     Returns:
         bool: True if paired with backend
     """
-    global __paired_cache
-    if __paired_cache:
+    global _paired_cache
+    if _paired_cache:
         # NOTE: This assumes once paired, the unit remains paired.  So
         # un-pairing must restart the system (or clear this value).
         # The Mark 1 does perform a restart on RESET.
@@ -269,8 +273,8 @@ def is_paired():
     try:
         api = DeviceApi()
         device = api.get()
-        __paired_cache = api.identity.uuid is not None and \
+        _paired_cache = api.identity.uuid is not None and \
             api.identity.uuid != ""
-        return __paired_cache
+        return _paired_cache
     except:
         return False


### PR DESCRIPTION
====  Tech Notes  ====
- Restore ConfigurationManager after mocking it
- enforce value of cached pairing status