### PR TITLE
Python 2/3 compatibility

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -23,6 +23,8 @@ from mycroft.configuration.config import DEFAULT_CONFIG, SYSTEM_CONFIG, \
 from mycroft.identity import IdentityManager
 from mycroft.version import VersionManager
 from mycroft.util import get_arch
+# python 2/3 compatibility
+from future.utils import iteritems
 
 _paired_cache = False
 
@@ -110,7 +112,7 @@ class Api(object):
     def build_json(self, params):
         json = params.get("json")
         if json and params["headers"]["Content-Type"] == "application/json":
-            for k, v in json.iteritems():
+            for k, v in iteritems(json):
                 if v == "":
                     json[k] = None
             params["json"] = json

--- a/mycroft/audio/main.py
+++ b/mycroft/audio/main.py
@@ -471,8 +471,8 @@ def main():
     AudioService(ws)  # Connect audio service instance to message bus
     try:
         ws.run_forever()
-    except KeyboardInterrupt as exc:
-        LOG.exception(exc)
+    except KeyboardInterrupt as e:
+        LOG.exception(e)
         speech.shutdown()
         sys.exit()
 

--- a/mycroft/audio/services/mopidy/mopidypost.py
+++ b/mycroft/audio/services/mopidy/mopidypost.py
@@ -25,7 +25,6 @@ _base_dict = {'jsonrpc': '2.0', 'id': 1, 'params': {}}
 
 class Mopidy(object):
     def __init__(self, url):
-        print "MOPIDY URL: " + url
         self.is_playing = False
         self.url = url + MOPIDY_API
         self.volume = None
@@ -41,7 +40,6 @@ class Mopidy(object):
         return r.json()['result'][1]['artists']
 
     def get_playlists(self, filter=None):
-        print "GETTING PLAYLISTS"
         d = copy(_base_dict)
         d['method'] = 'core.playlists.as_list'
         r = requests.post(self.url, data=json.dumps(d))
@@ -72,7 +70,6 @@ class Mopidy(object):
         d = copy(_base_dict)
         d['method'] = 'core.library.browse'
         d['params'] = {'uri': uri}
-        print "BROWSE"
         r = requests.post(self.url, data=json.dumps(d))
         if 'result' in r.json():
             return r.json()['result']
@@ -118,7 +115,6 @@ class Mopidy(object):
             r = requests.post(self.url, data=json.dumps(d))
 
     def stop(self):
-        print self.is_playing
         if self.is_playing:
             d = copy(_base_dict)
             d['method'] = 'core.playback.stop'
@@ -165,7 +161,6 @@ class Mopidy(object):
         d['params'] = {'uri': uri}
         r = requests.post(self.url, data=json.dumps(d))
         if 'result' in r.json():
-            print r.json()
             return [e['uri'] for e in r.json()['result']]
         else:
             return None
@@ -192,9 +187,7 @@ class Mopidy(object):
         return {e['name']: e for e in p if e['type'] == 'directory'}
 
     def get_local_playlists(self):
-        print "GETTING PLAYLISTS"
         p = self.get_playlists('m3u')
-        print "RETURNING PLAYLISTS"
         return {e['name']: e for e in p}
 
     def get_spotify_playlists(self):
@@ -203,9 +196,7 @@ class Mopidy(object):
 
     def get_gmusic_albums(self):
         p = self.browse('gmusic:album')
-        print p
         p = {e['name']: e for e in p if e['type'] == 'directory'}
-        print p
         return {e.split(' - ')[1]: p[e] for e in p}
 
     def get_gmusic_artists(self):

--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -14,7 +14,7 @@
 #
 import subprocess
 import time
-from Queue import Queue
+import sys
 from alsaaudio import Mixer
 from threading import Thread, Timer
 
@@ -35,6 +35,10 @@ from mycroft.util import play_wav, create_signal, connected, \
     wait_while_speaking
 from mycroft.util.audio_test import record
 from mycroft.util.log import LOG
+if sys.version_info[0] < 3:
+    from Queue import Queue
+else:
+    from queue import Queue
 
 
 class EnclosureReader(Thread):

--- a/mycroft/client/enclosure/display_manager.py
+++ b/mycroft/client/enclosure/display_manager.py
@@ -36,7 +36,7 @@ def _write_data(dictionary):
 
     if permission == "w+" and os.path.isdir(managerIPCDir) is False:
         os.makedirs(managerIPCDir)
-        os.chmod(managerIPCDir, 0777)
+        os.chmod(managerIPCDir, 0o777)
 
     try:
         with open(path, permission) as dispFile:
@@ -56,7 +56,7 @@ def _write_data(dictionary):
             dispFile.write(json.dumps(data))
             dispFile.truncate()
 
-        os.chmod(path, 0777)
+        os.chmod(path, 0o777)
 
     except Exception as e:
         LOG.error(e)

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -15,6 +15,7 @@
 import tempfile
 import time
 
+import sys
 import os
 from os.path import dirname, exists, join, abspath, expanduser, isdir, isfile
 
@@ -172,10 +173,11 @@ class PreciseHotword(HotWordEngine):
     @staticmethod
     def download(url, filename):
         import shutil
+
         # python 2/3 compatibility
-        try:
+        if sys.version_info[0] >= 3:
             from urllib.request import urlopen
-        except:
+        else:
             from urllib2 import urlopen
         LOG.info('Downloading: ' + url)
         req = urlopen(url)

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -172,7 +172,11 @@ class PreciseHotword(HotWordEngine):
     @staticmethod
     def download(url, filename):
         import shutil
-        from urllib2 import urlopen
+        # python 2/3 compatibility
+        try:
+            from urllib.request import urlopen
+        except:
+            from urllib2 import urlopen
         LOG.info('Downloading: ' + url)
         req = urlopen(url)
         with open(filename, 'wb') as fp:

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -13,9 +13,8 @@
 # limitations under the License.
 #
 import time
-from Queue import Queue, Empty
 from threading import Thread
-
+import sys
 import speech_recognition as sr
 from pyee import EventEmitter
 from requests import HTTPError
@@ -29,6 +28,10 @@ from mycroft.metrics import MetricsAggregator
 from mycroft.session import SessionManager
 from mycroft.stt import STTFactory
 from mycroft.util.log import LOG
+if sys.version_info[0] < 3:
+    from Queue import Queue, Empty
+else:
+    from queue import Queue, Empty
 
 
 class AudioProducer(Thread):
@@ -54,13 +57,13 @@ class AudioProducer(Thread):
                 try:
                     audio = self.recognizer.listen(source, self.emitter)
                     self.queue.put(audio)
-                except IOError, ex:
+                except IOError as e:
                     # NOTE: Audio stack on raspi is slightly different, throws
                     # IOError every other listen, almost like it can't handle
                     # buffering audio between listen loops.
                     # The internet was not helpful.
                     # http://stackoverflow.com/questions/10733903/pyaudio-input-overflowed
-                    self.emitter.emit("recognizer_loop:ioerror", ex)
+                    self.emitter.emit("recognizer_loop:ioerror", e)
 
     def stop(self):
         """

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -154,7 +154,7 @@ def main():
 
     try:
         loop.run()
-    except KeyboardInterrupt, e:
+    except KeyboardInterrupt as e:
         LOG.exception(e)
         sys.exit()
 

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -455,7 +455,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                     ww_module = self.wake_word_recognizer.__class__.__name__
 
                     ww = self.wake_word_name.replace(' ', '-')
-                    md = md5(ww_module).hexdigest()
+                    md = md5(ww_module.encode('utf-8')).hexdigest()
                     stamp = str(int(1000 * get_time()))
                     sid = SessionManager.get().session_id
                     aid = self.account_id

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
 import audioop
 import collections
 import datetime
@@ -134,6 +135,13 @@ class MutableMicrophone(Microphone):
         return self.muted
 
 
+def get_silence(num_bytes):
+    if sys.version_info[0] < 3:
+        return '\0' * num_bytes
+    else:
+        return bytes(num_bytes)
+
+
 class ResponsiveRecognizer(speech_recognition.Recognizer):
     # Padding of silence when feeding to pocketsphinx
     SILENCE_SEC = 0.01
@@ -246,7 +254,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                                     sec_per_buffer)
 
         # bytearray to store audio in
-        byte_data = '\0' * source.SAMPLE_WIDTH
+        byte_data = get_silence(source.SAMPLE_WIDTH)
 
         phrase_complete = False
         while num_chunks < max_chunks and not phrase_complete:
@@ -359,7 +367,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         num_silent_bytes = int(self.SILENCE_SEC * source.SAMPLE_RATE *
                                source.SAMPLE_WIDTH)
 
-        silence = '\0' * num_silent_bytes
+        silence = get_silence(num_silent_bytes)
 
         # bytearray to store audio in
         byte_data = silence

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import sys
 import audioop
 import collections
 import datetime
@@ -136,10 +135,7 @@ class MutableMicrophone(Microphone):
 
 
 def get_silence(num_bytes):
-    if sys.version_info[0] < 3:
-        return '\0' * num_bytes
-    else:
-        return bytes(num_bytes)
+    return b'\0' * num_bytes
 
 
 class ResponsiveRecognizer(speech_recognition.Recognizer):

--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -183,7 +183,7 @@ class LogMonitorThread(Thread):
                     mergedLog.append(self.logid + line.strip())
                 else:
                     if bSimple:
-                        print line.strip()
+                        print(line.strip())
                     else:
                         filteredLog.append(self.logid + line.strip())
                         mergedLog.append(self.logid + line.strip())
@@ -865,10 +865,10 @@ def gui_main(stdscr):
             # else:
             #    line += str(c)
 
-    except KeyboardInterrupt, e:
+    except KeyboardInterrupt as e:
         # User hit Ctrl+C to quit
         pass
-    except KeyboardInterrupt, e:
+    except KeyboardInterrupt as e:
         LOG.exception(e)
     finally:
         scr.erase()
@@ -893,10 +893,10 @@ def simple_cli():
             ws.emit(
                 Message("recognizer_loop:utterance",
                         {'utterances': [line.strip()]}))
-    except KeyboardInterrupt, e:
+    except KeyboardInterrupt as e:
         # User hit Ctrl+C to quit
         print("")
-    except KeyboardInterrupt, e:
+    except KeyboardInterrupt as e:
         LOG.exception(e)
         event_thread.exit()
         sys.exit()
@@ -928,7 +928,6 @@ def main():
         curses.wrapper(gui_main)
         curses.endwin()
         save_settings()
-
 
 if __name__ == "__main__":
     main()

--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 #
 import sys
-from cStringIO import StringIO
+from io import BytesIO
 
 # NOTE: If this script has errors, the following two lines might need to
 # be commented out for them to be displayed (depending on the type of
 # error).  But normally we want this to prevent extra messages from the
 # messagebus setup from appearing during startup.
-sys.stdout = StringIO()  # capture any output
-sys.stderr = StringIO()  # capture any output
+sys.stdout = BytesIO()  # capture any output
+sys.stderr = BytesIO()  # capture any output
 
 # All of the nopep8 comments below are to avoid E402 errors
 import os                                                   # nopep8
@@ -164,7 +164,7 @@ class LogMonitorThread(Thread):
         with open(self.filename, 'rb') as fh:
             fh.seek(bytefrom)
             while True:
-                line = fh.readline()
+                line = str(fh.readline())
                 if line == "":
                     break
 
@@ -221,7 +221,7 @@ class MicMonitorThread(Thread):
         global meter_cur
         global meter_thresh
 
-        with open(self.filename, 'rb') as fh:
+        with open(self.filename, 'r') as fh:
             fh.seek(bytefrom)
             while True:
                 line = fh.readline()
@@ -231,8 +231,8 @@ class MicMonitorThread(Thread):
                 # Just adjust meter settings
                 # Ex:Energy:  cur=4 thresh=1.5
                 parts = line.split("=")
-                meter_thresh = float(parts[len(parts) - 1])
-                meter_cur = float(parts[len(parts) - 2].split(" ")[0])
+                meter_thresh = float(parts[-1])
+                meter_cur = float(parts[-2].split(" ")[0])
 
 
 def start_mic_monitor(filename):
@@ -537,17 +537,17 @@ def _do_drawing(scr):
 
     # Log legend in the lower-right
     y_log_legend = curses.LINES - (3 + cy_chat_area)
-    scr.addstr(y_log_legend, curses.COLS / 2 + 2,
-               make_titlebar("Log Output Legend", curses.COLS / 2 - 2),
+    scr.addstr(y_log_legend, curses.COLS // 2 + 2,
+               make_titlebar("Log Output Legend", curses.COLS // 2 - 2),
                CLR_HEADING)
-    scr.addstr(y_log_legend + 1, curses.COLS / 2 + 2,
+    scr.addstr(y_log_legend + 1, curses.COLS // 2 + 2,
                "DEBUG output",
                CLR_LOG_DEBUG)
-    scr.addstr(y_log_legend + 2, curses.COLS / 2 + 2,
+    scr.addstr(y_log_legend + 2, curses.COLS // 2 + 2,
                os.path.basename(log_files[0]) + ", other",
                CLR_LOG1)
     if len(log_files) > 1:
-        scr.addstr(y_log_legend + 3, curses.COLS / 2 + 2,
+        scr.addstr(y_log_legend + 3, curses.COLS // 2 + 2,
                    os.path.basename(log_files[1]), CLR_LOG2)
 
     # Meter
@@ -558,7 +558,7 @@ def _do_drawing(scr):
 
     # History log in the middle
     y_chat_history = curses.LINES - (3 + cy_chat_area)
-    chat_width = curses.COLS / 2 - 2
+    chat_width = curses.COLS // 2 - 2
     chat_out = []
     scr.addstr(y_chat_history, 0, make_titlebar("History", chat_width),
                CLR_HEADING)
@@ -659,7 +659,7 @@ def show_help():
 def center(str_len):
     # generate number of characters needed to center a string
     # of the given length
-    return " " * ((curses.COLS - str_len) / 2)
+    return " " * ((curses.COLS - str_len) // 2)
 
 
 ##############################################################################
@@ -819,10 +819,10 @@ def gui_main(stdscr):
                     line = ""
             elif c == curses.KEY_LEFT:
                 # scroll long log lines left
-                log_line_lr_scroll += curses.COLS / 4
+                log_line_lr_scroll += curses.COLS // 4
             elif c == curses.KEY_RIGHT:
                 # scroll long log lines right
-                log_line_lr_scroll -= curses.COLS / 4
+                log_line_lr_scroll -= curses.COLS // 4
                 if log_line_lr_scroll < 0:
                     log_line_lr_scroll = 0
             elif c == curses.KEY_HOME:

--- a/mycroft/configuration/__init__.py
+++ b/mycroft/configuration/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from config import Configuration, LocalConf, RemoteConf, \
+from .config import Configuration, LocalConf, RemoteConf, \
                    SYSTEM_CONFIG, USER_CONFIG
 
 

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -23,7 +23,9 @@ from requests import HTTPError
 from mycroft.util.json_helper import load_commented_json
 from mycroft.util.log import LOG
 
+# Python 2+3 compatibility
 from future.utils import iteritems
+from past.builtins import basestring
 
 
 def merge_dict(base, delta):

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -23,6 +23,8 @@ from requests import HTTPError
 from mycroft.util.json_helper import load_commented_json
 from mycroft.util.log import LOG
 
+from future.utils import iteritems
+
 
 def merge_dict(base, delta):
     """
@@ -33,7 +35,7 @@ def merge_dict(base, delta):
             delta: Dictionary to merge into base
     """
 
-    for k, dv in delta.iteritems():
+    for k, dv in iteritems(delta):
         bv = base.get(k)
         if isinstance(dv, dict) and isinstance(bv, dict):
             merge_dict(bv, dv)
@@ -52,7 +54,7 @@ def translate_remote(config, setting):
     """
     IGNORED_SETTINGS = ["uuid", "@type", "active", "user", "device"]
 
-    for k, v in setting.iteritems():
+    for k, v in iteritems(setting):
         if k not in IGNORED_SETTINGS:
             # Translate the CamelCase values stored remotely into the
             # Python-style names used within mycroft-core.
@@ -108,7 +110,7 @@ class LocalConf(dict):
                     self.__setitem__(key, config[key])
 
                 LOG.debug("Configuration {} loaded".format(path))
-            except Exception, e:
+            except Exception as e:
                 LOG.error("Error loading configuration '{}'".format(path))
                 LOG.error(repr(e))
         else:

--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -66,7 +66,7 @@ class WebsocketClient(object):
         try:
             self.emitter.emit('error', error)
             self.client.close()
-        except Exception, e:
+        except Exception as e:
             LOG.error(repr(e))
         LOG.warning("WS Client will reconnect in %d seconds." % self.retry)
         time.sleep(self.retry)

--- a/mycroft/messagebus/send.py
+++ b/mycroft/messagebus/send.py
@@ -38,17 +38,17 @@ def main():
         try:
             dataToSend = json.loads(sys.argv[2])
         except BaseException:
-            print "Second argument must be a JSON string"
-            print "Ex: python -m mycroft.messagebus.send speak " \
-                "'{\"utterance\" : \"hello\"}'"
+            print("Second argument must be a JSON string")
+            print("Ex: python -m mycroft.messagebus.send speak "
+                  "'{\"utterance\" : \"hello\"}'")
             exit()
     else:
-        print "Command line interface to the mycroft-core messagebus."
-        print "Usage: python -m mycroft.messagebus.send message"
-        print "       python -m mycroft.messagebus.send message JSON-string\n"
-        print "Examples: python -m mycroft.messagebus.send mycroft.wifi.start"
-        print "Ex: python -m mycroft.messagebus.send speak " \
-            "'{\"utterance\" : \"hello\"}'"
+        print("Command line interface to the mycroft-core messagebus.")
+        print("Usage: python -m mycroft.messagebus.send message")
+        print("       python -m mycroft.messagebus.send message JSON-string\n")
+        print("Examples: python -m mycroft.messagebus.send mycroft.wifi.start")
+        print("Ex: python -m mycroft.messagebus.send speak "
+              "'{\"utterance\" : \"hello\"}'")
         exit()
 
     send(messageToSend, dataToSend)

--- a/mycroft/messagebus/send.py
+++ b/mycroft/messagebus/send.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# Backport python 3 print function
+from __future__ import print_function
+
 import sys
 import json
 from mycroft.messagebus.client.ws import WebsocketClient

--- a/mycroft/messagebus/service/ws.py
+++ b/mycroft/messagebus/service/ws.py
@@ -46,7 +46,7 @@ class WebsocketEventHandler(tornado.websocket.WebSocketHandler):
 
         try:
             self.emitter.emit(deserialized_message.type, deserialized_message)
-        except Exception, e:
+        except Exception as e:
             LOG.exception(e)
             traceback.print_exc(file=sys.stdout)
             pass

--- a/mycroft/skills/audioservice.py
+++ b/mycroft/skills/audioservice.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 #
 import time
-
 from os.path import abspath
 
 from mycroft.messagebus.message import Message
+# Python 2+3 compatibility
+from past.builtins import basestring
 
 
 def ensure_uri(s):

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -35,6 +35,8 @@ from mycroft.metrics import report_metric
 from mycroft.skills.settings import SkillSettings
 from mycroft.util.log import LOG
 
+# python 2+3 compatibility
+from past.builtins import basestring
 
 MainModule = '__init__'
 

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -14,13 +14,17 @@
 #
 import json
 import time
-from Queue import Queue
 from threading import Thread
 
 from os.path import isfile
 
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
+import sys
+if sys.version_info[0] < 3:
+    from Queue import Queue
+else:
+    from queue import Queue
 
 
 class EventScheduler(Thread):

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -22,6 +22,8 @@ from mycroft.messagebus.message import Message
 from mycroft.skills.core import open_intent_envelope
 from mycroft.util.log import LOG
 from mycroft.util.parse import normalize
+# python 2+3 compatibility
+from past.builtins import basestring
 
 
 class ContextManager(object):

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 import time
-from builtins import range
 from adapt.context import ContextManagerFrame
 from adapt.engine import IntentDeterminationEngine
 
@@ -24,6 +23,7 @@ from mycroft.util.log import LOG
 from mycroft.util.parse import normalize
 # python 2+3 compatibility
 from past.builtins import basestring
+from future.builtins import range
 
 
 class ContextManager(object):

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 import time
-
+from builtins import range
 from adapt.context import ContextManagerFrame
 from adapt.engine import IntentDeterminationEngine
 
@@ -89,7 +89,7 @@ class ContextManager(object):
 
         missing_entities = list(missing_entities)
         context = []
-        for i in xrange(max_frames):
+        for i in range(max_frames):
             frame_entities = [entity.copy() for entity in
                               relevant_frames[i].entities]
             for entity in frame_entities:
@@ -247,7 +247,6 @@ class IntentService(object):
             # update active skills
             skill_id = int(best_intent['intent_type'].split(":")[0])
             self.add_active_skill(skill_id)
-
         else:
             self.emitter.emit(Message("intent_failure", {
                 "utterance": utterances[0],

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -235,7 +235,7 @@ class IntentService(object):
             except StopIteration:
                 # don't show error in log
                 continue
-            except e:
+            except Exception as e:
                 LOG.exception(e)
                 continue
 
@@ -266,7 +266,6 @@ class IntentService(object):
                 start_concept, end_concept, alias_of=alias_of)
 
     def handle_register_intent(self, message):
-        print "Registering: " + str(message.data)
         intent = open_intent_envelope(message)
         self.engine.register_intent_parser(intent)
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -124,7 +124,7 @@ def _get_last_modified_date(path):
         Returns:    time of last change
     """
     last_date = 0
-    root_dir, subdirs, files = os.walk(path).next()
+    root_dir, subdirs, files = next(os.walk(path))
     # get subdirs and remove hidden ones
     subdirs = [s for s in subdirs if not s.startswith('.')]
     for subdir in subdirs:

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -14,7 +14,6 @@
 #
 import hashlib
 import random
-from Queue import Queue, Empty
 from threading import Thread
 from time import time, sleep
 
@@ -29,6 +28,11 @@ from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
 from mycroft.util import play_wav, play_mp3, check_for_signal, create_signal
 from mycroft.util.log import LOG
+import sys
+if sys.version_info[0] < 3:
+    from Queue import Queue, Empty
+else:
+    from queue import Queue, Empty
 
 
 class PlaybackThread(Thread):
@@ -89,7 +93,7 @@ class PlaybackThread(Thread):
                 self.blink(0.2)
             except Empty:
                 pass
-            except Exception, e:
+            except Exception as e:
                 LOG.exception(e)
                 if self._processing_queue:
                     self.tts.end_audio()

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -55,9 +55,8 @@ def download_subscriber_voices(selected_voice):
 
     # First download the selected voice if needed
     voice_file = SUBSCRIBER_VOICES.get(selected_voice)
-    print voice_file
     if voice_file is not None and not exists(voice_file):
-        print 'voice foesn\'t exist, downloading'
+        LOG.info('voice foesn\'t exist, downloading')
         dl = download(DeviceApi().get_subscriber_voice_url(selected_voice),
                       voice_file, make_executable)
         # Wait for completion
@@ -120,12 +119,13 @@ class Mimic(TTS):
     def visime(self, output):
         visimes = []
         start = time()
-        pairs = output.split(" ")
+        pairs = str(output).split(" ")
         for pair in pairs:
             pho_dur = pair.split(":")  # phoneme:duration
             if len(pho_dur) == 2:
                 visimes.append((VISIMES.get(pho_dur[0], '4'),
                                 float(pho_dur[1])))
+        print(visimes)
         return visimes
 
 

--- a/mycroft/tts/remote_tts.py
+++ b/mycroft/tts/remote_tts.py
@@ -43,7 +43,7 @@ class RemoteTTS(TTS):
                 try:
                     self.begin_audio()
                     self.__play(req)
-                except Exception, e:
+                except Exception as e:
                     LOG.error(e.message)
                 finally:
                     self.end_audio()

--- a/mycroft/util/download.py
+++ b/mycroft/util/download.py
@@ -85,7 +85,6 @@ class Downloader(Thread):
         tmp = _get_download_tmp(self.dest)
         self.status = self.perform_download(tmp)
 
-        print self.status
         if not self._abort and self.status == 0:
             self.finalize(tmp)
         else:

--- a/mycroft/util/setup_base.py
+++ b/mycroft/util/setup_base.py
@@ -37,7 +37,7 @@ def get_version():
         try:
             version = "dev-" + subprocess.check_output(
                 ["git", "rev-parse", "--short", "HEAD"]).strip()
-        except subprocess.CalledProcessError, e2:
+        except subprocess.CalledProcessError as e2:
             version = "development"
             LOG.debug(e)
             LOG.exception(e2)

--- a/mycroft/util/signal.py
+++ b/mycroft/util/signal.py
@@ -43,7 +43,7 @@ def get_ipc_directory(domain=None):
     return ensure_directory_exists(dir, domain)
 
 
-def ensure_directory_exists(dir, domain=None):
+def ensure_directory_exists(directory, domain=None):
     """ Create a directory and give access rights to all
 
     Args:
@@ -54,20 +54,20 @@ def ensure_directory_exists(dir, domain=None):
         str: a path to the directory
     """
     if domain:
-        dir = os.path.join(dir, domain)
-    dir = os.path.normpath(dir)
+        directory = os.path.join(directory, domain)
+    directory = os.path.normpath(directory)
 
-    if not os.path.isdir(dir):
+    if not os.path.isdir(directory):
         try:
             save = os.umask(0)
-            os.makedirs(dir, 0777)  # give everyone rights to r/w here
+            os.makedirs(directory, 0o777)  # give everyone rights to r/w here
         except OSError:
-            LOG.warning("Failed to create: " + dir)
+            LOG.warning("Failed to create: " + directory)
             pass
         finally:
             os.umask(save)
 
-    return dir
+    return directory
 
 
 def create_file(filename):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ tornado==4.2.1
 websocket-client==0.32.0
 adapt-parser==0.3.0
 futures==3.0.3
+future==0.16.0
 requests-futures==0.9.5
 parsedatetime==1.5
 pyyaml==3.11


### PR DESCRIPTION
Adding python 2/3 compatibility to, speech client, audio, skills and messagebus services.

Most of the changes are very trivial, for example using the more modern exception syntax (`except Exception as e:` instead of `except Exception, e:`. I've been using http://python-future.org/compatible_idioms.html as a guide and tried to use the "best" solutions for compatibility.

The cli still misbehaves under python 3 and there is a name-space collision with signal when running the audiotest but I believe this is a good start and will be good to have in preparation for the move to python3.