### PR TITLE
Cleanup of CLI filters and logged messages

### DIFF
--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -66,7 +66,6 @@ class EnclosureReader(Thread):
                 data = self.serial.readline()[:-2]
                 if data:
                     self.process(data)
-                    LOG.info("Reading: " + data)
             except Exception as e:
                 LOG.error("Reading error: {0}".format(e))
 
@@ -205,7 +204,6 @@ class EnclosureWriter(Thread):
             try:
                 cmd = self.commands.get()
                 self.serial.write(cmd + '\n')
-                LOG.info("Writing: " + cmd)
                 self.commands.task_done()
             except Exception as e:
                 LOG.error("Writing error: {0}".format(e))

--- a/mycroft/client/enclosure/display_manager.py
+++ b/mycroft/client/enclosure/display_manager.py
@@ -98,7 +98,6 @@ def set_active(skill_name):
             string: skill_name
     """
     _write_data({"active_skill": skill_name})
-    LOG.debug("Setting active skill to " + skill_name)
 
 
 def get_active():
@@ -123,7 +122,7 @@ def remove_active():
 def initiate_display_manager_ws():
     """ Initiates the web sockets on the display_manager
     """
-    LOG.info("Initiating dispaly manager websocket")
+    LOG.info("Initiating display manager websocket")
 
     # Should remove needs to be an object so it can be referenced in functions
     # [https://stackoverflow.com/questions/986006/how-do-i-pass-a-variable-by-reference]

--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -51,7 +51,7 @@ auto_scroll = True
 
 mergedLog = []
 filteredLog = []
-default_log_filters = ["mouth.viseme"]
+default_log_filters = ["mouth.viseme", "mouth.display", "mouth.icon"]
 log_filters = list(default_log_filters)
 log_files = []
 find_str = None
@@ -691,7 +691,7 @@ def handle_cmd(cmd):
             log_filters = list(default_log_filters)
         else:
             # extract last word(s)
-            param = get_cmd_param(cmd)
+            param = _get_cmd_param(cmd)
 
             if "remove" in cmd and param in log_filters:
                 log_filters.remove(param)


### PR DESCRIPTION
This cleans up the amount of noise in the logs:
* Removed logging of the serial port raw read/writes.
* Removed the "Setting active skill" log in display_manager.py
* Corrected typo "dispaly"
* Added default CLI filter for mouth.display and mouth.icon messages
* Fixed bug when adding new filters