### PR TITLE
Make sure structure for wake word config entry exist before use

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -221,6 +221,8 @@ class RecognizerLoop(EventEmitter):
         phonemes = self.config.get("phonemes")
         thresh = self.config.get("threshold")
         config = self.config_core.get("hotwords", {word: {}})
+        if word not in config:
+            config[word] = {}
         if phonemes:
             config[word]["phonemes"] = phonemes
         if thresh:


### PR DESCRIPTION
==== Fixed Issues ====
#1105

====  Tech Notes ====
Verify that the sub-config for the set wake word exist before writing to
it.