### PR TITLE
Add send_email method to skills

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -162,6 +162,13 @@ class DeviceApi(Api):
                      "enclosureVersion": version.get("enclosureVersion")}
         })
 
+    def send_email(self, title, body, sender):
+        return self.request({
+            "method": "PUT",
+            "path": "/" + self.identity.uuid + "/message",
+            "json": {"title": title, "body": body, "sender": sender}
+        })
+
     def get(self):
         """ Retrieve all device information from the web backend """
         return self.request({

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -25,6 +25,7 @@ from adapt.intent import Intent, IntentBuilder
 from os import listdir
 from os.path import join, abspath, dirname, splitext, basename, exists
 
+from mycroft.api import DeviceApi
 from mycroft.client.enclosure.api import EnclosureAPI
 from mycroft.configuration import Configuration
 from mycroft.dialog import DialogLoader
@@ -229,6 +230,7 @@ class MycroftSkill(object):
         self.config = self.config_core.get(self.name)
         self.dialog_renderer = None
         self.vocab_dir = None
+        self.root_dir = None
         self.file_system = FileSystemAccess(join('skills', self.name))
         self.registered_intents = []
         self.log = LOG.create_logger(self.name)
@@ -323,6 +325,17 @@ class MycroftSkill(object):
             Returns:    True if an utterance was handled, otherwise False
         """
         return False
+
+    def send_email(self, title, body):
+        """
+        Send an email to the registered user's email
+
+        Args:
+            title (str): Title of email
+            body  (str): HTML body of email. This supports
+                         simple HTML like bold and italics
+        """
+        DeviceApi().send_email(title, body, basename(self.root_dir))
 
     def make_active(self):
         """
@@ -599,6 +612,7 @@ class MycroftSkill(object):
         self.init_dialog(root_directory)
         self.load_vocab_files(join(root_directory, 'vocab', self.lang))
         regex_path = join(root_directory, 'regex', self.lang)
+        self.root_dir = root_directory
         if exists(regex_path):
             self.load_regex_files(regex_path)
 

--- a/test/unittests/api/test_api.py
+++ b/test/unittests/api/test_api.py
@@ -19,6 +19,7 @@ import mock
 
 import mycroft.api
 import mycroft.configuration
+from mycroft.util.log import LOG
 
 CONFIG = {
     'server': {
@@ -168,6 +169,26 @@ class TestApi(unittest.TestCase):
         url = mock_request.call_args[0][1]
         self.assertEquals(
             url, 'https://api-test.mycroft.ai/v1/device/1234/setting')
+
+    @mock.patch('mycroft.api.IdentityManager.get')
+    @mock.patch('mycroft.api.requests.request')
+    def test_device_send_email(self, mock_request, mock_identity_get):
+        mock_request.return_value = create_response(200, {})
+        mock_identity = mock.MagicMock()
+        mock_identity.is_expired.return_value = False
+        mock_identity.uuid = '1234'
+        mock_identity_get.return_value = mock_identity
+        device = mycroft.api.DeviceApi()
+        device.send_email('title', 'body', 'sender')
+        url = mock_request.call_args[0][1]
+        params = mock_request.call_args[1]
+
+        content_type = params['headers']['Content-Type']
+        correct_json = {'body': 'body', 'sender': 'sender', 'title': 'title'}
+        self.assertEquals(content_type, 'application/json')
+        self.assertEquals(params['json'], correct_json)
+        self.assertEquals(
+            url, 'https://api-test.mycroft.ai/v1/device/1234/message')
 
     @mock.patch('mycroft.api.IdentityManager.get')
     @mock.patch('mycroft.api.requests.request')


### PR DESCRIPTION
Update: It now works for me.
### Usage
```Python
self.send_email('Title', '<b>content</b><br>here')
```

### Example Skill
**\_\_init__.py**
```Python
from mycroft import MycroftSkill, intent_file_handler


class EmailSkill(MycroftSkill):
    def __init__(self):
        MycroftSkill.__init__(self)

    @intent_file_handler('send.email.intent')
    def handle_send_email(self, message):
        self.send_email('Your email', message.data.get('content', '...'))
        self.speak_dialog('sent.email')


def create_skill():
    return EmailSkill()
```

**send.email.intent**
```
send an email saying {content}.
send the email {content}.
```

sent.email.dialog**
```
I've sent the email.
The email has been sent.
```