### PR TITLE
Added Alternate path for Virtual Wrapper Python

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -73,6 +73,8 @@ if [[ "$(hostname)" == "picroft" ]] || [[ "$(hostname)" =~ "mark_1" ]] && [[ -x 
 else
   if [[ -r /etc/bash_completion.d/virtualenvwrapper ]]; then
     source /etc/bash_completion.d/virtualenvwrapper
+   elif [[ -r /usr/bin/virtualenvwrapper.sh ]]; then
+    source /usr/bin/virtualenvwrapper.sh
   else
     if locate virtualenvwrapper ; then
       if ! source $(locate virtualenvwrapper) ; then


### PR DESCRIPTION
Some user reported problems with the previous ones saying that virtualenvwrapper is a drectory (which it apperantly was)