### PR TITLE
Improve mouth synchronization with speech

### DIFF
--- a/mycroft/client/enclosure/api.py
+++ b/mycroft/client/enclosure/api.py
@@ -168,7 +168,7 @@ class EnclosureAPI:
         self.ws.emit(Message("enclosure.mouth.smile"))
         DisplayManager.set_active(self.name)
 
-    def mouth_viseme(self, code):
+    def mouth_viseme(self, code, time_until=0):
         """Display a viseme mouth shape for synched speech
         Args:
             code (int):  0 = shape for sounds like 'y' or 'aa'
@@ -178,6 +178,8 @@ class EnclosureAPI:
                          4 = neutral shape for no sound
                          5 = shape for sounds like 'f' or 'v'
                          6 = shape for sounds like 'oy' or 'ao'
+            time_until(int): (optional) For timing, time.time() when this
+                         shape expires, or 0 for display regardles of time
         """
         self.ws.emit(Message("enclosure.mouth.viseme", {'code': code}))
 

--- a/mycroft/client/enclosure/api.py
+++ b/mycroft/client/enclosure/api.py
@@ -178,7 +178,7 @@ class EnclosureAPI:
                          4 = neutral shape for no sound
                          5 = shape for sounds like 'f' or 'v'
                          6 = shape for sounds like 'oy' or 'ao'
-            time_until(int): (optional) For timing, time.time() when this
+            time_until (float): (optional) For timing, time.time() when this
                          shape expires, or 0 for display regardles of time
         """
         self.ws.emit(Message("enclosure.mouth.viseme", {'code': code}))

--- a/mycroft/client/enclosure/mouth.py
+++ b/mycroft/client/enclosure/mouth.py
@@ -56,7 +56,11 @@ class EnclosureMouth:
     def viseme(self, event=None):
         if event and event.data:
             code = event.data.get("code")
-            if code:
+            time_until = event.data.get("until")
+            # Skip the viseme if the time has expired.  This helps when a
+            # system glitch overloads the bus and throws off the timing of
+            # the animation timing.
+            if code and (time_until == 0 or time.time() < time_until):
                 self.writer.write("mouth.viseme=" + code)
 
     def text(self, event=None):

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -111,7 +111,8 @@ class PlaybackThread(Thread):
                 self._clear_visimes = False
                 return True
             if self.enclosure:
-                self.enclosure.mouth_viseme(code)
+                # Include time stamp to assist with animation timing
+                self.enclosure.mouth_viseme(code, start+duration)
             delta = time() - start
             if delta < duration:
                 sleep(duration - delta)


### PR DESCRIPTION
When the TTS engine provides visemes to the faceplate, the information
passed along consists of the mouth shape and the duration to display it.
When the system get backed-up for some reason (e.g. the CPU is briefly
overloaded), the code would attempt to catch up the animation but would
still send the 'expired' viseme across the serial port to the faceplate
with no wait-time.  This results in a fast-moving mouth to catch up,
which isn't very pleasing.

Now the viseme is passed along with an expiration date, so if the time
to display it has already passed then the viseme code gets thrown away
instead of being sent across the (relatively slow) serial port.  This
allows better catch-up.