### PR TITLE
Add phonetic spelling option to TTS engines

### DIFF
--- a/mycroft/res/text/en-us/phonetic_spellings.txt
+++ b/mycroft/res/text/en-us/phonetic_spellings.txt
@@ -1,0 +1,2 @@
+jalepeno: hallipeenyo
+ai: A.I.

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -18,16 +18,19 @@ from Queue import Queue, Empty
 from threading import Thread
 from time import time, sleep
 
+import re
 import os
 import os.path
 from abc import ABCMeta, abstractmethod
-from os.path import dirname, exists, isdir
+from os.path import dirname, exists, isdir, join
 
 import mycroft.util
 from mycroft.client.enclosure.api import EnclosureAPI
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
-from mycroft.util import play_wav, play_mp3, check_for_signal, create_signal
+from mycroft.util import (
+    play_wav, play_mp3, check_for_signal, create_signal, resolve_resource_file
+)
 from mycroft.util.log import LOG
 
 
@@ -141,18 +144,35 @@ class TTS(object):
     """
     __metaclass__ = ABCMeta
 
-    def __init__(self, lang, voice, validator):
+    def __init__(self, lang, voice, validator, phonetic_spelling=True):
         super(TTS, self).__init__()
         self.lang = lang or 'en-us'
         self.voice = voice
         self.filename = '/tmp/tts.wav'
         self.validator = validator
+        self.phonetic_spelling = phonetic_spelling
         self.enclosure = None
         random.seed()
         self.queue = Queue()
         self.playback = PlaybackThread(self.queue)
         self.playback.start()
         self.clear_cache()
+        self.spellings = self.load_spellings()
+
+    def load_spellings(self):
+        """Load phonetic spellings of words as dictionary"""
+        path = join('text', self.lang, 'phonetic_spellings.txt')
+        spellings_file = resolve_resource_file(path)
+        if not spellings_file:
+            return {}
+        try:
+            with open(spellings_file) as f:
+                lines = filter(bool, f.read().split('\n'))
+            lines = [i.split(':') for i in lines]
+            return {key.strip(): value.strip() for key, value in lines}
+        except ValueError:
+            LOG.exception('Failed to load phonetic spellings.')
+            return {}
 
     def begin_audio(self):
         """Helper function for child classes to call in execute()"""
@@ -206,6 +226,11 @@ class TTS(object):
                 sentence:   Sentence to be spoken
         """
         create_signal("isSpeaking")
+        if self.phonetic_spelling:
+            for word in re.findall(r"[\w']+", sentence):
+                if word in self.spellings:
+                    sentence = sentence.replace(word, self.spellings[word])
+
         key = str(hashlib.md5(sentence.encode('utf-8', 'ignore')).hexdigest())
         wav_file = os.path.join(mycroft.util.get_cache_directory("tts"),
                                 key + '.' + self.type)


### PR DESCRIPTION
This can be used to resolve common pronunciation issues with TTS engines. Any engine can pass a parameter to the base constructor to disable this.