### PR TITLE
Make reference leak detection more reliable

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -284,5 +284,6 @@
       }
     },
     "default-backend": "local"
-  }
+  },
+  "debug": false
 }

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -42,6 +42,7 @@ ws = None
 event_scheduler = None
 skill_manager = None
 
+DEBUG = Configuration.get().get("debug", False)
 skills_config = Configuration.get().get("skills")
 BLACKLISTED_SKILLS = skills_config.get("blacklisted_skills", [])
 PRIORITY_SKILLS = skills_config.get("priority_skills", [])
@@ -279,15 +280,16 @@ class SkillManager(Thread):
             # removing listeners and stopping threads
             skill["instance"].shutdown()
 
-            gc.collect()  # Collect garbage to remove false references
-            # Remove two local references that are known
-            refs = sys.getrefcount(skill["instance"]) - 2
-            if refs > 0:
-                LOG.warning(
-                    "After shutdown of {} there are still "
-                    "{} references remaining. The skill "
-                    "won't be cleaned from memory."
-                    .format(skill['instance'].name, refs))
+            if DEBUG:
+                gc.collect()  # Collect garbage to remove false references
+                # Remove two local references that are known
+                refs = sys.getrefcount(skill["instance"]) - 2
+                if refs > 0:
+                    LOG.warning(
+                        "After shutdown of {} there are still "
+                        "{} references remaining. The skill "
+                        "won't be cleaned from memory."
+                        .format(skill['instance'].name, refs))
             del skill["instance"]
 
         # (Re)load the skill from disk

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 import time
 from threading import Timer, Thread, Event, Lock
+import gc
 
 import os
 from os.path import exists, join
@@ -278,6 +279,7 @@ class SkillManager(Thread):
             # removing listeners and stopping threads
             skill["instance"].shutdown()
 
+            gc.collect()  # Collect garbage to remove false references
             # Remove two local references that are known
             refs = sys.getrefcount(skill["instance"]) - 2
             if refs > 0:


### PR DESCRIPTION
The reference count sometimes reported that references were remaining
even if they actually weren't. By enforcing a garbage collector run
after shutting down a skill the false positives are reduced if not
removed all together.

As this is mainly for developers and can reduce performance it is now only active if a "debug" config value is set.