### PR TITLE
Upgrade Padatious to 0.3.2 which brings in entity support

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -403,19 +403,62 @@ class MycroftSkill(object):
     def register_intent_file(self, intent_file, handler, need_self=False):
         """
             Register an Intent file with the intent service.
+            For example:
+
+            === food.order.intent ===
+            Order some {food}.
+            Order some {food} from {place}.
+            I'm hungry.
+            Grab some {food} from {place}.
+
+            Optionally, you can also use <register_entity_file>
+            to specify some examples of {food} and {place}
+
+            In addition, instead of writing out multiple variations
+            of the same sentence you can write:
+
+            === food.order.intent ===
+            (Order | Grab) some {food} (from {place} | ).
+            I'm hungry.
 
             Args:
                 intent_file: name of file that contains example queries
                              that should activate the intent
                 handler:     function to register with intent
-                need_self:   use for decorator. See register_intent
+                need_self:   use for decorator. See <register_intent>
         """
-        intent_name = str(self.skill_id) + ':' + intent_file
+        name = str(self.skill_id) + ':' + intent_file
         self.emitter.emit(Message("padatious:register_intent", {
             "file_name": join(self.vocab_dir, intent_file),
-            "intent_name": intent_name
+            "name": name
         }))
-        self.add_event(intent_name, handler, need_self)
+        self.add_event(name, handler, need_self)
+
+    def register_entity_file(self, entity_file):
+        """
+            Register an Entity file with the intent service.
+            And Entity file lists the exact values that an entity can hold.
+            For example:
+
+            === ask.day.intent ===
+            Is it {weekday}?
+
+            === weekday.entity ===
+            Monday
+            Tuesday
+            ...
+
+            Args:
+                entity_file: name of file that contains examples
+                             of an entity. Must end with .entity
+        """
+        if '.entity' not in entity_file:
+            raise ValueError('Invalid entity filename: ' + entity_file)
+        name = str(self.skill_id) + ':' + entity_file.replace('.entity', '')
+        self.emitter.emit(Message("padatious:register_entity", {
+            "file_name": join(self.vocab_dir, entity_file),
+            "name": name
+        }))
 
     def disable_intent(self, intent_name):
         """Disable a registered intent"""

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -25,12 +25,11 @@ from mycroft.configuration import ConfigurationManager
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import FallbackSkill
 from mycroft.util.log import LOG
-from mycroft.util.parse import normalize
 
 __author__ = 'matthewscholefield'
 
 
-PADATIOUS_VERSION = '0.2.2'  # Also update in requirements.txt
+PADATIOUS_VERSION = '0.3.2'  # Also update in requirements.txt
 
 
 class PadatiousService(FallbackSkill):
@@ -50,7 +49,6 @@ class PadatiousService(FallbackSkill):
                 pass
             return
         ver = get_distribution('padatious').version
-        LOG.warning('VERSION: ' + ver)
         if ver != PADATIOUS_VERSION:
             LOG.warning('Using Padatious v' + ver + '. Please re-run ' +
                         'dev_setup.sh to install ' + PADATIOUS_VERSION)
@@ -59,6 +57,7 @@ class PadatiousService(FallbackSkill):
 
         self.emitter = emitter
         self.emitter.on('padatious:register_intent', self.register_intent)
+        self.emitter.on('padatious:register_entity', self.register_entity)
         self.register_fallback(self.handle_fallback, 5)
         self.finished_training_event = Event()
 
@@ -80,24 +79,29 @@ class PadatiousService(FallbackSkill):
             LOG.info('Training complete.')
             self.finished_training_event.set()
 
-    def register_intent(self, message):
-        LOG.debug('Registering Padatious intent: ' +
-                  message.data['intent_name'])
-
+    def _register_object(self, message, object_name, register_func):
         file_name = message.data['file_name']
-        intent_name = message.data['intent_name']
+        name = message.data['name']
+
+        LOG.debug('Registering Padatious ' + object_name + ': ' + name)
+
         if not isfile(file_name):
+            LOG.warning('Could not find file ' + file_name)
             return
 
-        self.container.load_file(intent_name, file_name)
+        register_func(name, file_name)
         self.train_time = get_time() + self.train_delay
         self.wait_and_train()
+
+    def register_intent(self, message):
+        self._register_object(message, 'intent', self.container.add_intent)
+
+    def register_entity(self, message):
+        self._register_object(message, 'entity', self.container.add_entity)
 
     def handle_fallback(self, message):
         utt = message.data.get('utterance')
         LOG.debug("Padatious fallback attempt: " + utt)
-
-        utt = normalize(utt, message.data.get('lang', 'en-us'))
 
         if not self.finished_training_event.is_set():
             LOG.debug('Waiting for training to finish...')
@@ -107,6 +111,8 @@ class PadatiousService(FallbackSkill):
 
         if data.conf < 0.5:
             return False
+
+        data.matches['utterance'] = utt
 
         self.emitter.emit(Message(data.name, data=data.matches))
         return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,4 @@ pulsectl==17.7.4
 aiml==0.8.6
 
 # Also update in mycroft/skills/padatious_service.py
-padatious==0.2.2
+padatious==0.3.2

--- a/test/unittests/skills/core.py
+++ b/test/unittests/skills/core.py
@@ -222,9 +222,9 @@ class MycroftSkillTest(unittest.TestCase):
             s.bind(self.emitter)
             s.initialize()
 
-    def check_register_intent_file(self, result_list):
-        for type in self.emitter.get_types():
-            self.assertEquals(type, 'padatious:register_intent')
+    def check_register_object_file(self, types_list, result_list):
+        self.assertEquals(sorted(self.emitter.get_types()),
+                          sorted(types_list))
         self.assertEquals(sorted(self.emitter.get_results()),
                           sorted(result_list))
         self.emitter.reset()
@@ -235,11 +235,25 @@ class MycroftSkillTest(unittest.TestCase):
         s.vocab_dir = join(dirname(__file__), 'intent_file')
         s.initialize()
 
-        expected = [{
-            'file_name': join(dirname(__file__), 'intent_file', 'test.intent'),
-            'intent_name': str(s.skill_id) + ':test.intent'}]
+        expected_types = [
+            'padatious:register_intent',
+            'padatious:register_entity'
+        ]
 
-        self.check_register_intent_file(expected)
+        expected_results = [
+            {
+                'file_name': join(dirname(__file__),
+                                  'intent_file', 'test.intent'),
+                'name': str(s.skill_id) + ':test.intent'
+            },
+            {
+                'file_name': join(dirname(__file__),
+                                  'intent_file', 'test_ent.entity'),
+                'name': str(s.skill_id) + ':test_ent'
+            }
+        ]
+
+        self.check_register_object_file(expected_types, expected_results)
 
     def check_register_decorators(self, result_list):
         self.assertEquals(sorted(self.emitter.get_results()),
@@ -263,7 +277,7 @@ class MycroftSkillTest(unittest.TestCase):
                     {
                      'file_name': join(dirname(__file__), 'intent_file',
                                        'test.intent'),
-                     'intent_name': str(s.skill_id) + ':test.intent'}]
+                     'name': str(s.skill_id) + ':test.intent'}]
 
         self.check_register_decorators(expected)
 
@@ -412,6 +426,7 @@ class TestSkill4(MycroftSkill):
     """ Test skill for padatious intent """
     def initialize(self):
         self.register_intent_file('test.intent', self.handler)
+        self.register_entity_file('test_ent.entity')
 
     def handler(self, message):
         pass


### PR DESCRIPTION
This upgrades Padatious which adds support for defining entity examples when declaring example-based intents. For example:

## Defining Entities
**`weather.intent`**
```
Is  {weekday}?
Is today {weekday}?
```
**`weekday.entity`**
```
Monday
Tuesday
...
```

## Intent Expansion
In addition, to reduce repetition, you can write out values with the or symbol in parentheses like this:

### Long Version
**`food.order.intent`**
```
Order some {food}.
Order some {food} from {place}.
Grab some {food}.
Grab some {food} from {place}.
```

### Short Version
**`food.order.intent`**
```
(Order | Grab) some {food} (from {place} | )
```

Another feature brought in is the ability to match numbers by using `#`. For example:

**`call.intent`**
```
Call {number}.
Call the phone number {number}.
```

**`number.intent`**
```
+### (###) ###-####
+## (###) ###-####
+# (###) ###-####
(###) ###-####
###-####
###-###-####
###.###.####
### ### ####
##########
```