### PR TITLE
Restore reconnect timer on ws on connect

### DIFF
--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -63,6 +63,8 @@ class WebsocketClient(object):
     def on_open(self, ws):
         LOG.info("Connected")
         self.emitter.emit("open")
+        # Restore reconnect timer to 5 seconds on sucessful connect
+        self.retry = 5
 
     def on_close(self, ws):
         self.emitter.emit("close")


### PR DESCRIPTION
====  Tech Notes ====
The retry timer doubles on each failed connect attempt but was never
restored to the original time causing an unncessary long wait time. This
restores the timer on each sucessful connection.