### PR TITLE
Fix wake word record length

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -284,7 +284,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
     @staticmethod
     def sec_to_bytes(sec, source):
-        return int(sec * source.SAMPLE_RATE * source.SAMPLE_WIDTH)
+        return int(sec * source.SAMPLE_RATE) * source.SAMPLE_WIDTH
 
     def _skip_wake_word(self):
         # Check if told programatically to skip the wake word, like

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -181,7 +181,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         # The maximum audio in seconds to keep for transcribing a phrase
         # The wake word must fit in this time
         num_phonemes = wake_word_recognizer.num_phonemes
-        len_phoneme = listener_config.get('phoneme_duration', 0.2)
+        len_phoneme = listener_config.get('phoneme_duration', 120) / 1000.0
         self.TEST_WW_SEC = num_phonemes * len_phoneme
         self.SAVED_WW_SEC = 10 if self.save_wake_words else self.TEST_WW_SEC
 

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -160,13 +160,6 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         listener_config = self.config.get('listener')
         self.upload_config = listener_config.get('wake_word_upload')
         self.wake_word_name = wake_word_recognizer.key_phrase
-        # The maximum audio in seconds to keep for transcribing a phrase
-        # The wake word must fit in this time
-        num_phonemes = wake_word_recognizer.num_phonemes
-        len_phoneme = listener_config.get('phoneme_duration', 120) / 1000.0
-        self.TEST_WW_SEC = int(num_phonemes * len_phoneme)
-        self.SAVED_WW_SEC = (10 if self.upload_config['enable']
-                             else self.TEST_WW_SEC)
 
         speech_recognition.Recognizer.__init__(self)
         self.wake_word_recognizer = wake_word_recognizer
@@ -183,6 +176,13 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         self.filenames_to_upload = []
         self.mic_level_file = os.path.join(get_ipc_directory(), "mic_level")
         self._stop_signaled = False
+
+        # The maximum audio in seconds to keep for transcribing a phrase
+        # The wake word must fit in this time
+        num_phonemes = wake_word_recognizer.num_phonemes
+        len_phoneme = listener_config.get('phoneme_duration', 0.2)
+        self.TEST_WW_SEC = num_phonemes * len_phoneme
+        self.SAVED_WW_SEC = 10 if self.save_wake_words else self.TEST_WW_SEC
 
     @staticmethod
     def record_sound_chunk(source):
@@ -283,7 +283,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
     @staticmethod
     def sec_to_bytes(sec, source):
-        return sec * source.SAMPLE_RATE * source.SAMPLE_WIDTH
+        return int(sec * source.SAMPLE_RATE * source.SAMPLE_WIDTH)
 
     def _skip_wake_word(self):
         # Check if told programatically to skip the wake word, like

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -125,7 +125,8 @@
       "user": "precise",
       "folder": "/home/precise/wakewords"
     },
-    "phoneme_duration": 0.2,
+    // In milliseconds
+    "phoneme_duration": 120,
     "multiplier": 1.0,
     "energy_ratio": 1.5,
     "wake_word": "hey mycroft",

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -125,7 +125,7 @@
       "user": "precise",
       "folder": "/home/precise/wakewords"
     },
-    "phoneme_duration": 120,
+    "phoneme_duration": 0.2,
     "multiplier": 1.0,
     "energy_ratio": 1.5,
     "wake_word": "hey mycroft",


### PR DESCRIPTION
Currently, wake word recordings that are used when the user opts in are too short (0.1 seconds or less). This fixes that. This also changes the value in the config to be in seconds. @forslund Let me know if there's a reason we should keep this as 120. I wasn't really sure what unit that was in, so I could be messing something up.

## Steps for Testing

**Before Patch:**
 - Comment [os.remove on line 338 of mic.py](https://github.com/MycroftAI/mycroft-core/blob/dev/mycroft/client/speech/mic.py#L338)
 - After `hey mycroft, <anything>`, the wav file stored in `/tmp/mycroft_wake_words/` should be really short

`git checkout bugfix/record-length`

**After Patch:**
 - Comment the same line of mic.py
 - After `hey mycroft, <anything>`, the wav file stored in `/tmp/mycroft_wake_words/` should be of long length and hold all of the wake word plus a bit before in case of multiple attempted activations.