### PR TITLE
Fix handling of unicode strings in dialog renderer

### DIFF
--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -75,8 +75,7 @@ class MustacheDialogRenderer(object):
         else:
             index %= len(template_functions)
         line = template_functions[index]
-        for k, v in context.items():
-            line = line.replace('{{' + str(k) + '}}', str(v))
+        line = line.replace('{{', '{').replace('}}', '}').format(**context)
         return line
 
 


### PR DESCRIPTION
Trying to parse the current weather dialog while having unicode data in the dict sent to dialog rendering, this causes issues when forcing the data back to string.

Using format to handle the different types instead of using str() to avoid issues trying to force to string.

format can be used for all types basically:

```python
 d ={'utf': u'¡!utfÅÄÖ', 'str': 'asdf', 'float': 12.34, 'int':42, 'bool': True, 'object': object()}
print u'{utf} {str} {float} {int} {bool} {object}'.format(**d)
```

yields

`¡!utfÅÄÖ asdf 12.34 42 True <object object at 0x7f33e9bd00b0>`