### PR TITLE
Bugfix/stop speaking

### DIFF
--- a/mycroft/audio/__init__.py
+++ b/mycroft/audio/__init__.py
@@ -14,8 +14,6 @@
 #
 import time
 
-import psutil
-
 from mycroft.util.signal import check_for_signal, create_signal
 import mycroft.configuration
 
@@ -41,28 +39,20 @@ def wait_while_speaking():
         time.sleep(0.1)
 
 
-def _kill(names):
-    for name in names:
-        for p in psutil.process_iter():
-            try:
-                if p.name() == name:
-                    p.kill()
-                    break
-            except:
-                pass
+def stop_speaking(ws=None):
+    from mycroft.messagebus.client.ws import WebsocketClient
+    from mycroft.messagebus.message import Message
 
-
-def stop_speaking():
+    if ws is None:
+        ws = WebsocketClient()
     # TODO: Less hacky approach to this once Audio Manager is implemented
     # Skills should only be able to stop speech they've initiated
-    config = mycroft.configuration.ConfigurationManager.get()
 
     create_signal('stoppingTTS')
+    ws.emit(Message('mycroft.audio.speech.stop'))
 
-    # Perform in while loop in case the utterance contained periods and was
-    # split into multiple chunks by handle_speak()
+    # Block until stopped
     while check_for_signal("isSpeaking", -1):
-        _kill([config.get('tts').get('module'), 'aplay'])
         time.sleep(0.25)
 
     # This consumes the signal

--- a/mycroft/audio/__init__.py
+++ b/mycroft/audio/__init__.py
@@ -16,7 +16,8 @@ import time
 
 import psutil
 
-from mycroft.util.signal import check_for_signal
+from mycroft.util.signal import check_for_signal, create_signal
+import mycroft.configuration
 
 
 def is_speaking():
@@ -41,7 +42,6 @@ def wait_while_speaking():
 
 
 def _kill(names):
-    print psutil.pids()
     for name in names:
         for p in psutil.process_iter():
             try:
@@ -55,15 +55,14 @@ def _kill(names):
 def stop_speaking():
     # TODO: Less hacky approach to this once Audio Manager is implemented
     # Skills should only be able to stop speech they've initiated
-    config = mycroft.configuration.ConfigurationManager.instance()
+    config = mycroft.configuration.ConfigurationManager.get()
 
     create_signal('stoppingTTS')
 
     # Perform in while loop in case the utterance contained periods and was
     # split into multiple chunks by handle_speak()
     while check_for_signal("isSpeaking", -1):
-        _kill([config.get('tts').get('module')])
-        _kill(["aplay"])
+        _kill([config.get('tts').get('module'), 'aplay'])
         time.sleep(0.25)
 
     # This consumes the signal

--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 #
 import time
-from threading import Lock
-
 import re
+
+from threading import Lock
 
 from mycroft.configuration import ConfigurationManager
 from mycroft.tts import TTSFactory
@@ -114,7 +114,6 @@ def handle_stop(event):
     _last_stop_signal = time.time()
     tts.playback.clear_queue()
     tts.playback.clear_visimes()
-    stop_speaking()
 
 
 def init(websocket):
@@ -131,6 +130,7 @@ def init(websocket):
     ConfigurationManager.init(ws)
     config = ConfigurationManager.get()
     ws.on('mycroft.stop', handle_stop)
+    ws.on('mycroft.audio.speech.stop', handle_stop)
     ws.on('speak', handle_speak)
 
     tts = TTSFactory.create()


### PR DESCRIPTION
Correct stop_speaking() to handle threaded tts OK

====  Tech Notes ====
Now the stop_speaking() method sends a signal to the speech module to
stop speech instead of killing all aplay/paplay instances.