### PR TITLE
Add messages for skill handler's starting/stopping

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -321,6 +321,8 @@ class MycroftSkill(object):
         """
         def wrapper(message):
             try:
+                # Indicate that the skill handler is starting
+                self.emitter.emit(Message("mycroft.skill.handler.start"))
                 if need_self:
                     # When registring from decorator self is required
                     if len(getargspec(handler).args) == 2:
@@ -345,6 +347,9 @@ class MycroftSkill(object):
                 logger.error(
                     "An error occurred while processing a request in " +
                     self.name, exc_info=True)
+            finally:
+                # Indicate that the skill handler has completed
+                self.emitter.emit(Message('mycroft.skill.handler.complete'))
         if handler:
             self.emitter.on(name, wrapper)
             self.events.append((name, wrapper))


### PR DESCRIPTION
====  Tech Notes ====
Add message bus messages when a skill handler is starting to execute and
a separate message for when skill handler completes. Usable if grouping
speech in certain clients for example. Can also be of use for audio
ducking and similar processes.

==== Protocol Notes ====
Adds the following messages:
mycroft.skill.handler.start
mycroft.skill.handler.complete