### PR TITLE
Precise Wake Word Listener

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -195,10 +195,7 @@ class PreciseHotword(HotWordEngine):
                 self.cooldown -= 1
                 self.has_found = False
                 continue
-            if float(line) > 0.5:
-                self.has_found = True
-            else:
-                self.has_found = False
+            self.has_found = float(line) > 0.5
 
     def update(self, chunk):
         self.proc.stdin.write(chunk)

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -144,6 +144,10 @@ class PreciseHotword(HotWordEngine):
         except OSError:
             pass
 
+        exe_file = expanduser('~/.mycroft/precise/' + self.exe_name)
+        if isfile(exe_file):
+            return exe_file
+
         import platform
         import stat
 
@@ -152,7 +156,7 @@ class PreciseHotword(HotWordEngine):
             Popen('echo "' + cmd + '" > /dev/ttyAMA0', shell=True)
 
         arch = platform.machine()
-        exe_file = expanduser('~/.mycroft/precise/' + self.exe_name)
+
         url = self.url_base + 'dist/' + arch + '/' + self.exe_name
 
         snd_msg('mouth.text=Updating Listener...')

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -111,8 +111,10 @@ class PreciseHotword(HotWordEngine):
     def __init__(self, key_phrase="hey mycroft", config=None, lang="en-us"):
         super(PreciseHotword, self).__init__(key_phrase, config, lang)
         self.update_freq = 24  # in hours
-        self.url_base = ('https://raw.githubusercontent.com/'
-                         'MycroftAI/precise-data/')
+
+        precise_config = Configuration.get()['precise']
+        self.dist_url = precise_config['dist_url']
+        self.models_url = precise_config['models_url']
         self.exe_name = 'precise-stream'
 
         ww = Configuration.get()['listener']['wake_word']
@@ -157,7 +159,7 @@ class PreciseHotword(HotWordEngine):
 
         arch = platform.machine()
 
-        url = self.url_base + 'dist/' + arch + '/' + self.exe_name
+        url = self.dist_url + arch + '/' + self.exe_name
 
         snd_msg('mouth.text=Updating Listener...')
         self.download(url, exe_file)
@@ -182,7 +184,7 @@ class PreciseHotword(HotWordEngine):
             if get_time() - stat.st_mtime < self.update_freq * 60 * 60:
                 return
         name = name.replace(' ', '%20')
-        url = self.url_base + 'models/' + name
+        url = self.models_url + name
         self.download(url, file_name)
         self.download(url + '.params', file_name + '.params')
 

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -420,6 +420,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                 byte_data = byte_data[len(chunk):] + chunk
 
             buffers_since_check += 1.0
+            self.wake_word_recognizer.update(chunk)
             if buffers_since_check > buffers_per_check:
                 buffers_since_check -= buffers_per_check
                 chopped = byte_data[-test_size:] \

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -437,12 +437,15 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                         mkdir(self.save_wake_words_dir)
                     dr = self.save_wake_words_dir
 
+                    ww_module = self.wake_word_recognizer.__class__.__name__
+
                     ww = self.wake_word_name.replace(' ', '-')
+                    md = str(abs(hash(ww_module)))
                     stamp = str(int(1000 * get_time()))
                     sid = SessionManager.get().session_id
                     uid = IdentityManager.get().uuid
 
-                    fn = join(dr, '.'.join([ww, stamp, sid, uid]) + '.wav')
+                    fn = join(dr, '.'.join([ww, md, stamp, sid, uid]) + '.wav')
                     with open(fn, 'wb') as f:
                         f.write(audio.get_wav_data())
 

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -133,6 +133,13 @@
     "stand_up_word": "wake up"
   },
 
+  // Settings used for any precise wake words
+  // Override: none
+  "precise": {
+    "dist_url": "https://raw.githubusercontent.com/MycroftAI/precise-data/dist/",
+    "models_url": "https://raw.githubusercontent.com/MycroftAI/precise-data/models/"
+  },
+
   // Hotword configurations
   "hotwords": {
     "hey mycroft": {


### PR DESCRIPTION
This adds precise as an optional wake word listener instead of Pocketsphinx. For testing, it has been made default by modifying the config with `{"hotwords": {"hey mycroft": {"module": "precise"}}}`. Once this has been tested, I can remove the `Make Precise default` commit before a merge.

Notes on testing: It downloads a 70 MB file the first time it runs. On the unit, this will be a 30MB file and it will notify the user with text on the screen. During this initial download period, Mycroft will not respond to the wake word.