### PR TITLE
Feature/skip wake words

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -136,9 +136,11 @@ class AudioConsumer(Thread):
         if self._audio_length(audio) < self.MIN_AUDIO_SIZE:
             LOG.warning("Audio too short to be processed")
         else:
-            if len(audio.frame_data) != 65538 and \
-                    len(audio.frame_data) != 96258:  # 3 seconds silence
-                self.transcribe(audio)
+            # skip transcribing silence
+            # 3 seconds silence,
+            # matches RECORDING_TIMEOUT_WITH_SILENCE in mic.py
+            # if len(audio.frame_data) != 96258:
+            self.transcribe(audio)
 
     def transcribe(self, audio):
         text = None

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -136,6 +136,8 @@ class AudioConsumer(Thread):
         if self._audio_length(audio) < self.MIN_AUDIO_SIZE:
             LOG.warning("Audio too short to be processed")
         else:
+            # if len(audio.frame_data) != 65538:  # 2 seconds (silence)
+            # if len(audio.frame_data) != 96258:  # 3 seconds silence
             self.transcribe(audio)
 
     def transcribe(self, audio):

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -21,6 +21,8 @@ from pyee import EventEmitter
 from requests import HTTPError
 from requests.exceptions import ConnectionError
 
+import pwd
+import os
 import mycroft.dialog
 from mycroft.client.speech.hotword_factory import HotWordFactory
 from mycroft.client.speech.mic import MutableMicrophone, ResponsiveRecognizer
@@ -200,6 +202,7 @@ class RecognizerLoop(EventEmitter):
         self.config = config.get('listener')
         rate = self.config.get('sample_rate')
         device_index = self.config.get('device_index')
+        self.enclosure_config = config.get('enclosure')
 
         self.microphone = MutableMicrophone(device_index, rate,
                                             mute=self.mute_calls > 0)
@@ -314,8 +317,40 @@ class RecognizerLoop(EventEmitter):
         """
             Reload configuration and restart consumer and producer
         """
-        self.stop()
-        # load config
-        self._load_config()
-        # restart
-        self.start_async()
+        platform = str(self.enclosure_config.get(
+            'platform', 'laptop/desktop platform'))
+        LOG.debug('''self.enclosure_config.get('platform') ==''' + platform)
+        if platform == "picroft" or platform == "mycroft_mark_1":
+            LOG.debug('''my/pi croft platform''')
+            try:
+                # uid = pwd.getpwnam('mycroft')[2]
+                # LOG.debug('''my/pi croft root uid ==''' + str(uid))
+                # os.setuid(uid)
+                LOG.debug(''' username = ''' +
+                          pwd.getpwuid(os.getuid()).pw_name)
+                os.system('/etc/init.d/mycroft-speech-client restart')
+            except Exception as e:
+                LOG.debug('''error == ''' + str(e))
+        else:
+            LOG.debug('''laptop/desktop platform''')
+            BASEDIR = os.path.abspath(
+                os.path.join(os.path.dirname(__file__),
+                             '..', '..', '..')
+            )
+            LOG.debug('BASEDIR = ' + BASEDIR)
+            try:
+                # uid = pwd.getpwnam('guy')[2]
+                # LOG.debug('''laptop root uid ==''' + str(uid))
+                # os.setuid(uid)
+                # os.system('/etc/init.d/mycroft-speech-client stop;
+                #   /etc/init.d/mycroft-speech-client start')
+                LOG.debug(''' username = ''' +
+                          pwd.getpwuid(os.getuid()).pw_name)
+                os.system(BASEDIR + '/start-mycroft.sh voice')
+            except Exception as e:
+                LOG.debug('''error == ''' + str(e))
+        # self.stop()
+        # # load config
+        # self._load_config()
+        # # restart
+        # self.start_async()

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -136,9 +136,9 @@ class AudioConsumer(Thread):
         if self._audio_length(audio) < self.MIN_AUDIO_SIZE:
             LOG.warning("Audio too short to be processed")
         else:
-            # if len(audio.frame_data) != 65538:  # 2 seconds (silence)
-            # if len(audio.frame_data) != 96258:  # 3 seconds silence
-            self.transcribe(audio)
+            if len(audio.frame_data) != 65538 and \
+                    len(audio.frame_data) != 96258:  # 3 seconds silence
+                self.transcribe(audio)
 
     def transcribe(self, audio):
         text = None
@@ -316,8 +316,16 @@ class RecognizerLoop(EventEmitter):
                 raise  # Re-raise KeyboardInterrupt
 
     def reload(self):
+        self.stop()
+        # load config
+        self._load_config()
+        # restart
+        self.start_async()
+
+
+    def restart(self):
         """
-            Reload configuration and restart consumer and producer
+            Restart the speech/voice client
         """
         platform = str(self.enclosure_config.get(
             'platform', 'laptop/desktop platform'))
@@ -351,8 +359,3 @@ class RecognizerLoop(EventEmitter):
                 os.system(BASEDIR + '/start-mycroft.sh voice')
             except Exception as e:
                 LOG.debug('''error == ''' + str(e))
-        # self.stop()
-        # # load config
-        # self._load_config()
-        # # restart
-        # self.start_async()

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -322,7 +322,6 @@ class RecognizerLoop(EventEmitter):
         # restart
         self.start_async()
 
-
     def restart(self):
         """
             Restart the speech/voice client

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -87,6 +87,10 @@ def handle_mic_unmute(event):
     loop.unmute()
 
 
+def handle_reload(event):
+    loop.reload()
+
+
 def handle_paired(event):
     IdentityManager.update(event.data)
 
@@ -138,10 +142,12 @@ def main():
     loop.on('recognizer_loop:wakeword', handle_wakeword)
     loop.on('recognizer_loop:record_end', handle_record_end)
     loop.on('recognizer_loop:no_internet', handle_no_internet)
+    loop.on('recognizer_loop:reload', handle_reload)
     ws.on('open', handle_open)
     ws.on('complete_intent_failure', handle_complete_intent_failure)
     ws.on('recognizer_loop:sleep', handle_sleep)
     ws.on('recognizer_loop:wake_up', handle_wake_up)
+    ws.on('recognizer_loop:reload', handle_reload)
     ws.on('mycroft.mic.mute', handle_mic_mute)
     ws.on('mycroft.mic.unmute', handle_mic_unmute)
     ws.on("mycroft.paired", handle_paired)

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -99,6 +99,10 @@ def handle_restart(event):
     loop.restart()
 
 
+def handle_reload(event):
+    loop.reload()
+
+
 def handle_paired(event):
     IdentityManager.update(event.data)
 
@@ -151,11 +155,13 @@ def main():
     loop.on('recognizer_loop:record_end', handle_record_end)
     loop.on('recognizer_loop:no_internet', handle_no_internet)
     loop.on('recognizer_loop:restart', handle_restart)
+    loop.on('recognizer_loop:reload', handle_reload)
     ws.on('open', handle_open)
     ws.on('complete_intent_failure', handle_complete_intent_failure)
     ws.on('recognizer_loop:sleep', handle_sleep)
     ws.on('recognizer_loop:wake_up', handle_wake_up)
     ws.on('recognizer_loop:restart', handle_restart)
+    ws.on('recognizer_loop:reload', handle_reload)
     ws.on('mycroft.mic.mute', handle_mic_mute)
     ws.on('mycroft.mic.unmute', handle_mic_unmute)
     ws.on("mycroft.paired", handle_paired)

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -95,8 +95,8 @@ def handle_mic_unmute(event):
     loop.unmute()
 
 
-def handle_reload(event):
-    loop.reload()
+def handle_restart(event):
+    loop.restart()
 
 
 def handle_paired(event):
@@ -150,12 +150,12 @@ def main():
     loop.on('recognizer_loop:wakeword', handle_wakeword)
     loop.on('recognizer_loop:record_end', handle_record_end)
     loop.on('recognizer_loop:no_internet', handle_no_internet)
-    loop.on('recognizer_loop:reload', handle_reload)
+    loop.on('recognizer_loop:restart', handle_restart)
     ws.on('open', handle_open)
     ws.on('complete_intent_failure', handle_complete_intent_failure)
     ws.on('recognizer_loop:sleep', handle_sleep)
     ws.on('recognizer_loop:wake_up', handle_wake_up)
-    ws.on('recognizer_loop:reload', handle_reload)
+    ws.on('recognizer_loop:restart', handle_restart)
     ws.on('mycroft.mic.mute', handle_mic_mute)
     ws.on('mycroft.mic.unmute', handle_mic_unmute)
     ws.on("mycroft.paired", handle_paired)

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -167,7 +167,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         elif listener_config.get('skip_wake_words', False) and \
                 not check_for_signal('restartedFromSkill', 15):
             self.skip_wake_words = True
-            LOG.debug("config skip_wake_words and not restartedFromSkill found 1")
+            LOG.debug("config skip_wake_words and"
+                      " not restartedFromSkill found 1")
         LOG.debug("self.skip_wake_words = " + str(self.skip_wake_words))
         self.wake_word_name = wake_word_recognizer.key_phrase
         # The maximum audio in seconds to keep for transcribing a phrase

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -160,12 +160,15 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         self.config = Configuration.get()
         listener_config = self.config.get('listener')
         self.upload_config = listener_config.get('wake_word_upload')
-        self.skip_wake_word = False
+        self.skip_wake_words = False
         if check_for_signal('skip_wake_word', -1):
-            self.skip_wake_word = True
-        elif listener_config.get('skip_wake_word', True) and \
-                not check_for_signal('restartedFromSkill', 10):
-            self.skip_wake_word = True
+            self.skip_wake_words = True
+            LOG.debug("skip_wake_words signal found 1")
+        elif listener_config.get('skip_wake_words', False) and \
+                not check_for_signal('restartedFromSkill', 15):
+            self.skip_wake_words = True
+            LOG.debug("config skip_wake_words and not restartedFromSkill found 1")
+        LOG.debug("self.skip_wake_words = " + str(self.skip_wake_words))
         self.wake_word_name = wake_word_recognizer.key_phrase
         # The maximum audio in seconds to keep for transcribing a phrase
         # The wake word must fit in this time
@@ -488,7 +491,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         #       speech is detected, but there is no code to actually do that.
         self.adjust_for_ambient_noise(source, 1.0)
 
-        if self.skip_wake_word:
+        if self.skip_wake_words:
             create_signal('startListening')
             LOG.debug("Skipping wake word... waiting...")
         else:
@@ -503,7 +506,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         # If enabled, play a wave file with a short sound to audibly
         # indicate recording has begun.
         if (self.config.get('confirm_listening') and
-                (not self.skip_wake_word or
+                (not self.skip_wake_words or
                  check_for_signal('WaitingToConfirm', 10))):
             file = resolve_resource_file(
                 self.config.get('sounds').get('start_listening'))

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -34,6 +34,7 @@ from speech_recognition import (
 from mycroft.configuration import Configuration
 from mycroft.session import SessionManager
 from mycroft.util import (
+    create_signal,
     check_for_signal,
     get_ipc_directory,
     resolve_resource_file,
@@ -159,6 +160,12 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         self.config = Configuration.get()
         listener_config = self.config.get('listener')
         self.upload_config = listener_config.get('wake_word_upload')
+        self.skip_wake_word = False
+        if check_for_signal('skip_wake_word', -1):
+            self.skip_wake_word = True
+        elif listener_config.get('skip_wake_word', True) and \
+                not check_for_signal('restartedFromSkill', 10):
+            self.skip_wake_word = True
         self.wake_word_name = wake_word_recognizer.key_phrase
         # The maximum audio in seconds to keep for transcribing a phrase
         # The wake word must fit in this time
@@ -481,7 +488,11 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         #       speech is detected, but there is no code to actually do that.
         self.adjust_for_ambient_noise(source, 1.0)
 
-        LOG.debug("Waiting for wake word...")
+        if self.skip_wake_word:
+            create_signal('startListening')
+            LOG.debug("Skipping wake word... waiting...")
+        else:
+            LOG.debug("Waiting for wake word...")
         self._wait_until_wake_word(source, sec_per_buffer)
         if self._stop_signaled:
             return
@@ -491,7 +502,9 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
         # If enabled, play a wave file with a short sound to audibly
         # indicate recording has begun.
-        if self.config.get('confirm_listening'):
+        if (self.config.get('confirm_listening') and
+                (not self.skip_wake_word or
+                 check_for_signal('WaitingToConfirm', 10))):
             file = resolve_resource_file(
                 self.config.get('sounds').get('start_listening'))
             if file:

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -117,7 +117,7 @@
     "sample_rate": 16000,
     "channels": 1,
     "record_wake_words": false,
-    "record_utterances": true,
+    "record_utterances": false,
     "skip_wake_words": false,
     "wake_word_upload": {
       "enable": false,

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -98,7 +98,7 @@
   "server": {
     "url": "https://api.mycroft.ai",
     "version": "v1",
-    "update": true,
+    "update": false,
     "metrics": false
   },
   
@@ -117,7 +117,9 @@
     "sample_rate": 16000,
     "channels": 1,
     "record_wake_words": false,
-    "record_utterances": false,
+    "record_utterances": true,
+    "record_utterances_test": true,
+    "skip_wake_words": true,
     "wake_word_upload": {
       "enable": false,
       "server": "mycroft.wickedbroadband.com",

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -98,7 +98,7 @@
   "server": {
     "url": "https://api.mycroft.ai",
     "version": "v1",
-    "update": false,
+    "update": true,
     "metrics": false
   },
   
@@ -118,8 +118,7 @@
     "channels": 1,
     "record_wake_words": false,
     "record_utterances": true,
-    "record_utterances_test": true,
-    "skip_wake_words": true,
+    "skip_wake_words": false,
     "wake_word_upload": {
       "enable": false,
       "server": "mycroft.wickedbroadband.com",


### PR DESCRIPTION
Skipping wake words does just that.  It keeps recording, after 3 seconds of silence (or whatever the setting), it stops and then starts recording again.  There are a few comments in listener.process() where one can bypass the STT of the silence, which it might not be if the utterance happens to be exactly 3 secs.  Any other length of audio gets transcribed and sent on to skills.

Skipping wake words relies on the reload function working in order to start/stop it via a skill. That commit is included in this.  I'm not sure if that's how to handle commit dependencies, newby that I am to git.