### PR TITLE
Handle missing messagebus in a correct way

### DIFF
--- a/mycroft/messagebus/send.py
+++ b/mycroft/messagebus/send.py
@@ -80,4 +80,7 @@ def send(messageToSend, dataToSend=None):
 
 
 if __name__ == '__main__':
-    main()
+    try:
+        main()
+    except IOError:
+        print('Could not connect to websocket, no message sent')


### PR DESCRIPTION
==== Tech notes ====
The send script will throw an IOerror exception if the bus service isn't
started. This correctly catches it and emits a single warning.