### PR TITLE
Better support for creating distribution packages and having skills folders not at /opt/mycroft/skills

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -87,18 +87,23 @@ fi
 # Determine if on picroft/mk1?
 picroft_mk1="false"
 vwrap="true"
+use_virtualenvwrapper="$(get_config_value '.enclosure.use_virtualenvwrapper' 'true')"
 if [[ "${mycroft_platform}" == "picroft" ]] || [[ "${mycroft_platform}" == "mycroft_mark_1" ]] ; then
   picroft_mk1="true"
 else
-  if [[ -r /etc/bash_completion.d/virtualenvwrapper ]]; then
-    source /etc/bash_completion.d/virtualenvwrapper
-   elif [[ -r /usr/bin/virtualenvwrapper.sh ]]; then
-    source /usr/bin/virtualenvwrapper.sh
-  else
-    if locate virtualenvwrapper ; then
-      if ! source $(locate virtualenvwrapper) ; then
-        echo "WARNING: Unable to locate virtualenvwrapper.sh, not able to install skills!"
-        vwrap="false"
+  if [[ ${use_virtualenvwrapper} == "true" ]] ; then
+    if [[ -r /etc/bash_completion.d/virtualenvwrapper ]]; then
+      source /etc/bash_completion.d/virtualenvwrapper
+     elif [[ -r /usr/bin/virtualenvwrapper.sh ]]; then
+      source /usr/bin/virtualenvwrapper.sh
+     elif [[ -r /usr/bin/virtualenvwrapper ]]; then
+      source /usr/bin/virtualenvwrapper
+    else
+      if locate virtualenvwrapper ; then
+        if ! source $(locate virtualenvwrapper) ; then
+          echo "WARNING: Unable to locate virtualenvwrapper.sh, not able to install skills!"
+          vwrap="false"
+        fi
       fi
     fi
   fi

--- a/msm/msm
+++ b/msm/msm
@@ -52,11 +52,25 @@ function help() {
   exit 1
 }
 
+function get_config_value() {
+  key="$1"
+  default="$2"
+  value="null"
+  for file in ~/.mycroft/mycroft.conf /etc/mycroft/mycroft.conf ; do
+    if [[ -r ~/.mycroft/mycroft.conf ]] ; then
+        value=$( jq -r "$key" "$file" )
+        if [[ "${value}" != "null" ]] ;  then
+            echo "$value"
+            return
+        fi
+    fi
+  done
+  echo "$default"
+}
+
 # Determine the platform
-mycroft_platform="null"
-if [[ -r /etc/mycroft/mycroft.conf ]] ; then
-   mycroft_platform=$( jq -r '.enclosure.platform' /etc/mycroft/mycroft.conf )
-else
+mycroft_platform="$(get_config_value '.enclosure.platform' 'null')"
+if [[ "${mycroft_platform}" == "null" ]] ; then
    if [[ "$(hostname)" == "picroft" ]] ; then
       mycroft_platform="picroft"
    elif [[ "$(hostname)" =~ "mark_1" ]] ; then
@@ -64,15 +78,7 @@ else
    fi
 fi
 
-# Get the location of the Skill folder
-mycroft_skill_folder="null"
-if [[ -r /etc/mycroft/mycroft.conf ]] ; then
-   mycroft_skill_folder=$( jq -r '.enclosure.skill_folder' /etc/mycroft/mycroft.conf )
-fi
-if [[ ${mycroft_skill_folder} == "null" ]] ; then
-   mycroft_skill_folder="/opt/mycroft/skills"
-fi
-
+mycroft_skill_folder="$(get_config_value '.enclosure.skill_folder' '/opt/mycroft/skills')"
 if [[ ! -d "${mycroft_skill_folder}" ]] ; then
   echo "ERROR: Unable to find/access ${mycroft_skill_folder}!"
   exit 101

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -22,6 +22,7 @@ from requests import HTTPError
 
 from mycroft.util.json_helper import load_commented_json
 from mycroft.util.log import LOG
+from mycroft.filesystem import FileSystemAccess
 
 
 def merge_dict(base, delta):
@@ -135,7 +136,8 @@ class RemoteConf(LocalConf):
     def __init__(self, cache=None):
         super(RemoteConf, self).__init__(None)
 
-        cache = cache or '/opt/mycroft/web_config_cache.json'
+        if not cache:
+            cache = join(FileSystemAccess('cache').path, 'web_config_cache.json')
 
         try:
             # Here to avoid cyclic import

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -171,7 +171,10 @@
     "update": true,
     
     // Run a self test at bootup?
-    "test": false
+    "test": false,
+
+    // use virtualenvwrapper (or if false, just use the system python modules)
+    "use_virtualenvwrapper": true
   },
 
   // Level of logs to store, one of  "CRITICAL", "ERROR", "WARNGIN", "INFO", "DEBUG"

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -44,7 +44,7 @@ skill_manager = None
 skills_config = Configuration.get().get("skills")
 BLACKLISTED_SKILLS = skills_config.get("blacklisted_skills", [])
 PRIORITY_SKILLS = skills_config.get("priority_skills", [])
-SKILLS_DIR = '/opt/mycroft/skills'
+SKILLS_DIR = skills_config.get("directory") or '/opt/mycroft/skills'
 
 installer_config = Configuration.get().get("SkillInstallerSkill")
 MSM_BIN = installer_config.get("path", join(MYCROFT_ROOT_PATH, 'msm', 'msm'))


### PR DESCRIPTION
These commits try to let users define their own skills folder so /opt/mycroft/skills is not hardcoded (althought will still be used by default). This will allow me to create openSUSE packages for mycroft so regular users can execute all mycroft services (and plasmoid)