### PR TITLE
Fix requirements installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+six==1.10.0
 pystache==0.5.4
 wikipedia==1.4.0
 requests==2.13.0


### PR DESCRIPTION
Resolve conflict between six versions for adapt and websocket-client (websocket client installs latest version of six, and it recently got updated).

This will allow installs and to complete successfully.