### PR TITLE
Add workaround for inspect-decorator problem

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -344,6 +344,13 @@ class MycroftSkill(object):
                         handler(self, message)
                     elif len(getargspec(handler).args) == 1:
                         handler(self)
+                    elif len(getargspec(handler).args) == 0:
+                        # Zero may indicate multiple decorators, trying the
+                        # usual call signatures
+                        try:
+                            handler(self, message)
+                        except TypeError:
+                            handler(self)
                     else:
                         raise TypeError
                 else:


### PR DESCRIPTION
====  Tech Notes ====
when using multiple decorators on a method inspect will return incorrect
values despite `@wraps`. This causes the intent handler to fail to
execute.

`@decorator` can't really be of help here since it doesn't handle
decorators with arguments (as far as I can understand)

This is a workaround using the fact that the argument count will be zero
on methods with multiple decorators, and basically tries the usual
signatures.

@MatthewScholefield you have more experience with inspect than I do, is there a better solution apart from switching to python 3.5+ where `@wraps` is more complete?