### PR TITLE
SkillManager, msm messagebus notifications

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -46,17 +46,6 @@ function help() {
 }
 
 
-# These skills are automatically installed on all mycroft-core
-# installations.
-DEFAULT_SKILLS="skill-alarm skill-audio-record skill-configuration "\
-"skill-date-time skill-desktop-launcher duckduckgo-skill skill-ip skill-joke "\
-"skill-hello-world skill-media skill-npr-news skill-naptime skill-pairing "\
-"skill-personal skill-playback-control skill-reminder skill-installer "\
-"skill-singing skill-speak skill-spelling skill-stop skill-stock "\
-"skill-volume skill-weather skill-wiki "\
-"fallback-aiml skill-mark1-demo "
-
-
 # Determine the location of the Skill folder
 mycroft_skill_folder=${mycroft_skill_folder:-"/opt/mycroft/skills"}
 if [[ ! -d "${mycroft_skill_folder}" ]] ; then
@@ -106,6 +95,57 @@ function get_skill_list() {
     fi
   fi
 }
+
+# Communicate with mycroft-core to inform it of install status
+install_started="false"
+update_started="false"
+remove_started="false"
+function send_start_install () {
+    if [[ "${install_started}" == "false" ]] ; then
+        $( python -m mycroft.messagebus.send msm.installing )
+        install_started="true"
+    fi
+}
+function send_start_update () {
+    if [[ "${update_started}" == "false" ]] ; then
+        res=$( python -m mycroft.messagebus.send msm.updating )
+        update_started="true"
+    fi
+}
+function send_start_remove () {
+    if [[ "${remove_started}" == "false" ]] ; then
+        res=$( python -m mycroft.messagebus.send msm.removing )
+        remove_started="true"
+    fi
+}
+function send_install_success () {
+    res=$( python -m mycroft.messagebus.send msm.install.succeeded '{"skill": "${1}" }' )
+}
+function send_install_fail () {
+    res=$( python -m mycroft.messagebus.send msm.install.failed '{"skill": "${1}", "error" : ${2} }' )
+}
+function send_remove_success () {
+    res=$( python -m mycroft.messagebus.send msm.remove.succeeded '{"skill": "${1}" }' )
+}
+function send_remove_fail () {
+    res=$( python -m mycroft.messagebus.send msm.remove.failed '{"skill": "${1}", "error" : ${2} }' )
+}
+function send_end_install () {
+    if [[ "${install_started}" == "true" ]] ; then
+        res=$( python -m mycroft.messagebus.send msm.installed )
+    fi
+}
+function send_end_update () {
+    if [[ "${update_started}" == "true" ]] ; then
+        res=$( python -m mycroft.messagebus.send msm.updated )
+    fi
+}
+function send_end_remove () {
+    if [[ "${remove_started}" == "true" ]] ; then
+        res=$( python -m mycroft.messagebus.send msm.removed )
+    fi
+}
+
 
 function remove() {
   str=$*
@@ -161,13 +201,16 @@ function remove() {
 
      # Delete the skill folder
      echo -n "Removing '${name}'..."
+     send_start_remove
      rm -rf "${name}"
      if [[ -d "${mycroft_skill_folder}/${name}" ]] ; then
         # Failed to remove the skill directory
+        send_remove_fail "${name}" 249
         return 249
      else
         echo "done"
         echo "Removed: ${name}"
+        send_remove_success
         return 0
      fi
   else
@@ -250,9 +293,11 @@ function install() {
     fi
 
     echo "Installing from: ${repo}"
+    send_start_install
     git clone "${repo}" >> /dev/null
     if ! cd "${name}" ; then
       echo "ERROR: Unable to access directory ${name}!"
+      send_install_fail "${name}" 102
       return 102
     fi
     if [[ "${picroft_mk1}" == "true" ]] ; then
@@ -262,6 +307,7 @@ function install() {
       if [[ "${group}" != "mycroft" ]] || [[ "${owner}" != "mycroft" ]] ; then
          if ! sudo chown -R mycroft:mycroft "${mycroft_skill_folder}/${name}" ; then
            echo "ERROR: Unable to chown install directory ${name}!"
+           send_install_fail "${name}" 123
            return 123
          fi
       fi
@@ -272,6 +318,7 @@ function install() {
         if [[ "${VIRTUAL_ENV}" =~ .mycroft$ ]] ; then
           if ! pip install -r requirements.txt ; then
             echo "ERROR: Unable to install requirements for skill '${name}'"
+            send_install_fail "${name}" 121
             return 121
           fi
         else
@@ -279,22 +326,26 @@ function install() {
             if ! pip install -r requirements.txt ; then
               echo "ERROR: Unable to install requirements for skill '${name}'"
               deactivate mycroft
+              send_install_fail "${name}" 121
               return 121
             fi
           else
             echo "ERROR: Unable to activate 'mycroft' virtualenv, requirements not installed."
+            send_install_fail "${name}" 120
             return 120
           fi
         fi
       else
         if ! sudo pip install -r requirements.txt ; then
           echo "ERROR: Unable to install requirements for '${name}', it may not work"
+          send_install_fail "${name}" 121
           return 121
         fi
       fi
     fi
 
     echo "Installed: ${name}"
+    send_install_success "${name}"
     return 0
 }
 
@@ -341,6 +392,7 @@ function update() {
       then
         echo "Updating ${d}..."
         echo -n "  "
+        send_start_update
         git fetch
         git reset --hard origin/master
         rm -f *.pyc
@@ -353,6 +405,7 @@ function update() {
 
 OPT=$1
 shift
+
 
 case ${OPT} in
   "install")
@@ -375,6 +428,7 @@ case ${OPT} in
                fi
             fi
          done
+         send_end_install
       else
          # install requires a parameter, show help
          help
@@ -401,6 +455,7 @@ case ${OPT} in
                fi
             fi
          done
+         send_end_remove
       else
          # remove requires a parameter, show help
          help
@@ -426,6 +481,7 @@ case ${OPT} in
       fi
 
       update
+      send_end_update
       exit_code=$?
       ;;
   "default")
@@ -437,6 +493,18 @@ case ${OPT} in
          echo "${script}: error ${exit_code}"
          exit ${exit_code}
       fi
+
+      # These skills are automatically installed on all mycroft-core
+      # installations.
+      # TODO: Load from https://raw.githubusercontent.com/MycroftAI/mycroft-skills/master/DEFAULT_SKILLS
+      # TODO: Load from https://raw.githubusercontent.com/MycroftAI/mycroft-skills/master/DEFAULT_SKILLS.${platform}
+      DEFAULT_SKILLS="skill-alarm skill-audio-record skill-configuration "\
+        "skill-date-time skill-desktop-launcher duckduckgo-skill skill-ip skill-joke "\
+        "skill-hello-world skill-media skill-npr-news skill-naptime skill-pairing "\
+        "skill-personal skill-playback-control skill-reminder skill-installer "\
+        "skill-singing skill-speak skill-spelling skill-stop skill-stock "\
+        "skill-volume skill-weather skill-wiki "\
+        "fallback-aiml skill-mark1-demo "
 
       for name in ${DEFAULT_SKILLS}
       do
@@ -456,6 +524,7 @@ case ${OPT} in
 
       if [[ ${exit_code} -eq 0 ]] ; then
          update
+         send_end_update
          exit_code=$?
       fi
    ;;

--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -37,15 +37,16 @@ class WebsocketClient(object):
         validate_param(port, "websocket.port")
         validate_param(route, "websocket.route")
 
-        self.build_url(host, port, route, ssl)
+        self.url = WebsocketClient.build_url(host, port, route, ssl)
         self.emitter = EventEmitter()
         self.client = self.create_client()
         self.pool = ThreadPool(10)
         self.retry = 5
 
-    def build_url(self, host, port, route, ssl):
+    @staticmethod
+    def build_url(host, port, route, ssl):
         scheme = "wss" if ssl else "ws"
-        self.url = scheme + "://" + host + ":" + str(port) + route
+        return scheme + "://" + host + ":" + str(port) + route
 
     def create_client(self):
         return WebSocketApp(self.url,

--- a/mycroft/messagebus/send.py
+++ b/mycroft/messagebus/send.py
@@ -1,0 +1,56 @@
+# Copyright 2017 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import sys
+import json
+from mycroft.messagebus.client.ws import WebsocketClient
+from mycroft.messagebus.message import Message
+from mycroft.configuration import ConfigurationManager
+from websocket import create_connection
+
+# Parse the command line
+if len(sys.argv) == 2:
+    messageToSend = sys.argv[1]
+    dataToSend = {}
+elif len(sys.argv) == 3:
+    messageToSend = sys.argv[1]
+    try:
+        dataToSend = json.loads(sys.argv[2])
+    except BaseException:
+        print "Second argument must be a JSON string"
+        print "Ex: python -m mycroft.messagebus.send speak " \
+            "'{\"utterance\" : \"hello\"}'"
+        exit()
+else:
+    print "Command line interface to the mycroft-core messagebus."
+    print "Usage:    python -m mycroft.messagebus.send message"
+    print "          python -m mycroft.messagebus.send message JSON-string\n"
+    print "Examples: python -m mycroft.messagebus.send mycroft.wifi.start"
+    print "Ex: python -m mycroft.messagebus.send speak " \
+        "'{\"utterance\" : \"hello\"}'"
+    exit()
+
+
+# Calculate the standard Mycroft messagebus websocket address
+config = ConfigurationManager.get().get("websocket")
+url = WebsocketClient.build_url(config.get("host"),
+                                config.get("port"),
+                                config.get("route"),
+                                config.get("ssl"))
+
+# Send the provided message/data
+ws = create_connection(url)
+packet = Message(messageToSend, dataToSend).serialize()
+ws.send(packet)
+ws.close()

--- a/mycroft/res/text/en-us/sorry I couldn't install default skills.dialog
+++ b/mycroft/res/text/en-us/sorry I couldn't install default skills.dialog
@@ -1,2 +1,1 @@
-sorry I couldn't install default skills
-an error occured while installing default skills
+an error occured while updating skills

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -16,16 +16,16 @@ import json
 import subprocess
 import sys
 import time
-from threading import Timer, Thread, Event
+from threading import Timer, Thread, Event, Lock
 
 import os
 from os.path import exists, join
 
 import mycroft.dialog
+import mycroft.lock
 from mycroft import MYCROFT_ROOT_PATH
 from mycroft.api import is_paired
 from mycroft.configuration import ConfigurationManager
-from mycroft.lock import Lock  # Creates PID file for single instance
 from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import load_skill, create_skill_descriptor, \
@@ -39,19 +39,15 @@ from mycroft.util.log import LOG
 
 ws = None
 event_scheduler = None
-loaded_skills = {}
-last_modified_skill = 0
-skill_reload_thread = None
-skills_manager_timer = None
+skill_manager = None
 
 skills_config = ConfigurationManager.instance().get("skills")
 BLACKLISTED_SKILLS = skills_config.get("blacklisted_skills", [])
 PRIORITY_SKILLS = skills_config.get("priority_skills", [])
-
 SKILLS_DIR = '/opt/mycroft/skills'
-
-installer_config = ConfigurationManager.instance().get("SkillInstallerSkill")
-MSM_BIN = installer_config.get("path", join(MYCROFT_ROOT_PATH, 'msm', 'msm'))
+MSM_BIN = ConfigurationManager.instance().get("SkillInstallerSkill").get(
+    "path", join(MYCROFT_ROOT_PATH, 'msm', 'msm'))
+MINUTES = 60  # number of seconds in a minute (syntatic sugar)
 
 
 def connect():
@@ -59,83 +55,19 @@ def connect():
     ws.run_forever()
 
 
-def install_default_skills(speak=True):
-    """
-        Install default skill set using msm.
-
-        Args:
-            speak (optional): Enable response for success. Default True
-    """
-    if exists(MSM_BIN):
-        p = subprocess.Popen(MSM_BIN + " default", stderr=subprocess.STDOUT,
-                             stdout=subprocess.PIPE, shell=True)
-        (output, err) = p.communicate()
-        res = p.returncode
-        if res == 0 and speak:
-            # ws.emit(Message("speak", {
-            #     'utterance': mycroft.dialog.get("skills updated")}))
-            pass
-        elif not connected():
-            LOG.error('msm failed, network connection is not available')
-            ws.emit(Message("speak", {
-                'utterance': mycroft.dialog.get("no network connection")}))
-        elif res != 0:
-            LOG.error('msm failed with error {}: {}'.format(res, output))
-            ws.emit(Message("speak", {
-                'utterance': mycroft.dialog.get(
-                    "sorry I couldn't install default skills")}))
-
-    else:
-        LOG.error("Unable to invoke Mycroft Skill Manager: " + MSM_BIN)
-
-
-def skills_manager(message):
-    """
-        skills_manager runs on a Timer every hour and checks for updated
-        skills.
-    """
-    global skills_manager_timer
-
-    if connected():
-        if skills_manager_timer is None:
-            pass
-        # Install default skills and look for updates via Github
-        LOG.debug("==== Invoking Mycroft Skill Manager: " + MSM_BIN)
-        install_default_skills(False)
-
-    # Perform check again once and hour
-    skills_manager_timer = Timer(3600, _skills_manager_dispatch)
-    skills_manager_timer.daemon = True
-    skills_manager_timer.start()
-
-
-def _skills_manager_dispatch():
-    """
-        Thread function to trigger skill_manager over message bus.
-    """
-    global ws
-    ws.emit(Message("skill_manager", {}))
-
-
 def _starting_up():
     """
         Start loading skills.
 
         Starts
-        - reloading of skills when needed
+        - SkillManager to load/reloading of skills when needed
         - a timer to check for internet connection
-        - a timer for updating skills every hour
         - adapt intent service
         - padatious intent service
     """
-    global ws, skill_reload_thread, event_scheduler
+    global ws, skill_manager, event_scheduler
 
     ws.on('intent_failure', FallbackSkill.make_intent_failure_handler(ws))
-
-    # Create skill_manager listener and invoke the first time
-    ws.on('skill_manager', skills_manager)
-    ws.on('mycroft.internet.connected', install_default_skills)
-    ws.emit(Message('skill_manager', {}))
 
     # Create the Intent manager, which converts utterances to intents
     # This is the heart of the voice invoked skill system
@@ -143,14 +75,15 @@ def _starting_up():
     PadatiousService(ws)
     IntentService(ws)
     event_scheduler = EventScheduler(ws)
+
     # Create a thread that monitors the loaded skills, looking for updates
-    skill_reload_thread = WatchSkills()
-    skill_reload_thread.daemon = True
-    skill_reload_thread.start()
+    skill_manager = SkillManager(ws)
+    skill_manager.daemon = True
+    skill_manager.start()
 
     # Wait until skills have been loaded once before starting to check
     # network connection
-    skill_reload_thread.wait_loaded_priority()
+    skill_manager.wait_loaded_priority()
     check_connection()
 
 
@@ -207,169 +140,244 @@ def _get_last_modified_date(path):
     return last_date
 
 
-def load_skill_list(skills_to_load):
-    """
-        load list of specific skills.
+class SkillManager(Thread):
+    """ Load, update and manage instances of Skill on this system """
 
-        Args:
-            skills_to_load (list): list of skill directories to load
-    """
-    if exists(SKILLS_DIR):
-        # checking skills dir and getting all priority skills there
-        skill_list = [folder for folder in filter(
-            lambda x: os.path.isdir(os.path.join(SKILLS_DIR, x)),
-            os.listdir(SKILLS_DIR)) if folder in skills_to_load]
-        for skill_folder in skill_list:
-            skill = {"id": hash(os.path.join(SKILLS_DIR, skill_folder))}
-            skill["path"] = os.path.join(SKILLS_DIR, skill_folder)
-            # checking if is a skill
-            if not MainModule + ".py" in os.listdir(skill["path"]):
-                continue
-            # getting the newest modified date of skill
-            last_mod = _get_last_modified_date(skill["path"])
-            skill["last_modified"] = last_mod
-            # loading skill
-            skill["loaded"] = True
-            skill["instance"] = load_skill(
-                create_skill_descriptor(skill["path"]),
-                ws, skill["id"])
-            loaded_skills[skill_folder] = skill
-
-
-class WatchSkills(Thread):
-    """
-        Thread function to reload skills when a change is detected.
-    """
-
-    def __init__(self):
-        super(WatchSkills, self).__init__()
+    def __init__(self, ws):
+        super(SkillManager, self).__init__()
         self._stop_event = Event()
-        self._loaded_once = Event()
         self._loaded_priority = Event()
+        self.next_download = time.time() - 1    # download ASAP
+        self.last_modified_skill = 0
+        self.loaded_skills = {}
+        self.msm_blocked = False
+        self.ws = ws
+
+        # Conversation management
+        ws.on('skill.converse.request', self.handle_converse_request)
+
+        # Update on initial connection
+        ws.on('mycroft.internet.connected', self.schedule_update_skills)
+
+        # Update upon request
+        ws.on('skillmanager.update', self.schedule_update_skills)
+
+        # Register handlers for external MSM signals
+        ws.on('msm.updating', self.block_msm)
+        ws.on('msm.removing', self.block_msm)
+        ws.on('msm.installing', self.block_msm)
+        ws.on('msm.updated', self.restore_msm)
+        ws.on('msm.removed', self.restore_msm)
+        ws.on('msm.installed', self.restore_msm)
+
+        # when locked, MSM is active or intentionally blocked
+        self.__msm_lock = Lock()
+
+    def schedule_update_skills(self):
+        # Update skills at next opportunity
+        self.next_download = time.time() - 1
+
+    def block_msm(self):
+        if not self.msm_blocked:
+            self.__msm_lock.acquire()
+            self.msm_blocked = True
+
+    def restore_msm(self):
+        if self.msm_blocked:
+            self.__msm_lock.release()
+            self.msm_blocked = False
+
+    def download_skills(self, speak=True):
+        """ Invoke MSM to install default skills and/or update installed skills
+
+            Args:
+                speak (bool, optional): Speak the result? Defaults to True
+        """
+        # Don't invoke msm if already running
+        if exists(MSM_BIN) and self.__msm_lock.acquire():
+            try:
+                # Invoke the MSM script to do the hard work.
+                LOG.debug("==== Invoking Mycroft Skill Manager: " + MSM_BIN)
+                p = subprocess.Popen(MSM_BIN + " default",
+                                     stderr=subprocess.STDOUT,
+                                     stdout=subprocess.PIPE, shell=True)
+                (output, err) = p.communicate()
+                res = p.returncode
+                if res == 0 and speak:
+                    # self.ws.emit(Message("speak", {
+                    #     'utterance': mycroft.dialog.get("skills updated")}))
+                    self.next_download = time.time() + 60 * MINUTES
+                    return True
+                elif not connected():
+                    LOG.error('msm failed, network connection not available')
+                    self.ws.emit(Message("speak", {
+                        'utterance':
+                            mycroft.dialog.get("no network connection")}))
+                    self.next_download = time.time() + 5 * MINUTES
+                    return False
+                elif res != 0:
+                    LOG.error(
+                        'msm failed with error {}: {}'.format(
+                            res, output))
+                    self.ws.emit(Message("speak", {
+                        'utterance': mycroft.dialog.get(
+                            "sorry I couldn't install default skills")}))
+                    self.next_download = time.time() + 5 * MINUTES
+                    return False
+            finally:
+                self.__msm_lock.release()
+        else:
+            LOG.error("Unable to invoke Mycroft Skill Manager: " + MSM_BIN)
+
+    def _load_or_reload_skill(self, skill_folder):
+        if skill_folder not in self.loaded_skills:
+            self.loaded_skills[skill_folder] = {
+                "id": hash(os.path.join(SKILLS_DIR, skill_folder))
+            }
+        skill = self.loaded_skills.get(skill_folder)
+        skill["path"] = os.path.join(SKILLS_DIR, skill_folder)
+
+        # check if folder is a skill (must have __init__.py)
+        if not MainModule + ".py" in os.listdir(skill["path"]):
+            return
+
+        # getting the newest modified date of skill
+        last_mod = _get_last_modified_date(skill["path"])
+        skill["last_modified"] = last_mod
+        modified = skill.get("last_modified", 0)
+        # checking if skill is loaded and wasn't modified
+        if skill.get("loaded") and modified <= self.last_modified_skill:
+            return
+
+        # check if skill was modified
+        elif (skill.get("instance") and modified >
+                self.last_modified_skill):
+
+            # check if skill is allowed to reloaded
+            if not skill["instance"].reload_skill:
+                return
+
+            LOG.debug("Reloading Skill: " + skill_folder)
+            # removing listeners and stopping threads
+            skill["instance"].shutdown()
+
+            # Remove two local references that are known
+            refs = sys.getrefcount(skill["instance"]) - 2
+            if refs > 0:
+                LOG.warning(
+                    "After shutdown of {} there are still "
+                    "{} references remaining. The skill "
+                    "won't be cleaned from memory."
+                    .format(skill['instance'].name, refs))
+            del skill["instance"]
+
+        # (Re)load the skill from disk
+        skill["loaded"] = True
+        skill["instance"] = load_skill(create_skill_descriptor(skill["path"]),
+                                       self.ws, skill["id"],
+                                       BLACKLISTED_SKILLS)
+
+    def load_skill_list(self, skills_to_load):
+        """ Load the specified list of skills from disk
+
+            Args:
+                skills_to_load (list): list of skill directory names to load
+        """
+        if exists(SKILLS_DIR):
+            # checking skills dir and getting all priority skills there
+            skill_list = [folder for folder in filter(
+                lambda x: os.path.isdir(os.path.join(SKILLS_DIR, x)),
+                os.listdir(SKILLS_DIR)) if folder in skills_to_load]
+            for skill_folder in skill_list:
+                self._load_or_reload_skill(skill_folder)
 
     def run(self):
-        global ws, loaded_skills, last_modified_skill
+        """ Load skills and update periodically from disk and internet """
 
-        # Load priority skills first by order
-        load_skill_list(PRIORITY_SKILLS)
+        # Load priority skills first, in order (very first time this will
+        # occur before MSM has run)
+        self.load_skill_list(PRIORITY_SKILLS)
         self._loaded_priority.set()
 
         # Scan the file folder that contains Skills.  If a Skill is updated,
         # unload the existing version from memory and reload from the disk.
         while not self._stop_event.is_set():
+
+            # Update skills once an hour
+            if (time.time() >= self.next_download):
+                self.download_skills(False)
+
+            # Look for recently changed skill(s) needing a reload
             if exists(SKILLS_DIR):
                 # checking skills dir and getting all skills there
                 list = filter(lambda x: os.path.isdir(
                     os.path.join(SKILLS_DIR, x)), os.listdir(SKILLS_DIR))
 
                 for skill_folder in list:
-                    if skill_folder not in loaded_skills:
-                        loaded_skills[skill_folder] = {
-                            "id": hash(os.path.join(SKILLS_DIR, skill_folder))
-                        }
-                    skill = loaded_skills.get(skill_folder)
-                    skill["path"] = os.path.join(SKILLS_DIR, skill_folder)
-                    # checking if is a skill
-                    if not MainModule + ".py" in os.listdir(skill["path"]):
-                        continue
-                    # getting the newest modified date of skill
-                    last_mod = _get_last_modified_date(skill["path"])
-                    skill["last_modified"] = last_mod
-                    modified = skill.get("last_modified", 0)
-                    # checking if skill is loaded and wasn't modified
-                    if skill.get(
-                            "loaded") and modified <= last_modified_skill:
-                        continue
-                    # checking if skill was modified
-                    elif (skill.get("instance") and modified >
-                            last_modified_skill):
-                        # checking if skill should be reloaded
-                        if not skill["instance"].reload_skill:
-                            continue
-                        LOG.debug("Reloading Skill: " + skill_folder)
-                        # removing listeners and stopping threads
-                        skill["instance"].shutdown()
+                    self._load_or_reload_skill(skill_folder)
 
-                        # -2 since two local references that are known
-                        refs = sys.getrefcount(skill["instance"]) - 2
-                        if refs > 0:
-                            LOG.warning(
-                                "After shutdown of {} there are still "
-                                "{} references remaining. The skill "
-                                "won't be cleaned from memory."
-                                .format(skill['instance'].name, refs))
-                        del skill["instance"]
-                    skill["loaded"] = True
-                    skill["instance"] = load_skill(
-                        create_skill_descriptor(skill["path"]),
-                        ws, skill["id"],
-                        BLACKLISTED_SKILLS)
-            # get the last modified skill
+            # remember the date of the last modified skill
             modified_dates = map(lambda x: x.get("last_modified"),
-                                 loaded_skills.values())
+                                 self.loaded_skills.values())
             if len(modified_dates) > 0:
-                last_modified_skill = max(modified_dates)
+                self.last_modified_skill = max(modified_dates)
 
-            if not self._loaded_once.is_set():
-                self._loaded_once.set()
             # Pause briefly before beginning next scan
             time.sleep(2)
 
+        # Do a clean shutdown of all skills
+        for skill in self.loaded_skills:
+            try:
+                self.loaded_skills[skill]['instance'].shutdown()
+            except BaseException:
+                pass
+
     def wait_loaded_priority(self):
-        """
-            Block until priority skills have loaded
-        """
+        """ Block until all priority skills have loaded """
         while not self._loaded_priority.is_set():
             time.sleep(1)
 
-    def wait_loaded_once(self):
-        """
-            Block until skills have loaded at least once.
-        """
-        while not self._loaded_once.is_set():
-            time.sleep(1)
-
     def stop(self):
-        """
-            Stop the thread.
-        """
+        """ Tell the manager to shutdown """
         self._stop_event.set()
 
+    def handle_converse_request(self, message):
+        """ Check if the targeted skill id can handle conversation
 
-def handle_converse_request(message):
-    """
-        handle_converse_request checks if the targeted skill id can handle
-        conversation.
-    """
-    skill_id = int(message.data["skill_id"])
-    utterances = message.data["utterances"]
-    lang = message.data["lang"]
-    global ws, loaded_skills
-    # loop trough skills list and call converse for skill with skill_id
-    for skill in loaded_skills:
-        if loaded_skills[skill]["id"] == skill_id:
-            try:
-                instance = loaded_skills[skill]["instance"]
-            except:
-                LOG.error("converse requested but skill not loaded")
-                ws.emit(Message("skill.converse.response", {
-                    "skill_id": 0, "result": False}))
-                return
-            try:
-                result = instance.converse(utterances, lang)
-                ws.emit(Message("skill.converse.response", {
-                    "skill_id": skill_id, "result": result}))
-                return
-            except:
-                LOG.error(
-                    "Converse method malformed for skill " + str(skill_id))
-    ws.emit(Message("skill.converse.response",
-                    {"skill_id": 0, "result": False}))
+        If supported, the conversation is invoked.
+        """
+
+        skill_id = int(message.data["skill_id"])
+        utterances = message.data["utterances"]
+        lang = message.data["lang"]
+
+        # loop trough skills list and call converse for skill with skill_id
+        for skill in self.loaded_skills:
+            if self.loaded_skills[skill]["id"] == skill_id:
+                try:
+                    instance = self.loaded_skills[skill]["instance"]
+                except BaseException:
+                    LOG.error("converse requested but skill not loaded")
+                    self.ws.emit(Message("skill.converse.response", {
+                        "skill_id": 0, "result": False}))
+                    return
+                try:
+                    result = instance.converse(utterances, lang)
+                    self.ws.emit(Message("skill.converse.response", {
+                        "skill_id": skill_id, "result": result}))
+                    return
+                except BaseException:
+                    LOG.error(
+                        "Converse method malformed for skill " + str(skill_id))
+        self.ws.emit(Message("skill.converse.response",
+                             {"skill_id": 0, "result": False}))
 
 
 def main():
     global ws
-    lock = Lock('skills')  # prevent multiple instances of this service
+
+    # Create PID file, prevent multiple instancesof this service
+    lock = mycroft.lock.Lock('skills')
 
     # Connect this Skill management process to the websocket
     ws = WebsocketClient()
@@ -389,13 +397,12 @@ def main():
                 # do not log tokens from registration messages
                 _message["data"]["token"] = None
             message = json.dumps(_message)
-        except:
+        except BaseException:
             pass
         LOG('SKILLS').debug(message)
 
     ws.on('message', _echo)
-    ws.on('skill.converse.request', handle_converse_request)
-    # Startup will be called after websocket is full live
+    # Startup will be called after websocket is fully live
     ws.once('open', _starting_up)
     ws.run_forever()
 
@@ -406,17 +413,11 @@ if __name__ == "__main__":
     except KeyboardInterrupt:
         if event_scheduler:
             event_scheduler.shutdown()
-        # Do a clean shutdown of all skills and terminate all running threads
-        for skill in loaded_skills:
-            try:
-                loaded_skills[skill]['instance'].shutdown()
-            except:
-                pass
-        if skills_manager_timer:
-            skills_manager_timer.cancel()
-        if skill_reload_thread:
-            skill_reload_thread.stop()
-            skill_reload_thread.join()
+
+        # Terminate all running threads that update skills
+        if skill_manager:
+            skill_manager.stop()
+            skill_manager.join()
 
     finally:
         sys.exit()

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -141,7 +141,7 @@ def _get_last_modified_date(path):
 
 
 class SkillManager(Thread):
-    """ Load, update and manage instances of Skill on this system """
+    """ Load, update and manage instances of Skill on this system. """
 
     def __init__(self, ws):
         super(SkillManager, self).__init__()
@@ -174,15 +174,18 @@ class SkillManager(Thread):
         self.__msm_lock = Lock()
 
     def schedule_update_skills(self):
+        """ Schedule a skill update to take place directly. """
         # Update skills at next opportunity
         self.next_download = time.time() - 1
 
     def block_msm(self):
+        """ Disallow start of msm. """
         if not self.msm_blocked:
             self.__msm_lock.acquire()
             self.msm_blocked = True
 
     def restore_msm(self):
+        """ Allow start of msm if not allowed. """
         if self.msm_blocked:
             self.__msm_lock.release()
             self.msm_blocked = False
@@ -230,6 +233,10 @@ class SkillManager(Thread):
             LOG.error("Unable to invoke Mycroft Skill Manager: " + MSM_BIN)
 
     def _load_or_reload_skill(self, skill_folder):
+        """
+            Check if unloaded skill or changed skill needs reloading
+            and perform loading if necessary.
+        """
         if skill_folder not in self.loaded_skills:
             self.loaded_skills[skill_folder] = {
                 "id": hash(os.path.join(SKILLS_DIR, skill_folder))
@@ -304,7 +311,7 @@ class SkillManager(Thread):
         while not self._stop_event.is_set():
 
             # Update skills once an hour
-            if (time.time() >= self.next_download):
+            if time.time() >= self.next_download:
                 self.download_skills(False)
 
             # Look for recently changed skill(s) needing a reload
@@ -377,7 +384,7 @@ def main():
     global ws
 
     # Create PID file, prevent multiple instancesof this service
-    lock = mycroft.lock.Lock('skills')
+    mycroft.lock.Lock('skills')
 
     # Connect this Skill management process to the websocket
     ws = WebsocketClient()


### PR DESCRIPTION
Significantly reworked the loading/updating of Skills.  Unified
all management under a single SkillManager class.  This class
runs as a thread that initially loads, upgrades (via MSM)
and reloads skills.

Removed the independent threads that were being run.  The skill
updating still happens once an hour, but works in conjunction
with the scan to reload modified skills.  Also added messagebus
notifications from MSM so mycroft-core can pause reloading
skills until the installation is complete.

Added a new mycroft.messagebus.send module to allow command
line interaction with the messagebus, e.g.:
   python -m mycroft.messagebus.send mycroft.wifi.start
   python -m mycroft.messagebus.send speak '{"utterance":"hello"}'

==== Fixed Issues ====
MSM installs that have PIP dependencies were failing, as the
load would occur after code was retrieved but before PIP install
completed.  Restart was required to load new skills.

====  Tech Notes ====
TODO: Change the way we manage modules.  The auto-load of the
remote configuration for the module is silly, slow and wasteful.

I made the WebsocketClient.build_url() method static in
anticipation of being able to do this more efficiently when the
submodule load doesn't hit the remove API automatically.

==== Localization Notes ====
Modified 'sorry I couldn't install default skills' message.

==== Protocol Notes ====
MSM now generates:
  msm.updating
  msm.installing
  msm.install.succeeded     { "skill" : name }
  msm.install.failed        { "skill" : name, "error" : code }
  msm.installed
  msm.updated
  msm.removing
  msm.remove.succeeded      { "skill" : name }
  msm.remove.failed { "skill" : name, "error" : code }
  msm.removed

An update can now be forced by posting 'skillmanager.update' to the
messagebus.