### PR TITLE
Add replacment for Google TTS via Google Cloud Speech API 

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Put a relevant key inside the quotes and mycroft-core should begin to use the ke
 ## API Key Services
 These are the keys currently used in Mycroft Core:
 
-- [STT API, Google STT](http://www.chromium.org/developers/how-tos/api-keys)
+- [STT API, Google STT, Google Cloud Speech](http://www.chromium.org/developers/how-tos/api-keys)
 - [Weather Skill API, OpenWeatherMap](http://openweathermap.org/api)
 - [Wolfram-Alpha Skill](http://products.wolframalpha.com/api/)
 

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import re
+import json
 from abc import ABCMeta, abstractmethod
 from requests import post
 from speech_recognition import Recognizer
@@ -54,6 +55,14 @@ class TokenSTT(STT):
         self.token = str(self.credential.get("token"))
 
 
+class GoogleJsonSTT(STT):
+    __metaclass__ = ABCMeta
+
+    def __init__(self):
+        super(GoogleJsonSTT, self).__init__()
+        self.json_credentials = json.dumps(self.credential.get("json"))
+
+
 class BasicSTT(STT):
     __metaclass__ = ABCMeta
 
@@ -70,6 +79,17 @@ class GoogleSTT(TokenSTT):
     def execute(self, audio, language=None):
         self.lang = language or self.lang
         return self.recognizer.recognize_google(audio, self.token, self.lang)
+
+
+class GoogleCloudSTT(GoogleJsonSTT):
+    def __init__(self):
+        super(GoogleCloudSTT, self).__init__()
+
+    def execute(self, audio, language=None):
+        self.lang = language or self.lang
+        return self.recognizer.recognize_google_cloud(audio,
+                                                      self.json_credentials,
+                                                      self.lang)
 
 
 class WITSTT(TokenSTT):
@@ -126,6 +146,7 @@ class STTFactory(object):
     CLASSES = {
         "mycroft": MycroftSTT,
         "google": GoogleSTT,
+        "google_cloud": GoogleCloudSTT,
         "wit": WITSTT,
         "ibm": IBMSTT,
         "kaldi": KaldiSTT

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ python-dateutil==2.6.0
 pychromecast==0.7.7
 python-vlc==1.1.2
 pulsectl==17.7.4
+google-api-python-client==1.6.4
 
 # dev setup tools
 pep8==1.7.0

--- a/test/unittests/stt/test_stt.py
+++ b/test/unittests/stt/test_stt.py
@@ -29,6 +29,11 @@ class TestSTT(unittest.TestCase):
                  'module': 'mycroft',
                  'wit': {'credential': {'token': 'FOOBAR'}},
                  'google': {'credential': {'token': 'FOOBAR'}},
+                 'google_cloud': {
+                   'credential': {
+                     'json': {}
+                   }
+                 },
                  'ibm': {'credential': {'token': 'FOOBAR'}},
                  'kaldi': {'uri': 'https://test.com'},
                  'mycroft': {'uri': 'https://test.com'}
@@ -43,6 +48,10 @@ class TestSTT(unittest.TestCase):
         config['stt']['module'] = 'google'
         stt = mycroft.stt.STTFactory.create()
         self.assertEquals(type(stt), mycroft.stt.GoogleSTT)
+
+        config['stt']['module'] = 'google_cloud'
+        stt = mycroft.stt.STTFactory.create()
+        self.assertEquals(type(stt), mycroft.stt.GoogleCloudSTT)
 
         config['stt']['module'] = 'ibm'
         stt = mycroft.stt.STTFactory.create()
@@ -115,6 +124,26 @@ class TestSTT(unittest.TestCase):
         stt = mycroft.stt.GoogleSTT()
         stt.execute(audio)
         self.assertTrue(stt.recognizer.recognize_google.called)
+
+    @mock.patch.object(Configuration, 'get')
+    def test_google_cloud_stt(self, mock_get):
+        mycroft.stt.Recognizer = mock.MagicMock
+        config = {'stt': {
+                 'module': 'google_cloud',
+                 'google_cloud': {
+                   'credential': {
+                     'json': {}
+                   }
+                 },
+            },
+            "lang": "en-US"
+        }
+        mock_get.return_value = config
+
+        audio = mock.MagicMock()
+        stt = mycroft.stt.GoogleCloudSTT()
+        stt.execute(audio)
+        self.assertTrue(stt.recognizer.recognize_google_cloud.called)
 
     @mock.patch.object(Configuration, 'get')
     def test_ibm_stt(self, mock_get):


### PR DESCRIPTION
As noted on the Chromium Dev How-to [1] and on the
SpeechRecognition library docs [2], the Google TTS API
is really not the right API to call. While it's simple,
and allows you to authenticate via a simple token, it is
also limited to a max of *50* requests per day.

That's not a lot. I don't think many people will find that
useful, outside of quick testing (if they can even get an
API key - I couldn't figure out how to generate one that
worked correctly).

This commit introduces a new STT backend, google_cloud, so that
the Google STT backend can be deprecated eventually. To do so, we
needed to:
- Install the Google API Client Library
- Create a new STT class which knows how to turn a provided Google
  JSON credentials file into a string (the SpeechRecognition library
  expects you to pass in the JSON string, not a file path, nor an object).

Any person wishing to use this will need to:
- Enable the Cloud Speech API on the Google Cloud Platform console
- Create a new Service Account Key, and download the credentials to
  a secure location
- Configure that location in mycroft.conf, like so:

```json
  "stt": {
    "google_cloud": {
      "credential": {
        "json": { contents of downloaded credentials }
      }
    }
  }
```

It's worth noting that the Cloud Speech API has a free quota of
60 minutes per month, which would probably stretch further than 50
individual requests. So for hobbyists, it should be nothing but
a net benefit.

[1] http://www.chromium.org/developers/how-tos/api-keys
[2] https://github.com/Uberi/speech_recognition/blob/master/reference/library-reference.rst#recognizer_instancerecognize_googleaudio_data-key--none-language--en-us-show_all--false