### PR TITLE
Padatious fixes

### DIFF
--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -25,7 +25,7 @@ from mycroft.skills.core import FallbackSkill
 from mycroft.util.log import LOG
 
 
-PADATIOUS_VERSION = '0.3.2'  # Also update in requirements.txt
+PADATIOUS_VERSION = '0.3.3'  # Also update in requirements.txt
 
 
 class PadatiousService(FallbackSkill):

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -90,10 +90,10 @@ class PadatiousService(FallbackSkill):
         self.wait_and_train()
 
     def register_intent(self, message):
-        self._register_object(message, 'intent', self.container.add_intent)
+        self._register_object(message, 'intent', self.container.load_intent)
 
     def register_entity(self, message):
-        self._register_object(message, 'entity', self.container.add_entity)
+        self._register_object(message, 'entity', self.container.load_entity)
 
     def handle_fallback(self, message):
         utt = message.data.get('utterance')

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,4 @@ pulsectl==17.7.4
 aiml==0.8.6
 
 # Also update in mycroft/skills/padatious_service.py
-padatious==0.3.2
+padatious==0.3.3


### PR DESCRIPTION
This fixes using the wrong method to register intents with Padatious and increments the version from `0.3.2` to `0.3.3` which adds a bugfix for calculating intents when the container is empty.