### PR TITLE
Feature/keep transcriptions

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -29,6 +29,7 @@ from mycroft.metrics import MetricsAggregator
 from mycroft.session import SessionManager
 from mycroft.stt import STTFactory
 from mycroft.util.log import LOG
+from mycroft.client.speech.transcribe import Transcribe
 
 
 class AudioProducer(Thread):
@@ -163,6 +164,7 @@ class AudioConsumer(Thread):
             }
             self.emitter.emit("recognizer_loop:utterance", payload)
             self.metrics.attr('utterances', [text])
+            Transcribe().write_transcribed_files(audio.frame_data, text)
 
     def __speak(self, utterance):
         payload = {

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -164,7 +164,7 @@ class AudioConsumer(Thread):
             }
             self.emitter.emit("recognizer_loop:utterance", payload)
             self.metrics.attr('utterances', [text])
-            Transcribe().write_transcribed_files(audio.frame_data, text)
+            Transcribe.write_transcribed_files(audio.frame_data, text)
 
     def __speak(self, utterance):
         payload = {

--- a/mycroft/client/speech/transcribe.py
+++ b/mycroft/client/speech/transcribe.py
@@ -10,7 +10,8 @@ import os
 
 __author__ = "reginaneon"
 
-text_permission = check_for_signal('transcribe_text_permission', 0) # starting default is off
+text_permission = check_for_signal(
+    'transcribe_text_permission', 0) # starting default is off
 audio_permission = check_for_signal('keep_audio_permission', 0)
 # text_permission = create_signal('transcribe_text_permission')
 # audio_permission = create_signal('keep_audio_permission')
@@ -53,17 +54,19 @@ class Transcribe:
                 os.makedirs("/var/log/mycroft/ts_transcript_audio_segments/"
                             + globdate)
             except OSError:
-                if not os.path.isdir("/var/log/mycroft/ts_transcript_audio_segments/"
+                if not os.path.isdir("/var/log/mycroft/"
+                                     "ts_transcript_audio_segments/"
                                              + globdate):
                     raise
 
-            filename = "/var/log/mycroft/ts_transcript_audio_segments/" + globdate + \
+            filename = "/var/log/mycroft/ts_transcript_audio_segments/" +\
+                       globdate + \
                        "/" + (globstamp + " " + text).decode("utf8") + " .wav"
 
             self.save_record(filename, audio)
             LOG.info(
-                "Transcribing Permission Granted: The Audio Recording of User's Input Saved in Full Format")
-
+                "Transcribing Permission Granted: The Audio Recording of "
+                "User's Input Saved in Full Format")
 
         else:
             LOG.info("Audio Save Permission Denied")
@@ -76,4 +79,3 @@ class Transcribe:
         waveFile.setframerate(16000)
         waveFile.writeframes(audio)
         waveFile.close()
-

--- a/mycroft/client/speech/transcribe.py
+++ b/mycroft/client/speech/transcribe.py
@@ -35,6 +35,15 @@ class Transcribe:
             # if trans_values.text_permission:
             filename1 = "/var/log/mycroft/ts_transcripts/" + \
                         globdate + ".txt"
+
+            try:
+                os.makedirs("/var/log/mycroft/"
+                            "ts_transcripts/")
+            except OSError:
+                if not os.path.isdir("/var/log/mycroft/"
+                                     "ts_transcripts/"):
+                    raise
+
             with open(filename1, 'a+') as filea:
                 filea.write(globstamp + " " + text + "\n")
                 LOG.info("Transcribing Permission Granted: "

--- a/mycroft/client/speech/transcribe.py
+++ b/mycroft/client/speech/transcribe.py
@@ -1,7 +1,6 @@
 from mycroft.util.log import LOG
 import wave
 from mycroft.util.signal import (
-    create_signal,
     check_for_signal
 )
 import datetime

--- a/mycroft/client/speech/transcribe.py
+++ b/mycroft/client/speech/transcribe.py
@@ -11,7 +11,7 @@ import os
 __author__ = "reginaneon"
 
 text_permission = check_for_signal(
-    'transcribe_text_permission', 0) # starting default is off
+    'transcribe_text_permission', 0)  # starting default is off
 audio_permission = check_for_signal('keep_audio_permission', 0)
 # text_permission = create_signal('transcribe_text_permission')
 # audio_permission = create_signal('keep_audio_permission')
@@ -51,12 +51,13 @@ class Transcribe:
         if check_for_signal('keep_audio_permission', -1):
             LOG.info("Audio Save Permission Granted")
             try:
-                os.makedirs("/var/log/mycroft/ts_transcript_audio_segments/"
-                            + globdate)
+                os.makedirs("/var/log/mycroft/"
+                            "ts_transcript_audio_segments/" +
+                            globdate)
             except OSError:
                 if not os.path.isdir("/var/log/mycroft/"
-                                     "ts_transcript_audio_segments/"
-                                             + globdate):
+                                     "ts_transcript_audio_segments/" +
+                                     globdate):
                     raise
 
             filename = "/var/log/mycroft/ts_transcript_audio_segments/" +\

--- a/mycroft/client/speech/transcribe.py
+++ b/mycroft/client/speech/transcribe.py
@@ -10,8 +10,10 @@ import os
 
 __author__ = "reginaneon"
 
-text_permission = create_signal('transcribe_text_permission')
-audio_permission = create_signal('keep_audio_permission')
+text_permission = check_for_signal('transcribe_text_permission', 0) # starting default is off
+audio_permission = check_for_signal('keep_audio_permission', 0)
+# text_permission = create_signal('transcribe_text_permission')
+# audio_permission = create_signal('keep_audio_permission')
 
 
 class Transcribe:

--- a/mycroft/client/speech/transcribe.py
+++ b/mycroft/client/speech/transcribe.py
@@ -1,0 +1,77 @@
+from mycroft.util.log import LOG
+import wave
+from mycroft.util.signal import (
+    create_signal,
+    check_for_signal
+)
+import datetime
+import os
+
+
+__author__ = "reginaneon"
+
+text_permission = create_signal('transcribe_text_permission')
+audio_permission = create_signal('keep_audio_permission')
+
+
+class Transcribe:
+    """
+    Name: Transcribe
+    Purpose: Writes the transcription file.
+    Imports data to the new, more precise text file, containing
+             the lines needed.
+    """
+
+    def write_transcribed_files(self, audio, text):
+        # save the audio before it is sent off:
+        globstamp = str(datetime.datetime.now())
+        globdate = str(datetime.date.today())
+
+        # check_for_signal('keep_audio_permission', 0)
+
+        if check_for_signal('transcribe_text_permission', -1):
+            # if trans_values.text_permission:
+            filename1 = "/var/log/mycroft/ts_transcripts/" + \
+                        globdate + ".txt"
+            with open(filename1, 'a+') as filea:
+                filea.write(globstamp + " " + text + "\n")
+                LOG.info("Transcribing Permission Granted: "
+                         "Text Input Saved Successfully")
+
+            LOG.info(
+                "Transcribing Permission Granted: "
+                "The Audio Recording of User's Input Saved in Full Format")
+
+        else:
+            LOG.warning("Transcribing Permission Denied")
+
+        if check_for_signal('keep_audio_permission', -1):
+            LOG.info("Audio Save Permission Granted")
+            try:
+                os.makedirs("/var/log/mycroft/ts_transcript_audio_segments/"
+                            + globdate)
+            except OSError:
+                if not os.path.isdir("/var/log/mycroft/ts_transcript_audio_segments/"
+                                             + globdate):
+                    raise
+
+            filename = "/var/log/mycroft/ts_transcript_audio_segments/" + globdate + \
+                       "/" + (globstamp + " " + text).decode("utf8") + " .wav"
+
+            self.save_record(filename, audio)
+            LOG.info(
+                "Transcribing Permission Granted: The Audio Recording of User's Input Saved in Full Format")
+
+
+        else:
+            LOG.info("Audio Save Permission Denied")
+
+    def save_record(self, wav_name, audio):
+        # TODO: use "with"
+        waveFile = wave.open(wav_name, 'wb')
+        waveFile.setnchannels(1)
+        waveFile.setsampwidth(2)
+        waveFile.setframerate(16000)
+        waveFile.writeframes(audio)
+        waveFile.close()
+

--- a/mycroft/client/speech/transcribe.py
+++ b/mycroft/client/speech/transcribe.py
@@ -23,7 +23,7 @@ class Transcribe:
     Imports data to the new, more precise text file, containing
              the lines needed.
     """
-
+    @classmethod
     def write_transcribed_files(self, audio, text):
         # save the audio before it is sent off:
         globstamp = str(datetime.datetime.now())
@@ -49,10 +49,6 @@ class Transcribe:
                 LOG.info("Transcribing Permission Granted: "
                          "Text Input Saved Successfully")
 
-            LOG.info(
-                "Transcribing Permission Granted: "
-                "The Audio Recording of User's Input Saved in Full Format")
-
         else:
             LOG.warning("Transcribing Permission Denied")
 
@@ -72,19 +68,16 @@ class Transcribe:
                        globdate + \
                        "/" + (globstamp + " " + text).decode("utf8") + " .wav"
 
-            self.save_record(filename, audio)
+            waveFile = wave.open(filename, 'wb')
+            waveFile.setnchannels(1)
+            waveFile.setsampwidth(2)
+            waveFile.setframerate(16000)
+            waveFile.writeframes(audio)
+            waveFile.close()
+
             LOG.info(
                 "Transcribing Permission Granted: The Audio Recording of "
                 "User's Input Saved in Full Format")
 
         else:
             LOG.info("Audio Save Permission Denied")
-
-    def save_record(self, wav_name, audio):
-        # TODO: use "with"
-        waveFile = wave.open(wav_name, 'wb')
-        waveFile.setnchannels(1)
-        waveFile.setsampwidth(2)
-        waveFile.setframerate(16000)
-        waveFile.writeframes(audio)
-        waveFile.close()


### PR DESCRIPTION
Changes core to optionally (based on signal files) write out either or both audio files and text transcription files which are both written to /var/log/mycroft.  Default is set to 'off'.
Note: Associated with skill-keep-transcriptions which provides intents to start/stop the audio/text transcriptions.