### PR TITLE
Fix Padatious Entities

### DIFF
--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -25,7 +25,7 @@ from mycroft.skills.core import FallbackSkill
 from mycroft.util.log import LOG
 
 
-PADATIOUS_VERSION = '0.3.4'  # Also update in requirements.txt
+PADATIOUS_VERSION = '0.3.6'  # Also update in requirements.txt
 
 
 class PadatiousService(FallbackSkill):

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,4 +38,4 @@ pulsectl==17.7.4
 aiml==0.8.6
 
 # Also update in mycroft/skills/padatious_service.py
-padatious==0.3.4
+padatious==0.3.6


### PR DESCRIPTION
Fixes issue registering entities by incrementing the version to 0.3.6. Test it like so:

**`test-skill/vocab/en-us/test.intent`**:
```
test {thing}
````

**`test-skill/vocab/en-us/thing.entity`**:
```
name
```

**`test-skill/__init__.py`**:
```Python
from mycroft import MycroftSkill
def TestSkill(MycroftSkill):
    def __ini__(self):
        MycroftSkill.__init__(self)
    def initialize(self):
        self.register_intent_file('test.intent', self.test)
        self.register_entity_file('thing.entity')
    def test(self):
        self.speak('This is a test.')
```

Now, test with:

`"test name"` -> "This is a test."
`"test other"` -> "Sorry, I couldn't understand the request. Please rephrase your request"