### PR TITLE
Allow name-less label in settingmeta.json

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -246,7 +246,9 @@ class SkillSettings(dict):
                     sections = skill_setting['skillMetadata']['sections']
                     for section in sections:
                         for field in section["fields"]:
-                            self.__setitem__(field["name"], field["value"])
+                            if "name" in field:  # no name for 'label' fields
+                                self.__setitem__(field["name"],
+                                                 field["value"])
 
             # store value if settings has changed from backend
             self.store()


### PR DESCRIPTION
A type='label' field in the settingmeta.json might not have a field name,
which was causing a crash.