### PR TITLE
Fix the timing of isSpeaking signal

### DIFF
--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -158,7 +158,6 @@ class TTS(object):
         """Helper function for child classes to call in execute()"""
         # Create signals informing start of speech
         self.ws.emit(Message("recognizer_loop:audio_output_start"))
-        create_signal("isSpeaking")
 
     def end_audio(self):
         """
@@ -206,6 +205,7 @@ class TTS(object):
             Args:
                 sentence:   Sentence to be spoken
         """
+        create_signal("isSpeaking")
         key = str(hashlib.md5(sentence.encode('utf-8', 'ignore')).hexdigest())
         wav_file = os.path.join(mycroft.util.get_cache_directory("tts"),
                                 key + '.' + self.type)


### PR DESCRIPTION
The isSpeaking signal would only be generated when the actual audio playback
started, but this could be several seconds for TTS engines like Mimic which
take some time to generate the audio file for playback.  This changes the
creation of the "isSpeaking" signal to the start of the execute() method,
which should queue up audio and leave the signal set until the queue has
eventually been cleared.