### PR TITLE
allow phonemes in any lang

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -34,7 +34,6 @@ RECOGNIZER_DIR = join(abspath(dirname(__file__)), "recognizer")
 
 class HotWordEngine(object):
     def __init__(self, key_phrase="hey mycroft", config=None, lang="en-us"):
-        self.lang = str(lang).lower()
         self.key_phrase = str(key_phrase).lower()
         # rough estimate 1 phoneme per 2 chars
         self.num_phonemes = len(key_phrase) / 2 + 1
@@ -43,7 +42,7 @@ class HotWordEngine(object):
             config = config.get(self.key_phrase, {})
         self.config = config
         self.listener_config = Configuration.get().get("listener", {})
-        self.lang = str(self.config.get("lang", self.lang)).lower()
+        self.lang = str(self.config.get("lang", lang)).lower()
 
     def found_wake_word(self, frame_data):
         return False

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -43,7 +43,7 @@ class HotWordEngine(object):
             config = config.get(self.key_phrase, {})
         self.config = config
         self.listener_config = Configuration.get().get("listener", {})
-        self.lang = self.config.get("lang", self.lang)
+        self.lang = str(self.config.get("lang", self.lang)).lower()
 
     def found_wake_word(self, frame_data):
         return False

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -43,6 +43,7 @@ class HotWordEngine(object):
             config = config.get(self.key_phrase, {})
         self.config = config
         self.listener_config = Configuration.get().get("listener", {})
+        self.lang = self.config.get("lang", self.lang)
 
     def found_wake_word(self, frame_data):
         return False

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -145,13 +145,15 @@
     "hey mycroft": {
         "module": "pocketsphinx",
         "phonemes": "HH EY . M AY K R AO F T",
-        "threshold": 1e-90
+        "threshold": 1e-90,
+        "lang": "en-us"
         },
 
     "wake up": {
         "module": "pocketsphinx",
         "phonemes": "W EY K . AH P",
-        "threshold": 1e-20
+        "threshold": 1e-20,
+        "lang": "en-us"
         }
   },
 


### PR DESCRIPTION
info:

wakewords now work even if the main language is changed, as long as the phonemes are accurate everything should just work

changes made:

This allows hotword engines to explicitly request a language in config file

solves:

English phonemes may not exist in other language, which would break wakeword when changing main language

