### PR TITLE
Add get_response method as a synchronous alternative to converse

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -152,6 +152,7 @@ class AudioConsumer(Thread):
                 text = "pair my device"  # phrase to start the pairing process
                 LOG.warning("Access Denied at mycroft.ai")
         except Exception as e:
+            self.emitter.emit('recognizer_loop:speech.recognition.unknown')
             LOG.error(e)
             LOG.error("Speech Recognition could not understand audio")
         if text:

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -56,6 +56,10 @@ def handle_utterance(event):
     ws.emit(Message('recognizer_loop:utterance', event))
 
 
+def handle_unknown():
+    ws.emit(Message('mycroft.speech.recognition.unknown'))
+
+
 def handle_speak(event):
     """
         Forward speak message to message bus.
@@ -133,6 +137,7 @@ def main():
     Configuration.init(ws)
     loop = RecognizerLoop()
     loop.on('recognizer_loop:utterance', handle_utterance)
+    loop.on('recognizer_loop:speech.recognition.unknown', handle_unknown)
     loop.on('speak', handle_speak)
     loop.on('recognizer_loop:record_begin', handle_record_begin)
     loop.on('recognizer_loop:wakeword', handle_wakeword)

--- a/mycroft/res/text/en-us/cancel.voc
+++ b/mycroft/res/text/en-us/cancel.voc
@@ -1,0 +1,5 @@
+cancel
+stop
+end
+I am done
+nevermind

--- a/mycroft/res/text/en-us/cancel.voc
+++ b/mycroft/res/text/en-us/cancel.voc
@@ -1,5 +1,3 @@
 cancel
-stop
-end
-I am done
 nevermind
+forget it

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -405,11 +405,11 @@ class MycroftSkill(object):
         def is_cancel(utterance):
             return utterance in cancel_words
 
-        def on_valid_default(utterance):
+        def validator_default(utterance):
             # accept anything except 'cancel'
             return not is_cancel(utterance)
 
-        validator = validator or on_valid_default
+        validator = validator or validator_default
         on_fail_fn = on_fail if callable(on_fail) else on_fail_default
 
         self.speak(get_announcement(), expect_response=True)

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -348,7 +348,7 @@ class MycroftSkill(object):
         converse.response = None
         default_converse = self.converse
         self.converse = converse
-        event.wait(10)  # after 10 seconds, timeout
+        event.wait(15)  # 10 for listener, 5 for SST, then timeout
         self.converse = default_converse
         return converse.response
 
@@ -383,8 +383,10 @@ class MycroftSkill(object):
         """
         data = data or {}
 
-        announcement = announcement or self.dialog_renderer.render(dialog, data)
-        if not announcement:
+        def get_announcement():
+            return announcement or self.dialog_renderer.render(dialog, data)
+
+        if not get_announcement():
             raise ValueError('announcement or dialog message required')
 
         def on_fail_default(utterance):
@@ -393,7 +395,7 @@ class MycroftSkill(object):
             if on_fail:
                 return self.dialog_renderer.render(on_fail, fail_data)
             else:
-                return announcement
+                return get_announcement()
 
         # TODO: Load with something like mycroft.dialog.get_all()
         cancel_voc = 'text/' + self.lang + '/cancel.voc'
@@ -410,7 +412,7 @@ class MycroftSkill(object):
         validator = validator or on_valid_default
         on_fail_fn = on_fail if callable(on_fail) else on_fail_default
 
-        self.speak(announcement, expect_response=True)
+        self.speak(get_announcement(), expect_response=True)
         num_fails = 0
         while True:
             response = self.__get_response()

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -23,7 +23,8 @@ import abc
 import re
 from adapt.intent import Intent, IntentBuilder
 from os import listdir
-from os.path import join, abspath, dirname, splitext, basename, exists
+from os.path import join, abspath, dirname, splitext, basename, exists, isfile
+from threading import Event
 
 from mycroft.api import DeviceApi
 from mycroft.client.enclosure.api import EnclosureAPI
@@ -33,6 +34,7 @@ from mycroft.filesystem import FileSystemAccess
 from mycroft.messagebus.message import Message
 from mycroft.metrics import report_metric
 from mycroft.skills.settings import SkillSettings
+from mycroft.util import resolve_resource_file
 from mycroft.util.log import LOG
 
 
@@ -320,12 +322,108 @@ class MycroftSkill(object):
             indicate that the utterance has been handled.
 
             Args:
-                utterances: The utterances from the user
+                utterances (list): The utterances from the user
                 lang:       language the utterance is in
 
             Returns:    True if an utterance was handled, otherwise False
         """
         return False
+
+    def __get_response(self):
+        """
+        Grab a reponse from the user
+        Returns:
+            str: STT transcription
+        """
+        event = Event()
+
+        def converse(utterances, lang="en-us"):
+            converse.response = utterances[0] if utterances else None
+            event.set()
+            return True
+
+        self.make_active()
+        converse.response = None
+        default_converse = self.converse
+        self.converse = converse
+        event.wait(20)
+        self.converse = default_converse
+        return converse.response
+
+    def get_response(self, dialog='', data=None, text='', validator=None,
+                     on_fail=None, num_retries=-1):
+        """
+        Ask and return a response from the user for the given dialog. Examples:
+        color = self.get_response(dialog='ask.favorite.color')
+
+        Args:
+            dialog (str): Intro dialog file to read to the user
+            data (dict): Data used to render the dialog
+            text (str): Intro text instead of dialog file
+            validator (any): Function with following signature
+                def validator(utterance):
+                    return is_valid(utterance)
+            on_fail (any): Dialog file to read on invalid input,
+                or a function to call that returns utterance
+                def on_fail(utterance):
+                    return self.dialog_renderer.render('my.dialog')
+            num_retries (int): Number of times to keep asking user for input
+                Note, the user can still stop talking or say "cancel" at any
+                time to stop. -1 for infinite
+        Returns:
+            any: None or transcription user's reply
+        """
+        data = data or {}
+        validator = validator or bool
+
+        def get_intro():
+            if dialog:
+                return self.dialog_renderer.render(dialog, data)
+            else:
+                return text
+
+        if not get_intro() and not text:
+            raise ValueError('Please specify an intro message')
+
+        def on_fail_default(utterance):
+            fail_data = data.copy()
+            fail_data['utterance'] = utterance
+            if on_fail:
+                return self.dialog_renderer.render(on_fail, fail_data)
+            else:
+                return get_intro()
+
+        cancel_voc = 'text/' + self.lang + '/cancel.voc'
+        with open(resolve_resource_file(cancel_voc)) as f:
+            cancel_words = list(filter(bool, f.read().split('\n')))
+
+        def is_cancel(utterance):
+            return max(w in utterance for w in cancel_words)
+
+        on_fail_fn = on_fail if callable(on_fail) else on_fail_default
+
+        self.speak(get_intro(), expect_response=True)
+        num_fails = 0
+        while True:
+            response = self.__get_response()
+
+            if response is None:
+                num_none_fails = 1 if num_retries < 0 else num_retries
+                if num_fails >= num_none_fails:
+                    return None
+            else:
+                if validator(response):
+                    return response
+
+                if is_cancel(response):
+                    return None
+
+            num_fails += 1
+            if 0 < num_retries < num_fails:
+                return None
+
+            line = on_fail_fn(response)
+            self.speak(line, expect_response=True)
 
     def report_metric(self, name, data):
         """
@@ -841,8 +939,8 @@ class FallbackSkill(MycroftSkill):
                                   "fallback_handler": get_handler_name(
                                       handler)}))
                         return
-                except Exception as e:
-                    LOG.info('Exception in fallback: ' + str(e))
+                except Exception:
+                    LOG.exception('Exception in fallback.')
             ws.emit(Message('complete_intent_failure'))
             LOG.warning('No fallback could handle intent.')
             #  indicate completion with exception
@@ -873,7 +971,12 @@ class FallbackSkill(MycroftSkill):
             register a fallback with the list of fallback handlers
             and with the list of handlers registered by this instance
         """
-        self.instance_fallback_handlers.append(handler)
+        def wrapper(*args, **kwargs):
+            if handler(*args, **kwargs):
+                self.make_active()
+                return True
+            return False
+        self.instance_fallback_handlers.append(wrapper)
         self._register_fallback(handler, priority)
 
     @classmethod

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -23,7 +23,7 @@ import abc
 import re
 from adapt.intent import Intent, IntentBuilder
 from os import listdir
-from os.path import join, abspath, dirname, splitext, basename, exists, isfile
+from os.path import join, abspath, dirname, splitext, basename, exists
 from threading import Event
 
 from mycroft.api import DeviceApi

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -384,8 +384,8 @@ class SkillManager(Thread):
                         "skill_id": skill_id, "result": result}))
                     return
                 except BaseException:
-                    LOG.error(
-                        "Converse method malformed for skill " + str(skill_id))
+                    LOG.exception(
+                        "Error in converse method for skill " + str(skill_id))
         self.ws.emit(Message("skill.converse.response",
                              {"skill_id": 0, "result": False}))
 


### PR DESCRIPTION
Documentation:
```python
def get_response(self, dialog, data=None):
    """
    Ask and return a response from the user for the given dialog

    Args:
        dialog (str): Dialog file to read to the user
        data (str): data used to render the dialog
    Returns:
        any: None or transcription user's reply
    """
    pass
```

Example usage:
```python
color = self.get_response('what.is.your.favorite.color')
if color:
    self.speak('My favorite color is also ' + color)
```