### PR TITLE
Fall back to default wake word on invalid config

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -57,7 +57,7 @@ class PocketsphinxHotWord(HotWordEngine):
         self.num_phonemes = len(self.phonemes.split())
         self.threshold = self.config.get("threshold", 1e-90)
         self.sample_rate = self.listener_config.get("sample_rate", 1600)
-        dict_name = self.create_dict(key_phrase, self.phonemes)
+        dict_name = self.create_dict(self.key_phrase, self.phonemes)
         config = self.create_config(dict_name, Decoder.default_config())
         self.decoder = Decoder(config)
 
@@ -137,4 +137,10 @@ class HotWordFactory(object):
         module = config.get(hotword).get("module", "pocketsphinx")
         config = config.get(hotword, {"module": module})
         clazz = HotWordFactory.CLASSES.get(module)
-        return clazz(hotword, config, lang=lang)
+        try:
+            return clazz(hotword, config, lang=lang)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            LOG.exception('Could not create hotword. Falling back to default.')
+            return HotWordFactory.CLASSES['pocketsphinx']()

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -159,7 +159,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         self.config = ConfigurationManager.instance()
         listener_config = self.config.get('listener')
         self.upload_config = listener_config.get('wake_word_upload')
-        self.wake_word_name = listener_config['wake_word']
+        self.wake_word_name = wake_word_recognizer.key_phrase
         # The maximum audio in seconds to keep for transcribing a phrase
         # The wake word must fit in this time
         num_phonemes = wake_word_recognizer.num_phonemes


### PR DESCRIPTION
Also format to lowercase to prevent decoder error if wake word has capitals

### Testing procedure
```bash
./start-mycroft.sh all && tail -f scripts/logs/mycroft-voice.log
#  - Create invalid config in home.mycroft.ai (set phonemes to something like "ZZZ")
#  - "hey mycroft, update config"
# You should see an exception in the logs and it should no longer respond
#  - Ctrl+C

git fetch
git checkout feature/robust-listener
./start-mycroft.sh all && tail -f scripts/logs/mycroft-voice.log
# You should still see exceptions in the logs, but it should still respond
#  - Reset hom.mycroft.ai to valid config
#  - "hey mycroft, update config"
# You should no longer see an exception in the logs and it should still respond
```