### PR TITLE
Added remove_event skills/core.py

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -388,10 +388,10 @@ class MycroftSkill(object):
             Args:
                 name: Name Intent
         """
-        for e, f in self.events:
-            if name in e:
-                self.events.remove((e, f))
-                self.emitter.remove(e, f)
+        for _name, _handler in self.events:
+            if name == _name:
+                self.events.remove((_name, _handler))
+                self.emitter.remove(_name, _handler)
 
     def register_intent(self, intent_parser, handler, need_self=False):
         """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -381,6 +381,18 @@ class MycroftSkill(object):
             self.emitter.on(name, wrapper)
             self.events.append((name, wrapper))
 
+    def remove_event(self, name):
+        """
+            Removes an event from emitter and events list
+
+            Args:
+                name: Name Intent
+        """
+        for e, f in self.events:
+            if name in e:
+                self.events.remove((e, f))
+                self.emitter.remove(e, f)
+
     def register_intent(self, intent_parser, handler, need_self=False):
         """
             Register an Intent with the intent service.
@@ -700,6 +712,7 @@ class MycroftSkill(object):
                 name (str):   Name of event
         """
         data = {'event': self._unique_name(name)}
+        self.remove_event(name)
         self.emitter.emit(Message('mycroft.scheduler.remove_event', data=data))
 
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -711,8 +711,9 @@ class MycroftSkill(object):
             Args:
                 name (str):   Name of event
         """
-        data = {'event': self._unique_name(name)}
-        self.remove_event(name)
+        unique_name = self._unique_name(name)
+        data = {'event': unique_name}
+        self.remove_event(unique_name)
         self.emitter.emit(Message('mycroft.scheduler.remove_event', data=data))
 
 


### PR DESCRIPTION
====  Tech Notes ====
This allows you to remove message bus messages inside core.py. When canceling scheduling events, the message bus messages were not removed which could caused duplicate listeners and handlers for the same intent. Adding remove_event function removes the actual messages from the bus to prevent potential duplicates.