### PR TITLE
Fix cd syntax to avoid "too many arguments" error.

### DIFF
--- a/scripts/install-pygtk.sh
+++ b/scripts/install-pygtk.sh
@@ -41,7 +41,7 @@ then
     (   cd $CACHE
         curl 'https://www.cairographics.org/releases/py2cairo-1.10.0.tar.bz2' > "py2cairo.tar.bz2"
         tar -xvf py2cairo.tar.bz2
-        (   cd py2cairo*
+        (   cd py2cairo-*
             autoreconf -ivf
             ./configure --prefix=$VIRTUAL_ENV --disable-dependency-tracking
             make -j${CORES}
@@ -63,7 +63,7 @@ then
     (   cd $CACHE
         curl 'http://ftp.gnome.org/pub/GNOME/sources/pygobject/2.28/pygobject-2.28.6.tar.bz2' > 'pygobject.tar.bz2'
         tar -xvf pygobject.tar.bz2
-        (   cd pygobject*
+        (   cd pygobject-*
             ./configure --prefix=$VIRTUAL_ENV --disable-introspection
             make -j${CORES}
             make install


### PR DESCRIPTION
On Arch Linux (and probably other systems too) this creates an error because the wildcards also match the original .tar.gz files. This should fix that.