### PR TITLE
Fixes for startup when not paired

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -204,7 +204,11 @@ class DeviceApi(Api):
             status of subscription. True if device is connected to a paying
             subscriber.
         """
-        return self.get_subscription().get('@type') != 'free'
+        try:
+            return self.get_subscription().get('@type') != 'free'
+        except:
+            # If can't retrieve, assume not paired and not a subscriber yet
+            return False
 
     def get_subscriber_voice_url(self, voice=None):
         self.check_token()

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -16,6 +16,7 @@ import inflection
 import re
 import json
 from os.path import exists, isfile, join, dirname, expanduser
+from requests import HTTPError
 
 from mycroft.util.json_helper import load_commented_json
 from mycroft.util.log import LOG
@@ -148,6 +149,11 @@ class RemoteConf(LocalConf):
             for key in config:
                 self.__setitem__(key, config[key])
             self.store(cache)
+
+        except HTTPError as e:
+            LOG.error("HTTPError fetching remote configuration: %s" %
+                      e.response.status_code)
+            self.load_local(cache)
 
         except Exception as e:
             LOG.error("Failed to fetch remote configuration: %s" % repr(e),


### PR DESCRIPTION
Several attempts to connect to the backend fail before pairing has
been completed, which was producing errors that prevented the
messagebus and audio services from starting up.

Now the DeviceApi().is_subscriber property returns False if the
check fails, assuming unpaired == not subscribed.

Also stopped logging the call stack on the HTTPError exception, it
made an expected situation look like a major crash.