### PR TITLE
Minor improvements to the msm tool

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -506,7 +506,12 @@ function print_info() {
         fi
     fi
     
-    local baseUrl=$(echo "${repo}/master/" | sed -e 's/github.com/raw.githubusercontent.com/g')
+    local baseUrl=$(echo "${repo}" | sed -e 's/github.com/raw.githubusercontent.com/g' | sed -e 's/\.git$//g')/master
+    ### debugging output:
+    # echo git line is: "$git_line"
+    # echo repo line is: "$repo_line"
+    # echo repo is: "$repo"
+    # echo base url is "$baseUrl"
     local readmeUrl="$baseUrl/readme.md"
     local stat="$(curl -I -s $readmeUrl | sed -n '1p')"
     local readme=""
@@ -687,6 +692,7 @@ case ${OPT} in
       rc=$?
       if [[ ${rc} -gt 0 ]] ; then
           if [[ ${rc} -gt ${exit_code} ]] ; then
+              echo "${script}: error ${exit_code}"
               exit_code=${rc}
           fi
       fi

--- a/msm/msm
+++ b/msm/msm
@@ -460,6 +460,77 @@ function update() {
   done
 }
 
+function print_info() {
+    str=$*
+    if [[ "${str}" == "git@"* || "${str}" == "https://"* || "${str}" == "http://"* ]]; then
+        # Repo was given
+        repo="${str}"
+    else
+        # Search for the given word(s) as the submodule
+        skills=$(echo "${LIST_CACHE}" | grep -n 'submodule' | sed 's/[[:space:]]//g' | sed 's/\[submodule"//g' | sed 's/"\]//g')
+
+        # Test for exact name match
+        exact_match=$(echo "$skills" | grep -i ".*:${str}$")
+        if [[ ! -z "${exact_match}" ]]; then
+            # Found a perfect match!
+            skill=${exact_match}
+        else
+            # Test for match of all supplied words/subwords
+            skill=$(echo "$skills")  # start with all skills
+            for s in ${str}
+            do
+                # whittle list down with each word in the search string
+                skill=$(echo "$skill" | grep -i ".*:.*${s}.*")
+            done
+        fi
+
+        git_line=$(echo "$skill" | sed 's/\:.*//')
+
+        if [[ "${skill}" ==  *$'\n'* ]]; then
+            # The str matches multiple skill repos, don't install
+            # due to ambiguity.
+            echo "Multiple matches for '${str}', be more specfic."
+            echo "------------------------------------------------------------"
+            echo "$skill" | sed 's/.*://g' | sort
+            echo "------------------------------------------------------------"
+            return 201
+        else
+            if [[ -z "${git_line}" ]]; then
+                echo "'${str}' skill was not found"
+            return 202
+            fi
+            repo_line=$(($git_line + 2))
+            repo=$(echo "${LIST_CACHE}" | sed -n $repo_line'{p;q;}' | sed 's/[[:space:]]//g' | sed 's/[[:space:]]//g' | sed 's/url=//g')
+        fi
+    fi
+    
+    local baseUrl=$(echo "${repo}/master/" | sed -e 's/github.com/raw.githubusercontent.com/g')
+    local readmeUrl="$baseUrl/readme.md"
+    local stat="$(curl -I -s $readmeUrl | sed -n '1p')"
+    local readme=""
+    if [[ $stat == *"200"* ]] ; then
+        readme="$(curl -s $readmeUrl)"
+    else
+        readmeUrl="$baseUrl/Readme.md"
+        stat=$(curl -I -s ${readmeUrl} | sed -n '1p')
+        if [[ $stat == *"200"* ]] ; then
+            readme="$(curl -s $readmeUrl)"
+        else
+            readmeUrl="$baseUrl/README.md"
+            stat=$(curl -I -s ${readmeUrl} | sed -n '1p')
+            if [[ $stat == *"200"* ]] ; then
+                readme="$(curl -s $readmeUrl)"
+            else
+                exit 404
+            fi
+        fi
+    fi
+
+    echo "$readme"
+    exit 0
+    
+}
+
 OPT=$1
 shift
 
@@ -602,6 +673,22 @@ case ${OPT} in
          help
          exit_code=1
       fi
+      ;;
+  "info")
+      get_skill_list
+      exit_code=$?
+      if [[ ${exit_code} -gt 0 ]] ; then
+          echo "${script}: error ${exit_code}"
+          exit ${exit_code}
+      fi
+      print_info $1
+      rc=$?
+      if [[ ${rc} -gt 0 ]] ; then
+          if [[ ${rc} -gt ${exit_code} ]] ; then
+              exit_code=${rc}
+          fi
+      fi
+      exit_code=0
       ;;
   *)
       help

--- a/msm/msm
+++ b/msm/msm
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+RED='\033[0;31m'
+NOCOLOR='\033[0m'
+GREEN='\033[0;32m'
+
+
 script=${0}
 script=${script##*/}
 
@@ -610,9 +615,9 @@ case ${OPT} in
       while read -r submod
       do
           if [[ -d "$mycroft_skill_folder/$submod" ]] ; then
-              echo "$submod [installed]"
+              printf "$submod ${RED}[${GREEN}installed${RED}]${NOCOLOR}\n\r"
           else
-              echo "$submod"
+              printf "$submod\n\r"
           fi
       done <<< "$submodules"
       exit_code=$?

--- a/msm/msm
+++ b/msm/msm
@@ -528,7 +528,8 @@ function print_info() {
             if [[ $stat == *"200"* ]] ; then
                 readme="$(curl -s $readmeUrl)"
             else
-                exit 404
+                echo "Didn't find any information to display."
+                exit 0
             fi
         fi
     fi

--- a/msm/msm
+++ b/msm/msm
@@ -29,6 +29,8 @@ function help() {
   echo "  list                     list all mycroft-skills"
   echo "  update                   update all installed skills"
   echo "  search <name>            search mycroft-skills for match for <name>"
+  echo "  info <name>              shows information about the skill matching <name>"
+  echo "  info <repo>              shows information about the skill in the specified repo"
   echo
   echo "Params:"
   echo "  <repo>   full URL to a Github repo"

--- a/msm/msm
+++ b/msm/msm
@@ -526,7 +526,16 @@ case ${OPT} in
           echo "${script}: error ${exit_code}"
           exit ${exit_code}
       fi
-      echo "${LIST_CACHE}" | grep 'submodule "' | sed 's/\[submodule "//g'| sed 's/"\]//g' | sort
+
+      submodules=$(echo "${LIST_CACHE}" | grep 'submodule "' | sed 's/\[submodule "//g'| sed 's/"\]//g' | sort)
+      while read -r submod
+      do
+          if [[ -d "$mycroft_skill_folder/$submod" ]] ; then
+              echo "$submod [installed]"
+          else
+              echo "$submod"
+          fi
+      done <<< "$submodules"
       exit_code=$?
       ;;
   "update")


### PR DESCRIPTION
This pull requests adds two improvements to the msm command line tool.

1) `msm list` will now show which skills are already installed (issue #1202)

2) A new `msm info <skill>` command has been added, with <skill> either being a distinct substring of a skill's name or the skill's github repository's url. It will display the readme.md from the repository in the terminal (if found). (issue #1203)