### PR TITLE
Add timeout to consumer queue get

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 import time
-from Queue import Queue
+from Queue import Queue, Empty
 from threading import Thread
 
 import speech_recognition as sr
@@ -96,9 +96,9 @@ class AudioConsumer(Thread):
             self.read()
 
     def read(self):
-        audio = self.queue.get()
-
-        if audio is None:
+        try:
+            audio = self.queue.get(0.5)
+        except Empty:
             return
 
         if self.state.sleeping:


### PR DESCRIPTION
Prevents hanging on config reload. Otherwise, when a config change is detected, the speech client sets the loop state to stop, but the loop state variable only gets read when the thread returns from the queue and continues in the loop. This adds a timeout so that it will check the loop state variable every 0.5 seconds. I'm curious as to why this just started happening because it looks like the code that caused this has been in there quite a while.

To test:
Before applying branch, try changing a listener config and after a minute asking Mycroft a question. It should not respond. After applying the patch, try changing the config and asking Mycroft a question. It should respond.