### PR TITLE
Remove pystache

### DIFF
--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -16,7 +16,6 @@ import random
 from io import open
 
 import os
-import pystache
 
 from mycroft.util import resolve_resource_file
 from mycroft.util.log import LOG
@@ -75,7 +74,10 @@ class MustacheDialogRenderer(object):
             index = random.randrange(len(template_functions))
         else:
             index %= len(template_functions)
-        return pystache.render(template_functions[index], context)
+        line = template_functions[index]
+        for k, v in context.items():
+            line = line.replace('{{' + k + '}}', v)
+        return line
 
 
 class DialogLoader(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 six==1.10.0
-pystache==0.5.4
 requests==2.13.0
 gTTS==1.1.7
 gTTS-token==1.1.1


### PR DESCRIPTION
On certain platforms it escapes quotes which causes problems. Since we only use it for something as simple as key value replacements, it doesn't make sense to include it as a dependency.

@forslund Any idea why this randomly started happening for me? It sounded very much like a Python 3 issue which is why I'm mentioning you. For me, the following is messed up:

`workon mycroft && python2`
```Python
import pystache
pystache.render('{{key}}', {'key': "'"})
```