### PR TITLE
Add support for unnamed intents

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -295,11 +295,11 @@ class MycroftSkill(object):
 
     def initialize(self):
         """
-        Initialization function to be implemented by all Skills.
+        Initialization function, run after fully constructed
 
         Usually used to create intents rules and register them.
         """
-        LOG.debug("No initialize function implemented")
+        pass
 
     def get_intro_message(self):
         """
@@ -458,6 +458,10 @@ class MycroftSkill(object):
             intent_parser = intent_parser.build()
         elif type(intent_parser) != Intent:
             raise ValueError('intent_parser is not an Intent')
+
+        if not intent_parser.name:
+            # Default to the handler's function name if None or ""
+            intent_parser.name = handler.__name__
 
         name = intent_parser.name
         intent_parser.name = str(self.skill_id) + ':' + intent_parser.name

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -400,6 +400,8 @@ class MycroftSkill(object):
                         except TypeError:
                             handler(self)
                     else:
+                        LOG.error("Unexpected argument count:" +
+                                  str(len(getargspec(handler).args)))
                         raise TypeError
                 else:
                     if len(getargspec(handler).args) == 2:
@@ -407,13 +409,17 @@ class MycroftSkill(object):
                     elif len(getargspec(handler).args) == 1:
                         handler()
                     else:
+                        LOG.error("Unexpected argument count:" +
+                                  str(len(getargspec(handler).args)))
                         raise TypeError
                 self.settings.store()  # Store settings if they've changed
             except Exception as e:
+                # Convert "MyFancySkill" to "My Fancy Skill" for speaking
+                name = re.sub("([a-z])([A-Z])","\g<1> \g<2>", self.name)
                 # TODO: Localize
                 self.speak(
                     "An error occurred while processing a request in " +
-                    self.name)
+                    name)
                 LOG.error(
                     "An error occurred while processing a request in " +
                     self.name, exc_info=True)
@@ -460,8 +466,7 @@ class MycroftSkill(object):
 
         # Default to the handler's function name if none given
         name = intent_parser.name or handler.__name__
-
-        intent_parser.name = str(self.skill_id) + ':' + intent_parser.name
+        intent_parser.name = str(self.skill_id) + ':' + name
         self.emitter.emit(Message("register_intent", intent_parser.__dict__))
         self.registered_intents.append((name, intent_parser))
         self.add_event(intent_parser.name, handler, need_self)

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -295,9 +295,8 @@ class MycroftSkill(object):
 
     def initialize(self):
         """
-        Initialization function, run after fully constructed
-
-        Usually used to create intents rules and register them.
+        Invoked after the skill is fully constructed and registered with the
+        system.  Use to perform any final setup needed for the skill.
         """
         pass
 
@@ -459,11 +458,9 @@ class MycroftSkill(object):
         elif type(intent_parser) != Intent:
             raise ValueError('intent_parser is not an Intent')
 
-        if not intent_parser.name:
-            # Default to the handler's function name if None or ""
-            intent_parser.name = handler.__name__
+        # Default to the handler's function name if none given
+        name = intent_parser.name or handler.__name__
 
-        name = intent_parser.name
         intent_parser.name = str(self.skill_id) + ':' + intent_parser.name
         self.emitter.emit(Message("register_intent", intent_parser.__dict__))
         self.registered_intents.append((name, intent_parser))

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -415,7 +415,7 @@ class MycroftSkill(object):
                 self.settings.store()  # Store settings if they've changed
             except Exception as e:
                 # Convert "MyFancySkill" to "My Fancy Skill" for speaking
-                name = re.sub("([a-z])([A-Z])","\g<1> \g<2>", self.name)
+                name = re.sub("([a-z])([A-Z])", "\g<1> \g<2>", self.name)
                 # TODO: Localize
                 self.speak(
                     "An error occurred while processing a request in " +


### PR DESCRIPTION
This allows skill writers to ignore naming intents.  Combined with a
forthcoming change to Adapt that creates a default of None for IntentBuilder()

This allows the current:
    @intent_handler(IntentBuilder("CurrentWeatherIntent").require(
        "Weather").optionally("Location").build())
    def handle_current_weather(self, message):
        ...

To become:
    @intent_handler(IntentBuilder().require("Weather").optionally("Location"))
    def handle_current_weather(self, message):
        ...

Which will automatically name the Intent "handle_current_weather".

Also dropped the log message in the default initialize() method since it is
common to not override it now.