### PR TITLE
Feature/status event scheduler

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -388,10 +388,10 @@ class MycroftSkill(object):
             Args:
                 name: Name Intent
         """
-        for e, f in self.events:
-            if name in e:
-                self.events.remove((e, f))
-                self.emitter.remove(e, f)
+        for _name, _handler in self.events:
+            if name == _name:
+                self.events.remove((_name, _handler))
+                self.emitter.remove(_name, _handler)
 
     def register_intent(self, intent_parser, handler, need_self=False):
         """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -381,6 +381,18 @@ class MycroftSkill(object):
             self.emitter.on(name, wrapper)
             self.events.append((name, wrapper))
 
+    def remove_event(self, name):
+        """
+            Removes an event from emitter and events list
+
+            Args:
+                name: Name Intent
+        """
+        for e, f in self.events:
+            if name in e:
+                self.events.remove((e, f))
+                self.emitter.remove(e, f)
+
     def register_intent(self, intent_parser, handler, need_self=False):
         """
             Register an Intent with the intent service.
@@ -700,6 +712,7 @@ class MycroftSkill(object):
                 name (str):   Name of event
         """
         data = {'event': self._unique_name(name)}
+        self.remove_event(name)
         self.emitter.emit(Message('mycroft.scheduler.remove_event', data=data))
 
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -16,7 +16,6 @@ import imp
 import operator
 import sys
 import time
-import datetime
 from functools import wraps
 from inspect import getargspec
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -711,8 +711,9 @@ class MycroftSkill(object):
             Args:
                 name (str):   Name of event
         """
-        data = {'event': self._unique_name(name)}
-        self.remove_event(name)
+        unique_name = self._unique_name(name)
+        data = {'event': unique_name}
+        self.remove_event(unique_name)
         self.emitter.emit(Message('mycroft.scheduler.remove_event', data=data))
 
 

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -42,6 +42,8 @@ class EventScheduler(Thread):
                         self.remove_event_handler)
         self.emitter.on('mycroft.scheduler.update_event',
                         self.update_event_handler)
+        self.emitter.on('mycroft.scheduler.get_event',
+                        self.get_event_handler)
         self.start()
 
     def load(self):
@@ -165,6 +167,15 @@ class EventScheduler(Thread):
         event = message.data.get('event')
         data = message.data.get('data')
         self.update_event(event, data)
+
+    def get_event_handler(self, message):
+        """ Messagebus interface to get_event method. """
+        event_name = message.data.get("name")
+        event = None
+        if event_name in self.events:
+            event = self.events[event_name]
+        emitter_name = 'mycroft.event_status.callback.{}'.format(event_name)
+        self.emitter.emit(Message(emitter_name, data=event))
 
     def store(self):
         """

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -169,7 +169,10 @@ class EventScheduler(Thread):
         self.update_event(event, data)
 
     def get_event_handler(self, message):
-        """ Messagebus interface to get_event method. """
+        """
+            Messagebus interface to get_event.
+            Emits another event sending event status
+        """
         event_name = message.data.get("name")
         event = None
         if event_name in self.events:


### PR DESCRIPTION
This PR gives an api for skill developers to query event status from the event scheduler

```
(_datetime, time_left) = self.get_event_status(name_of_scheduled_event)

#_datetime is the datetime object that the event will go off
# time_left is the seconds left in epoch time till the event go off
```