### PR TITLE
Correct test coverage

### DIFF
--- a/test/unittests/unittest.cfg
+++ b/test/unittests/unittest.cfg
@@ -1,2 +1,5 @@
 [unittest]
 test-file-pattern=*.py
+
+[coverage]
+coverage = mycroft


### PR DESCRIPTION
Previously the coverage counted the entire mycroft core including things
such as the docs and the tests themself. The inclusion of the actual
tests in the coverage metric scewed the metric quite a bit and the
inclusion of irrelevant files made the information presented by
coveralls cluttered.