### PR TITLE
Fix configuration manager saving

### DIFF
--- a/mycroft/configuration/__init__.py
+++ b/mycroft/configuration/__init__.py
@@ -306,7 +306,7 @@ class ConfigurationManager(object):
             LOG.info("Saving config")
             loc_config = load_commented_json(location)
             with open(location, 'w') as f:
-                loc_config.update(config)
+                ConfigurationLoader.merge_conf(loc_config, config)
                 json.dump(loc_config, f)
         except Exception as e:
             LOG.error(e)

--- a/mycroft/configuration/__init__.py
+++ b/mycroft/configuration/__init__.py
@@ -306,8 +306,8 @@ class ConfigurationManager(object):
             LOG.info("Saving config")
             loc_config = load_commented_json(location)
             with open(location, 'w') as f:
-                config = loc_config.update(config)
-                json.dump(config, f)
+                loc_config.update(config)
+                json.dump(loc_config, f)
         except Exception as e:
             LOG.error(e)
 


### PR DESCRIPTION
`dict.update()` returns None which previously deleted any saved config.