### PR TITLE
Increase min wait time in wait_while_speaking()

### DIFF
--- a/mycroft/audio/__init__.py
+++ b/mycroft/audio/__init__.py
@@ -33,7 +33,7 @@ def wait_while_speaking():
     briefly to ensure that any preceeding request to speak has time to
     begin.
     """
-    time.sleep(0.1)  # Wait briefly in for any queued speech to begin
+    time.sleep(0.3)  # Wait briefly in for any queued speech to begin
     while is_speaking():
         time.sleep(0.1)
 

--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -931,8 +931,7 @@ def normalize_en(text, remove_articles):
                        "there're", "there's", "they'd", "they'll", "they're",
                        "they've", "wasn't", "we'd", "we'll", "we're", "we've",
                        "weren't", "what'd", "what'll", "what're", "what's",
-                       "whats",
-                       # technically incorrect but some STT does this
+                       "whats",  # technically incorrect but some STT outputs
                        "what've", "when's", "when'd", "where'd", "where's",
                        "where've", "who'd", "who'd've", "who'll", "who're",
                        "who's", "who've", "why'd", "why're", "why's", "won't",


### PR DESCRIPTION
In code like this:
   self.speak_dialog("something")
   mycroft.audio.wait_while_speaking()
It was possible that the speaking of "something" would take longer to
start than the 0.1 seconds that was built into the wait_while_speaking().
The definition of this behavior is slightly fuzzy, but this is definitely
a case where the expectation is that previous request for speech would
start and complete.  For now, I have just bumped the minimum wait to
0.3 seconds.

In the long run we might consider tracking specific speak requests and
generating a notification when that request has been serviced.  Then the
skill could automatically hold off until that request has been serviced.
But the basic skill code won't have to change to make this happen, so
this additional sleep is adequate for today.

Also snuck in a minor change to a comment.