### PR TITLE
mycroft-use: Use autoremove when removing mycroft-mark-1 package

### DIFF
--- a/scripts/mycroft-use.sh
+++ b/scripts/mycroft-use.sh
@@ -278,7 +278,7 @@ elif [ "${change_to}" = "stable" ]; then
         if [ "${current_pkg}" = "${unstable_pkg}" ]; then
             # Need to remove the package to make sure upgrade happens due to
             # difference in stable/unstable to package numbering schemes
-            invoke_apt remove
+            invoke_apt autoremove
 
             change_build "${stable_pkg}"
         else


### PR DESCRIPTION
remove will only remove the meta package, autoremove will remove the
meta package and all packages installed as dependencies for that
package.

This will result in reinstallation of some extra packages but no download should be necessary so the process is swift.