### PR TITLE
Return if audio is None in listener

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -101,6 +101,9 @@ class AudioConsumer(Thread):
         except Empty:
             return
 
+        if audio is None:
+            return
+
         if self.state.sleeping:
             self.wake_up(audio)
         else:


### PR DESCRIPTION
This is necessary because if the listener receives a stop signal, it returns `None`.