### PR TITLE
Added a new feature to... nevermind

### DIFF
--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -23,7 +23,7 @@ from mycroft.util.log import LOG
 class MustacheDialogRenderer(object):
     """
     A dialog template renderer based on the {{mustache}} templating language.
-    
+
     The {{mustache}} language is a simple scheme that supports simple,
     position-independent templating.  We use this same basic concept, but only
     implement the variable replacement mechanism -- no HTML quoting with triple

--- a/mycroft/res/text/en-us/nevermind.dialog
+++ b/mycroft/res/text/en-us/nevermind.dialog
@@ -1,0 +1,3 @@
+nevermind
+cancel
+ignore that

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -17,6 +17,7 @@ import time
 from adapt.context import ContextManagerFrame
 from adapt.engine import IntentDeterminationEngine
 
+import mycroft.dialog
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import open_intent_envelope
@@ -207,6 +208,14 @@ class IntentService(object):
             lang = "en-us"
 
         utterances = message.data.get('utterances', '')
+        
+        # check if the user aborted the utterance, e.g.
+        # "Hey Mycroft, can you play...aw heck...nevermind"
+        neverminds = mycroft.dialog.get_all("nevermind", lang)
+        for nevermind in neverminds:
+            for utterance in utterances:
+                if utterance.endswith(nevermind)
+                    return
 
         # check for conversation time-out
         self.active_skills = [skill for skill in self.active_skills

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -214,7 +214,7 @@ class IntentService(object):
         neverminds = mycroft.dialog.get_all("nevermind", lang)
         for nevermind in neverminds:
             for utterance in utterances:
-                if utterance.endswith(nevermind)
+                if utterance.endswith(nevermind):
                     return
 
         # check for conversation time-out


### PR DESCRIPTION
The utterance processing now looks at the tail end of the transcribed phrase, ignoring the utterance if it ends with "nevermind" or "cancel" or "ignore that".  This is for use case like:
   Hey Mycroft, can you tell me the...ummm...oh, nevermind

I have some concerns about a few corner cases that a skill might want to use.
For example:
 * Hey Mycroft, play Nirvana's Nevermind
 * Hey Mycroft, I want that last request to cancel
But I think this is something that can normally be designed around easily.

====  Tech Notes ====
Added mycroft.dialog.get_all(phrase, lang, context).  This lets you load all of the rendered versions, not just a single randomly selected one.

This class has the experiment of returning a value when a matching .dialog file isn't found.  Instead it returns ['phrase'], replacing the . with spaces.  So if I add:
    mycroft.dialog.get_all("thank.you") and there is no resource file found named 'thank.you.dialog', it will still return successfully:  ['thank you']

==== Localization Notes ====
This adds the new "nevermind" core resource string.