### PR TITLE
Remove Location as a default context word

### DIFF
--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -125,7 +125,7 @@ class IntentService(object):
     def __init__(self, emitter):
         self.config = Configuration.get().get('context', {})
         self.engine = IntentDeterminationEngine()
-        self.context_keywords = self.config.get('keywords', ['Location'])
+        self.context_keywords = self.config.get('keywords', [])
         self.context_max_frames = self.config.get('max_frames', 3)
         self.context_timeout = self.config.get('timeout', 2)
         self.context_greedy = self.config.get('greedy', False)


### PR DESCRIPTION
====  Tech Notes ====
Location was added as a default context keyword when the context manager
was added as an example of how the context feature could be used.
However in the current greedy implementation in can cause some confusion
with lingering context providing incorrect Location.

The feature can still be turned on in configuration if someone wants to
experiment with it.