### PR TITLE
Fix enclosure client broken by #1110

### DIFF
--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -319,7 +319,7 @@ class Enclosure(object):
             LOG.info("Connected to: %s rate: %s timeout: %s" %
                      (self.port, self.rate, self.timeout))
         except:
-            LOG.error("Impossible to connect to serial port: " + self.port)
+            LOG.error("Impossible to connect to serial port: " + str(self.port))
             raise
 
     def __register_events(self):

--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -319,7 +319,7 @@ class Enclosure(object):
             LOG.info("Connected to: %s rate: %s timeout: %s" %
                      (self.port, self.rate, self.timeout))
         except:
-            LOG.error("Impossible to connect to serial port: " + str(self.port))
+            LOG.error("Impossible to connect to serial port: "+str(self.port))
             raise
 
     def __register_events(self):

--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -238,7 +238,7 @@ class Enclosure(object):
         self.ws.on("open", self.on_ws_open)
 
         Configuration.init(self.ws)
-        self.config = Configuration.get("enclosure")
+        self.config = Configuration.get().get("enclosure")
 
         self.__init_serial()
         self.reader = EnclosureReader(self.serial, self.ws)


### PR DESCRIPTION
Syntax error, needed Configuration.get().get("enclosure")
instead of just Configuration.get("enclosure")