### PR TITLE
Make muted mic stay muted when stt is restarted

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -193,6 +193,7 @@ class RecognizerLoop(EventEmitter):
     """
     def __init__(self):
         super(RecognizerLoop, self).__init__()
+        self.mute_calls = 0
         self._load_config()
 
     def _load_config(self):
@@ -206,7 +207,8 @@ class RecognizerLoop(EventEmitter):
         rate = self.config.get('sample_rate')
         device_index = self.config.get('device_index')
 
-        self.microphone = MutableMicrophone(device_index, rate)
+        self.microphone = MutableMicrophone(device_index, rate,
+                                            mute=self.mute_calls > 0)
         # FIXME - channels are not been used
         self.microphone.CHANNELS = self.config.get('channels')
         self.mycroft_recognizer = self.create_mycroft_recognizer(rate, lang)
@@ -253,12 +255,31 @@ class RecognizerLoop(EventEmitter):
         self.consumer.join()
 
     def mute(self):
+        """
+            Mute microphone and increase number of requests to mute
+        """
+        self.mute_calls += 1
         if self.microphone:
             self.microphone.mute()
 
     def unmute(self):
-        if self.microphone:
+        """
+            Unmute mic if as many unmute calls as mute calls have been
+            received.
+        """
+        if self.mute_calls > 0:
+            self.mute_calls -= 1
+
+        if self.mute_calls <= 0 and self.microphone:
             self.microphone.unmute()
+            self.mute_calls = 0
+
+    def force_unmute(self):
+        """
+            Completely unmute mic dispite the number of calls to mute
+        """
+        self.mute_calls = 0
+        self.unmute()
 
     def is_muted(self):
         if self.microphone:

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -91,12 +91,25 @@ def handle_paired(event):
 
 
 def handle_audio_start(event):
-    if not loop.is_muted():
-        loop.mute()  # only mute if necessary
+    """
+        Mute recognizer loop
+    """
+    loop.mute()
 
 
 def handle_audio_end(event):
+    """
+        Request unmute, if more sources has requested the mic to be muted
+        it will remain muted.
+    """
     loop.unmute()  # restore
+
+
+def handle_stop(event):
+    """
+        Handler for mycroft.stop, i.e. button press
+    """
+    loop.force_unmute()
 
 
 def handle_open():
@@ -132,6 +145,7 @@ def main():
     ws.on("mycroft.paired", handle_paired)
     ws.on('recognizer_loop:audio_output_start', handle_audio_start)
     ws.on('recognizer_loop:audio_output_end', handle_audio_end)
+    ws.on('mycroft.stop', handle_stop)
     event_thread = Thread(target=connect)
     event_thread.setDaemon(True)
     event_thread.start()

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -48,19 +48,15 @@ class MutableStream(object):
         assert wrapped_stream is not None
         self.wrapped_stream = wrapped_stream
         self.muted = muted
+
         self.SAMPLE_WIDTH = pyaudio.get_sample_size(format)
         self.muted_buffer = b''.join([b'\x00' * self.SAMPLE_WIDTH])
-        self.mute_calls = 0
 
     def mute(self):
-        self.mute_calls = self.mute_calls + 1
         self.muted = True
 
     def unmute(self):
-        self.mute_calls = self.mute_calls - 1
-        if self.mute_calls <= 0:
-            self.mute_calls = 0
-            self.muted = False
+        self.muted = False
 
     def read(self, size):
         frames = collections.deque()
@@ -94,17 +90,14 @@ class MutableStream(object):
 
 
 class MutableMicrophone(Microphone):
-    def __init__(self, device_index=None, sample_rate=16000, chunk_size=1024):
+    def __init__(self, device_index=None, sample_rate=16000, chunk_size=1024,
+                 mute=False):
         Microphone.__init__(
             self, device_index=device_index, sample_rate=sample_rate,
             chunk_size=chunk_size)
-
-    @property
-    def muted(self):
-        if self.stream:
-            return self.stream.muted
-        else:
-            return False
+        self.muted = False
+        if mute:
+            self.mute()
 
     def __enter__(self):
         assert self.stream is None, \
@@ -126,10 +119,12 @@ class MutableMicrophone(Microphone):
         self.audio.terminate()
 
     def mute(self):
+        self.muted = True
         if self.stream:
             self.stream.mute()
 
     def unmute(self):
+        self.muted = False
         if self.stream:
             self.stream.unmute()
 


### PR DESCRIPTION
====  Tech Notes ====
- Number of callers is now handled in the recognizer loop to make sure
status isn't lost when new settings is applied and other cases where the Microphone is restarted.
- Adds a force_unmute method to make sure the device is completely
unmuted when the user presses the top button.