### PR TITLE
Fix dialog renderer

### DIFF
--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -76,7 +76,7 @@ class MustacheDialogRenderer(object):
             index %= len(template_functions)
         line = template_functions[index]
         for k, v in context.items():
-            line = line.replace('{{' + k + '}}', v)
+            line = line.replace('{{' + k + '}}', str(v))
         return line
 
 

--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -76,7 +76,7 @@ class MustacheDialogRenderer(object):
             index %= len(template_functions)
         line = template_functions[index]
         for k, v in context.items():
-            line = line.replace('{{' + k + '}}', str(v))
+            line = line.replace('{{' + str(k) + '}}', str(v))
         return line
 
 


### PR DESCRIPTION
The recent change to remove Pystache introduced a bug in cases where
the passed-in key/value data included non-strings for the value.  This
showed up in the weather skill which passed in "lat" and "lon" as floats.
Now the value is explicitly converted using str().