### PR TITLE
Fix no-internet prompt

### DIFF
--- a/mycroft/res/text/en-us/no network connection.dialog
+++ b/mycroft/res/text/en-us/no network connection.dialog
@@ -1,3 +1,0 @@
-I don't seem to be connected to the internet
-I can't reach the internt right now
-Unable to connect to the internet

--- a/mycroft/res/text/fr-fr/no network connection.dialog
+++ b/mycroft/res/text/fr-fr/no network connection.dialog
@@ -1,3 +1,0 @@
-Je ne semble pas être connecté à internet
-Je n'arrive pas à me connecter à internet actuellement
-Impossible de se connecter à internet

--- a/mycroft/res/text/nl-nl/no network connection.dialog
+++ b/mycroft/res/text/nl-nl/no network connection.dialog
@@ -1,3 +1,0 @@
-Ik schijn niet verbonden te zijn met het internet
-Ik kan het internet nu niet bereiken
-Het is onmogelijk met het internet te verbinden

--- a/mycroft/res/text/pt-pt/no network connection.dialog
+++ b/mycroft/res/text/pt-pt/no network connection.dialog
@@ -1,3 +1,0 @@
-Penso não estar ligado à internet
-Não estou a conseguir ligar-me à internet
-Não foi possivel ligar-me à internet

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -219,24 +219,25 @@ class SkillManager(Thread):
                     self.next_download = time.time() + 60 * MINUTES
 
                     if res == 0 and speak:
-                        self.ws.emit(Message("speak", {
-                            'utterance': mycroft.dialog.get("skills updated")})
-                            )
+                        self.ws.emit(Message("speak", {'utterance':
+                                     mycroft.dialog.get("skills updated")}))
                     return True
                 elif not connected():
                     LOG.error('msm failed, network connection not available')
-                    self.ws.emit(Message("speak", {
-                        'utterance':
-                            mycroft.dialog.get("no network connection")}))
+                    if speak:
+                        self.ws.emit(Message("speak", {
+                            'utterance': mycroft.dialog.get(
+                                "not connected to the internet")}))
                     self.next_download = time.time() + 5 * MINUTES
                     return False
                 elif res != 0:
                     LOG.error(
                         'msm failed with error {}: {}'.format(
                             res, output))
-                    self.ws.emit(Message("speak", {
-                        'utterance': mycroft.dialog.get(
-                            "sorry I couldn't install default skills")}))
+                    if speak:
+                        self.ws.emit(Message("speak", {
+                            'utterance': mycroft.dialog.get(
+                                "sorry I couldn't install default skills")}))
                     self.next_download = time.time() + 5 * MINUTES
                     return False
             finally:


### PR DESCRIPTION
The prompt during skill downloads was occurring even when the "speak" flag was
set to False.  Now it is honored.

Also removed the "no network connection.dialog" which essentially was a copy of
the "not connected to the internet.dialog" file.