### PR TITLE
Fix skill metrics

### DIFF
--- a/mycroft/metrics/__init__.py
+++ b/mycroft/metrics/__init__.py
@@ -30,7 +30,7 @@ def report_metric(name, data):
     Report a general metric to the Mycroft servers
 
     Args:
-        name (str): Name of metric
+        name (str): Name of metric. Must use only letters and hyphens
         data (dict): JSON dictionary to report. Must be valid JSON
     """
     if Configuration().get()['opt_in']:

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -332,10 +332,10 @@ class MycroftSkill(object):
         Report a skill metric to the Mycroft servers
 
         Args:
-            name (str): Name of metric
+            name (str): Name of metric. Must use only letters and hyphens
             data (dict): JSON dictionary to report. Must be valid JSON
         """
-        report_metric(basename(self.root_dir) + '/' + name, data)
+        report_metric(basename(self.root_dir) + ':' + name, data)
 
     def send_email(self, title, body):
         """


### PR DESCRIPTION
Otherwise, skill metric reporting always errors out because of an invalid endpoint.