### PR TITLE
Inform user about skill installation at first start

### DIFF
--- a/mycroft/res/text/en-us/installing default skills.dialog
+++ b/mycroft/res/text/en-us/installing default skills.dialog
@@ -1,0 +1,1 @@
+Please wait while default skills are installed

--- a/mycroft/res/text/en-us/skills updated.dialog
+++ b/mycroft/res/text/en-us/skills updated.dialog
@@ -1,2 +1,2 @@
 I'm up to date now
-Skills Updated.  I'm ready to help you.
+Skills Updated.

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -364,7 +364,7 @@ class SkillManager(Thread):
             # Pause briefly before beginning next scan
             time.sleep(2)
 
-            if not self._loaded_once.is_set():
+            if not self._loaded_once.is_set() and len(self.loaded_skills) > 0:
                 self._loaded_once.set()
 
         # Do a clean shutdown of all skills

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -166,6 +166,7 @@ class SkillManager(Thread):
         self.next_download = time.time() - 1    # download ASAP
         self.loaded_skills = {}
         self.msm_blocked = False
+        self.download_attempts = 0
         self.ws = ws
 
         # Conversation management
@@ -343,7 +344,9 @@ class SkillManager(Thread):
         while not self._stop_event.is_set():
             # Update skills once an hour
             if time.time() >= self.next_download:
-                self.download_skills(first_run())
+                should_speak = first_run() and self.download_attempts == 0
+                self.download_skills(should_speak)
+                self.download_attempts += 1
 
             # Look for recently changed skill(s) needing a reload
             if exists(SKILLS_DIR):


### PR DESCRIPTION
I haven't had time to test this thoroughly, seems to be ok from the 5 tests I've run but should be tested further before merge.

If no skills are present don't immediately try to start pairing, instead inform user that the skills will be installed and launch pairing after that.