### PR TITLE
Fix data field in msm messagebus messages.

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -143,16 +143,16 @@ function send_start_remove () {
     fi
 }
 function send_install_success () {
-    python -m mycroft.messagebus.send msm.install.succeeded '{"skill": "${1}" }'
+    python -m mycroft.messagebus.send msm.install.succeeded "{\"skill\": \"${1}\" }"
 }
 function send_install_fail () {
-    python -m mycroft.messagebus.send msm.install.failed '{"skill": "${1}", "error" : ${2} }'
+    python -m mycroft.messagebus.send msm.install.failed "{\"skill\": \"${1}\", \"error\" : ${2} }"
 }
 function send_remove_success () {
-    python -m mycroft.messagebus.send msm.remove.succeeded '{"skill": "${1}" }'
+    python -m mycroft.messagebus.send msm.remove.succeeded "{\"skill\": \"${1}\" }"
 }
 function send_remove_fail () {
-    python -m mycroft.messagebus.send msm.remove.failed '{"skill": "${1}", "error" : ${2} }'
+    python -m mycroft.messagebus.send msm.remove.failed "{\"skill\": \"${1}\", \"error\" : ${2} }"
 }
 function send_end_install () {
     if [[ "${install_started}" == "true" ]] ; then


### PR DESCRIPTION
Previously the msm data messages were not sent correctly, what appeared
on the bus was:
11:25:21.508 - SKILLS - DEBUG - {"type": "msm.install.succeeded", "data": {"skill": "${1}"}, "context": null}

(note the *${1}*) instead of the expected:
13:11:41.497 - SKILLS - DEBUG - {"type": "msm.install.succeeded", "data": {"skill": "skill-alarm"}, "context": null}

This was due to the use of `'` instead of `"` around the data field, the
`'`-strings does not replace variable names with their value.