### PR TITLE
Bugfix/hotword threshold

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -226,8 +226,10 @@ class RecognizerLoop(EventEmitter):
         phonemes = self.config.get("phonemes")
         thresh = self.config.get("threshold")
         config = self.config_core.get("hotwords", {word: {}})
-        config[word]["phonemes"] = phonemes
-        config[word]["threshold"] = thresh
+        if phonemes:
+            config[word]["phonemes"] = phonemes
+        if thresh:
+            config[word]["threshold"] = thresh
         if phonemes is None or thresh is None:
             config = None
         return HotWordFactory.create_hotword(word, config, self.lang)

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -123,7 +123,6 @@
     "multiplier": 1.0,
     "energy_ratio": 1.5,
     "wake_word": "hey mycroft",
-    "phonemes": "HH EY . M AY K R AO F T",
     "stand_up_word": "wake up"
   },
 


### PR DESCRIPTION
Hotword threshold was forcibly set to `None` when missing in config. (as was the case for the default config) crashing the mycroft-speech-client