### PR TITLE
Handle ConnectionError when retrieving user id in MutableMicrophone

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -31,7 +31,7 @@ from speech_recognition import (
     AudioSource,
     AudioData
 )
-from requests import HTTPError
+import requests
 
 from mycroft.api import DeviceApi
 from mycroft.configuration import Configuration
@@ -189,7 +189,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
         try:
             self.account_id = DeviceApi().get()['user']['uuid']
-        except (HTTPError, AttributeError):
+        except (requests.HTTPError, requests.ConnectionError, AttributeError):
             self.account_id = '0'
 
     @staticmethod


### PR DESCRIPTION
If the machine is not connected to the network getting the user uuid in MutableMic.__init__ will fail, raising ConnectionError. This caused the speech client to crash.

Adding handler for ConnectionError resolves this issue.

To test:
- Check out dev branch
- Disconnect from the network and start the speech client `workon mycroft && python mycroft/client/speech/main.py`, This should end in 
```
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='api.mycroft.ai', port=443): Max retries exceeded with url: /v1/device/051be23e-35c1-4d6b-ae2e-aefa6673fad5 (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7f831803c510>: Failed to establish a new connection: [Errno 101] Network is unreachable',))
```

- Switch to PR
- Disconnect from the network and start the speech client `workon mycroft && python mycroft/client/speech/main.py`, this should now continue working
- Reconnect to the network and verify that this is still working