### PR TITLE
Use opt in value to record wake words

### DIFF
--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -168,8 +168,8 @@ class EnclosureReader(Thread):
             enable = 'enable' in data
             word = 'enabled' if enable else 'disabled'
 
-            LOG.info("Setting wake word upload to: " + word)
-            new_config = {'listener': {'wake_word_upload': {'enable': enable}}}
+            LOG.info("Setting opt_in to: " + word)
+            new_config = {'opt_in': enable}
             ConfigurationManager.save(new_config)
             self.ws.emit(Message("speak", {
                 'utterance': mycroft.dialog.get("learning " + word)}))

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -183,7 +183,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
         self.save_utterances = listener_config.get('record_utterances', False)
         self.save_wake_words = listener_config.get('record_wake_words') \
-            or self.upload_config['enable']
+            or self.upload_config['enable'] or self.config['opt_in']
         self.upload_lock = Lock()
         self.save_wake_words_dir = join(gettempdir(), 'mycroft_wake_words')
         self.filenames_to_upload = []
@@ -447,7 +447,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                     with open(filename, 'wb') as f:
                         f.write(audio.get_wav_data())
 
-                    if self.upload_config['enable']:
+                    if self.upload_config['enable'] or self.config['opt_in']:
                         t = Thread(target=self._upload_file, args=(filename,))
                         t.daemon = True
                         t.start()

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -27,6 +27,10 @@
   // Date format, either 'MDY' (e.g. "11-29-1978") or 'DMY' (e.g. "29-11-1978")
   // Override: REMOTE
   "date_format": "MDY",
+
+  // Whether to opt in to data collection
+  // Override: REMOTE
+  "opt_in": false,
   
   // Play a beep when system begins to listen?
   // Override: none


### PR DESCRIPTION
This allows the value set in home.mycroft.ai to be used to enable uploading wake words.