### PR TITLE
Reduce unneccessary loading of configuration files

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -19,7 +19,7 @@ from requests import HTTPError
 
 from mycroft.configuration import Configuration
 from mycroft.configuration.config import DEFAULT_CONFIG, SYSTEM_CONFIG, \
-    USER_CONFIG, LocalConf
+    USER_CONFIG
 from mycroft.identity import IdentityManager
 from mycroft.version import VersionManager
 from mycroft.util import get_arch
@@ -32,9 +32,9 @@ class Api(object):
 
     def __init__(self, path):
         self.path = path
-        config = Configuration.get([LocalConf(DEFAULT_CONFIG),
-                                    LocalConf(SYSTEM_CONFIG),
-                                    LocalConf(USER_CONFIG)],
+        config = Configuration.get([DEFAULT_CONFIG,
+                                    SYSTEM_CONFIG,
+                                    USER_CONFIG],
                                    cache=False)
         config_server = config.get("server")
         self.url = config_server.get("url")


### PR DESCRIPTION
====  Tech Notes ====
Configuration.get() was originally thought to take a stack of configuration dicts and merge together into a single configuration dict but can also handle file paths.

The Api() class can't use the RemoteConfig class so it has supplied it's own stack of configuration files to avoid infinite recursion. Previously the files wore converted to dicts before passed into the Configuration which meant that 3 files were loaded even if the information was already cached. This means that each time an Api Object is created the disk is hit for these files.

This passes the files as file references that will only be converted to dicts if the cache is not found.

This can easily be tested on the current dev branch by starting a python prompt and entering

```python
from mycroft.configuration import Configuration
from mycroft.api import DeviceApi()
c = Configuration.get()
d = DeviceApi()
```

After the second the log info will show something along the lines of:
```
>>> d = DeviceApi()
00:41:42.007 - mycroft.configuration.config:load_local:110 - DEBUG - Configuration /home/ake/projects/python/mycroft-core/mycroft/configuration/mycroft.conf loaded
00:41:42.009 - mycroft.configuration.config:load_local:115 - DEBUG - Configuration '/etc/mycroft/mycroft.conf' not found
00:41:42.011 - mycroft.configuration.config:load_local:115 - DEBUG - Configuration '/home/ake/.mycroft/mycroft.conf' not found
```

Switching over the the PR should not show those loading messages.

