### PR TITLE
Modifications for wifi-setup rework

### DIFF
--- a/mycroft/res/text/en-us/mycroft.intro.dialog
+++ b/mycroft/res/text/en-us/mycroft.intro.dialog
@@ -1,0 +1,1 @@
+Hello I am Mycroft, your new assistant. To assist you I need to be connected to the internet. You can either plug me in with a network cable, or use wifi. Follow these instructions to set up wifi:


### PR DESCRIPTION
The new wifi-setup rework requires the lang parameter (and defaults to English if not given). This also moves the intro text to a dialog file.