### PR TITLE
Move session config from global scope

### DIFF
--- a/mycroft/session/__init__.py
+++ b/mycroft/session/__init__.py
@@ -19,8 +19,6 @@ from uuid import uuid4
 from mycroft.configuration import Configuration
 from mycroft.util.log import LOG
 
-config = Configuration.get().get('session')
-
 
 class Session(object):
     """
@@ -66,6 +64,8 @@ class SessionManager(object):
 
         :return: An active session
         """
+        config = Configuration.get().get('session')
+
         with SessionManager.__lock:
             if (not SessionManager.__current_session or
                     SessionManager.__current_session.expired()):


### PR DESCRIPTION
====  Tech Notes ====
As soon as mycroft, mycroft.api or mycroft.skills.core were imported the
configuration was loaded (including reaching out to the web config).
This will reduce unneccessary configuration loadings and make it easier
to handle configuration in the tests.