### PR TITLE
Chromecast quit current app before starting new playback

### DIFF
--- a/mycroft/audio/services/chromecast/__init__.py
+++ b/mycroft/audio/services/chromecast/__init__.py
@@ -11,6 +11,10 @@ __author__ = 'forslund'
 
 
 class ChromecastService(AudioBackend):
+    """
+        Audio backend for playback on chromecast. Using the default media
+        playback controller included in pychromecast.
+    """
     def _connect(self, message):
         LOG.info('Trying to connect to chromecast')
         casts = pychromecast.get_chromecasts()
@@ -46,34 +50,43 @@ class ChromecastService(AudioBackend):
             self.emitter.emit(Message('ChromecastServiceConnect'))
 
     def supported_uris(self):
-        print "CHROMECAST FOUND: " + str(self.cast)
+        """ Return supported uris of chromecast. """
+        LOG.info("Chromecasts found: " + str(self.cast))
         if self.cast:
             return ['http', 'https']
         else:
             return []
 
     def clear_list(self):
+        """ Clear tracklist. """
         self.tracklist = []
-        pass
 
     def add_list(self, tracks):
+        """
+            Add list of tracks to chromecast playlist.
+
+            Args:
+                tracks (list): list media to add to playlist.
+        """
         self.tracklist = tracks
         pass
 
     def play(self):
+        """ Start playback. """
         self.cast.quit_app()
 
         track = self.tracklist[0]
-        print track, guess_type(track)
+        LOG.debug('track: {}, type: {}'.format(track, guess_type(track)))
         mime = guess_type(track)[0] or 'audio/mp3'
-        print mime
         self.cast.play_media(track, mime)
 
     def stop(self):
+        """ Stop playback and quit app. """
         self.cast.media_controller.stop()
         self.cast.quit_app()
 
     def pause(self):
+        """ Pause current playback. """
         if not self.cast.media_controller.is_paused:
             self.cast.media_controller.pause()
 
@@ -82,9 +95,11 @@ class ChromecastService(AudioBackend):
             self.cast.media_controller.play()
 
     def next(self):
+        """ Skip current track. (Not implemented) """
         pass
 
     def previous(self):
+        """ Return to previous track. (Not implemented) """
         pass
 
     def lower_volume(self):
@@ -96,6 +111,7 @@ class ChromecastService(AudioBackend):
         pass
 
     def track_info(self):
+        """ Return info about currently playing track. """
         info = {}
         ret = {}
         ret['name'] = info.get('name', '')

--- a/mycroft/audio/services/chromecast/__init__.py
+++ b/mycroft/audio/services/chromecast/__init__.py
@@ -30,8 +30,6 @@ class ChromecastService(AudioBackend):
             self.emitter.emit(Message('ChromecastServiceConnect'))
             return
 
-        self.cast.quit_app()
-
     def __init__(self, config, emitter, name='chromecast', cast=None):
         self.connection_attempts = 0
         self.emitter = emitter
@@ -42,7 +40,6 @@ class ChromecastService(AudioBackend):
 
         if cast is not None:
             self.cast = cast
-            self.cast.quit_app()
         else:
             self.cast = None
             self.emitter.on('ChromecastServiceConnect', self._connect)
@@ -64,6 +61,8 @@ class ChromecastService(AudioBackend):
         pass
 
     def play(self):
+        self.cast.quit_app()
+
         track = self.tracklist[0]
         print track, guess_type(track)
         mime = guess_type(track)[0] or 'audio/mp3'


### PR DESCRIPTION

====  Tech Notes ====
Before the current chromecast application was quit when mycroft was started which caused some interference. Now the current app is quit right before starting playback on the device instead.