### PR TITLE
Bugfix/stop speaking

### DIFF
--- a/mycroft/audio/__init__.py
+++ b/mycroft/audio/__init__.py
@@ -39,17 +39,12 @@ def wait_while_speaking():
         time.sleep(0.1)
 
 
-def stop_speaking(ws=None):
-    from mycroft.messagebus.client.ws import WebsocketClient
-    from mycroft.messagebus.message import Message
-
-    if ws is None:
-        ws = WebsocketClient()
+def stop_speaking():
     # TODO: Less hacky approach to this once Audio Manager is implemented
     # Skills should only be able to stop speech they've initiated
-
+    from mycroft.messagebus.send import send
     create_signal('stoppingTTS')
-    ws.emit(Message('mycroft.audio.speech.stop'))
+    send('mycroft.audio.speech.stop')
 
     # Block until stopped
     while check_for_signal("isSpeaking", -1):

--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -19,7 +19,7 @@ from threading import Lock
 
 from mycroft.configuration import ConfigurationManager
 from mycroft.tts import TTSFactory
-from mycroft.util import create_signal, stop_speaking, check_for_signal
+from mycroft.util import create_signal, check_for_signal
 from mycroft.util.log import LOG
 
 ws = None
@@ -111,9 +111,10 @@ def handle_stop(event):
         handle stop message
     """
     global _last_stop_signal
-    _last_stop_signal = time.time()
-    tts.playback.clear_queue()
-    tts.playback.clear_visimes()
+    if check_for_signal("isSpeaking", -1):
+        _last_stop_signal = time.time()
+        tts.playback.clear_queue()
+        tts.playback.clear_visimes()
 
 
 def init(websocket):

--- a/mycroft/messagebus/send.py
+++ b/mycroft/messagebus/send.py
@@ -19,38 +19,65 @@ from mycroft.messagebus.message import Message
 from mycroft.configuration import ConfigurationManager
 from websocket import create_connection
 
-# Parse the command line
-if len(sys.argv) == 2:
-    messageToSend = sys.argv[1]
-    dataToSend = {}
-elif len(sys.argv) == 3:
-    messageToSend = sys.argv[1]
-    try:
-        dataToSend = json.loads(sys.argv[2])
-    except BaseException:
-        print "Second argument must be a JSON string"
+
+def main():
+    """
+        Main function, will run if executed from command line.
+
+        Sends parameters from commandline.
+
+        Param 1:    message string
+        Param 2:    data (json string)
+    """
+    # Parse the command line
+    if len(sys.argv) == 2:
+        messageToSend = sys.argv[1]
+        dataToSend = {}
+    elif len(sys.argv) == 3:
+        messageToSend = sys.argv[1]
+        try:
+            dataToSend = json.loads(sys.argv[2])
+        except BaseException:
+            print "Second argument must be a JSON string"
+            print "Ex: python -m mycroft.messagebus.send speak " \
+                "'{\"utterance\" : \"hello\"}'"
+            exit()
+    else:
+        print "Command line interface to the mycroft-core messagebus."
+        print "Usage: python -m mycroft.messagebus.send message"
+        print "       python -m mycroft.messagebus.send message JSON-string\n"
+        print "Examples: python -m mycroft.messagebus.send mycroft.wifi.start"
         print "Ex: python -m mycroft.messagebus.send speak " \
             "'{\"utterance\" : \"hello\"}'"
         exit()
-else:
-    print "Command line interface to the mycroft-core messagebus."
-    print "Usage:    python -m mycroft.messagebus.send message"
-    print "          python -m mycroft.messagebus.send message JSON-string\n"
-    print "Examples: python -m mycroft.messagebus.send mycroft.wifi.start"
-    print "Ex: python -m mycroft.messagebus.send speak " \
-        "'{\"utterance\" : \"hello\"}'"
-    exit()
+
+    send(messageToSend, dataToSend)
 
 
-# Calculate the standard Mycroft messagebus websocket address
-config = ConfigurationManager.get().get("websocket")
-url = WebsocketClient.build_url(config.get("host"),
-                                config.get("port"),
-                                config.get("route"),
-                                config.get("ssl"))
+def send(messageToSend, dataToSend=None):
+    """
+        Send a single message over the websocket.
 
-# Send the provided message/data
-ws = create_connection(url)
-packet = Message(messageToSend, dataToSend).serialize()
-ws.send(packet)
-ws.close()
+        Args:
+            messageToSend (str):    Message to send
+            dataToSend (dict):      data structure to go along with the
+                                    message, defaults to empty dict.
+    """
+    dataToSend = dataToSend or {}
+
+    # Calculate the standard Mycroft messagebus websocket address
+    config = ConfigurationManager.get().get("websocket")
+    url = WebsocketClient.build_url(config.get("host"),
+                                    config.get("port"),
+                                    config.get("route"),
+                                    config.get("ssl"))
+
+    # Send the provided message/data
+    ws = create_connection(url)
+    packet = Message(messageToSend, dataToSend).serialize()
+    ws.send(packet)
+    ws.close()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Apparently I couldn't get this feature right if my life depended on it.

==== Tech Notes ====
Previous approach did not work as websocket client was not running, this
uses the standalone send functionality recently added to send a single
message.
Also fixes a bug prevening next message from being spoken if stop speaking is sent before speech starts.