### PR TITLE
Prevent the "rolling eye" syndrome - Issue #967

### DIFF
--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -232,7 +232,7 @@ class Enclosure(object):
 
     def __init__(self):
         self.ws = WebsocketClient()
-        self.ws.open("open", self.on_ws_open)
+        self.ws.on("open", self.on_ws_open)
 
         ConfigurationManager.init(self.ws)
         self.config = ConfigurationManager.instance().get("enclosure")

--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -232,12 +232,19 @@ class Enclosure(object):
 
     def __init__(self):
         self.ws = WebsocketClient()
+        self.ws.open("open", self.on_ws_open)
+
         ConfigurationManager.init(self.ws)
         self.config = ConfigurationManager.instance().get("enclosure")
         self.__init_serial()
         self.reader = EnclosureReader(self.serial, self.ws)
         self.writer = EnclosureWriter(self.serial, self.ws)
 
+        # initiates the web sockets on display manager
+        # NOTE: this is a temporary place to initiate display manager sockets
+        initiate_display_manager_ws()
+
+    def on_ws_open(self, event=None):
         # Mark 1 auto-detection:
         #
         # Prepare to receive message when the Arduino responds to the
@@ -252,10 +259,6 @@ class Enclosure(object):
         # 5 seconds, assume there is nothing on the other end (e.g.
         # we aren't running a Mark 1 with an Arduino)
         Timer(5, self.check_for_response).start()
-
-        # initiates the web sockets on display manager
-        # NOTE: this is a temporary place to initiate display manager sockets
-        initiate_display_manager_ws()
 
         # Notifications from mycroft-core
         self.ws.on("enclosure.notify.no_internet", self.on_no_internet)


### PR DESCRIPTION
When (re)booting a Mark 1 unit will show rolling eyes until it reaches
a "ready" state.  This happens by sending a command to the Arduino.
There is also code that prevents sending commands our the serial port
if not running on a Mark 1.  In certain situations, the message
indicating that the Mark 1 Arduino was found was posted to the
messagebus before it was fully open.  When this was missed, the system
didn't think it was on a Mark 1 and the command to stop the eyes from
rolling (and for further interactions with the Mark 1 hardware) were
not sent.

The Mark 1 Arduino detection is now triggered when the messagebus
'open' notification is generated rather than when the object is
constructed.

==== Fixed Issues ====
#967 - Eyes never stop spinning on startup (Mark 1)