### PR TITLE
Global Sync for skill settings

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -18,6 +18,18 @@
     system to provide a GUI interface, described by meta-data described in
     an optional 'settingsmeta.json' file.
 
+    As it stands today, if you have multiple devices with the same skill
+    installed, they will share the same settings if the settings is can be
+    configurable on the web (anything sent by settingsmeta.json). If a skill
+    modify a setting on the client that can be configured in the web, the web
+    will update with the settings modified from the skill. Currently ONLY
+    the creator of the skill can modify the the web settings from the skill
+    it self. The creator is defined as the device that is the first one to
+    upload the settingsmeta.json to the web ui. This is temporary until
+    some mechanism are put into place in the backend to allow any device to
+    modify the settings configurable from the web.
+
+
     Usage Example:
         from mycroft.skill.settings import SkillSettings
 
@@ -463,6 +475,6 @@ class SkillSettings(dict):
             hashed_meta = self._get_meta_hash(settings_meta)
             uuid = self._load_uuid()
             if uuid is not None:
-                LOG.info("deleting meata data for {}".format(self.name))
+                LOG.info("deleting meta data for {}".format(self.name))
                 self._delete_metadata(uuid)
             self._upload_meta(settings_meta, hashed_meta)

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -88,7 +88,7 @@ class SkillSettings(dict):
             if self._is_new_hash(hashed_meta):
                 # first look at all other devices on user account to see
                 # if the settings exist. if it does then sync with this device
-                if skill_settings is not None:
+                if skill_settings:
                     # is_synced flags that this settings is loaded from
                     # another device. If a skill settings doesn't have
                     # is_synced, then the skill is created from that device

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -220,7 +220,7 @@ class SkillSettings(dict):
                 hashed_meta (str): {skill-folder}-settinsmeta.json
         """
         LOG.info("sending settingsmeta.json for {}".format(self.name) +
-                 " to home.mycroft.ai")
+                 " to servers")
         meta = self._migrate_settings(settings_meta)
         meta['identifier'] = str(hashed_meta)
         response = self._send_settings_meta(meta)
@@ -302,13 +302,13 @@ class SkillSettings(dict):
             if self.__getitem__('is_synced'):
                 LOG.info(
                     "syncing settings from other devices "
-                    "from home.mycroft.ai for {}".format(self.name))
+                    "from server for {}".format(self.name))
                 skills_settings = self._get_skill_by_identifier(hashed_meta)
                 if skills_settings is None:
                     raise
         except Exception as e:
             LOG.info("syncing settings from "
-                     "home.mycroft.ai for {}".format(self.name))
+                     "server for {}".format(self.name))
             skills_settings = self.get_remote_device_settings(hashed_meta)
 
         if skills_settings is not None:
@@ -389,7 +389,7 @@ class SkillSettings(dict):
             return user_skill[0]
 
     def _put_metadata(self, settings_meta):
-        """ PUT settingsmeta to backend to be configured in home.mycroft.ai.
+        """ PUT settingsmeta to backend to be configured in server.
             used in place of POST and PATCH.
 
             Args:

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -13,21 +13,40 @@
 # limitations under the License.
 #
 """
-    SkillSettings is a simple extension of the python dict which enables
-    local storage of settings.  Additionally it can interact with a backend
-    system to provide a GUI interface, described by meta-data described in
-    an optional 'settingsmeta.json' file.
+    SkillSettings is a simple extension of a Python dict which enables
+    simplified storage of settings.  Values stored into the dict will
+    automatically persist locally.  Additionally, it can interact with
+    a backend system to provide a GUI interface for some or all of the
+    settings.
 
-    As it stands today, if you have multiple devices with the same skill
-    installed, they will share the same settings if the settings is can be
-    configurable on the web (anything sent by settingsmeta.json). If a skill
-    modify a setting on the client that can be configured in the web, the web
-    will update with the settings modified from the skill. Currently ONLY
-    the creator of the skill can modify the the web settings from the skill
-    it self. The creator is defined as the device that is the first one to
-    upload the settingsmeta.json to the web ui. This is temporary until
-    some mechanism are put into place in the backend to allow any device to
-    modify the settings configurable from the web.
+    The GUI for the setting is described by a file in the skill's root
+    directory called settingsmeta.json.  The "name" is associates the
+    user-interface field with the setting name in the dictionary.  For
+    example, you might have a setting['username'].  In the settingsmeta
+    you can describe the interface you want to edit that value with:
+        ...
+        "fields": [
+               {
+                   "name": "username",
+                   "type": "email",
+                   "label": "Email address to associate",
+                   "placeholder": "example@mail.com",
+                   "value": ""
+               }]
+        ...
+    When the user changes the setting via the web UI, it will be sent
+    down to all the devices and automatically placed into the
+    settings['username'].  Any local changes made to the value (e.g.
+    via a verbal interaction) will also be synched to the server to show
+    on the web interface.
+
+    NOTE: As it stands today, this functions seamlessly with a single
+    device.  With multiple devices there are a few hitches that are being
+    worked out.  The first device where a skill is installed creates the
+    setting and values are sent down to any other devices that install the
+    same skill.  However only the original device can make changes locally
+    for synching to the web.  This limitation is temporary and will be
+    removed soon.
 
 
     Usage Example:
@@ -36,10 +55,7 @@
         s = SkillSettings('./settings.json', 'ImportantSettings')
         s['meaning of life'] = 42
         s['flower pot sayings'] = 'Not again...'
-        s.store()
-
-    Metadata format:
-        TODO: see https://goo.gl/MY3i1S
+        s.store()  # This happens automagically in a MycroftSkill
 """
 
 import json

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -207,7 +207,7 @@ class SkillSettings(dict):
             for j, field in enumerate(section['fields']):
                 if 'name' in field:
                     if field["name"] in self:
-                        sections[i]['fields'][j]["value"] = self['name']
+                        sections[i]['fields'][j]['value'] = str(self[field['name']])
         meta['skillMetadata']['sections'] = sections
         return meta
 

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -200,7 +200,7 @@ class SkillSettings(dict):
         return isfile(uuid_file)
 
     def _migrate_settings(self, settings_meta):
-        """ upload the new settings meta with values currently in settings """
+        """ sync settings.json and settingsmeta.json in memory """
         meta = settings_meta.copy()
         sections = meta['skillMetadata']['sections']
         for i, section in enumerate(sections):

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -207,7 +207,8 @@ class SkillSettings(dict):
             for j, field in enumerate(section['fields']):
                 if 'name' in field:
                     if field["name"] in self:
-                        sections[i]['fields'][j]['value'] = str(self[field['name']])
+                        sections[i]['fields'][j]['value'] = \
+                            str(self[field['name']])
         meta['skillMetadata']['sections'] = sections
         return meta
 

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -187,6 +187,18 @@ class SkillSettings(dict):
         with open(uuid_file, 'w') as f:
             f.write(str(uuid))
 
+    def _uuid_exist(self):
+        """ Checks if there is an uuid file.
+
+            Returns:
+                bool: True if uuid file exist False otherwise
+        """
+        directory = self.config.get("skills")["directory"]
+        directory = join(directory, self.name)
+        directory = expanduser(directory)
+        uuid_file = join(directory, 'uuid')
+        return isfile(uuid_file)
+
     def _migrate_settings(self, settings_meta):
         """ upload the new settings meta with values currently in settings """
         meta = settings_meta.copy()
@@ -211,9 +223,8 @@ class SkillSettings(dict):
                  " to home.mycroft.ai")
         meta = self._migrate_settings(settings_meta)
         meta['identifier'] = str(hashed_meta)
-        LOG.info(meta)
-        new_uuid = self._send_settings_meta(meta)
-        self._save_uuid(new_uuid)
+        response = self._send_settings_meta(meta)
+        self._save_uuid(response['uuid'])
         self._save_hash(hashed_meta)
 
     def _delete_old_meta(self):
@@ -226,18 +237,6 @@ class SkillSettings(dict):
                 self._delete_metatdata(old_uuid)
             except Exception as e:
                 LOG.info(e)
-
-    def _uuid_exist(self):
-        """ Checks if there is an uuid file.
-
-            Returns:
-                bool: True if uuid file exist False otherwise
-        """
-        directory = self.config.get("skills")["directory"]
-        directory = join(directory, self.name)
-        directory = expanduser(directory)
-        uuid_file = join(directory, 'uuid')
-        return isfile(uuid_file)
 
     def hash(self, str):
         """ md5 hasher for consistency across cpu architectures """

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -289,7 +289,7 @@ class SkillSettings(dict):
             return False if current_hash == str(hashed_meta) else True
         return True
 
-    def update(self):
+    def update_remote(self):
         """ update settings state from server """
         skills_settings = None
         if self.get('is_synced'):

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -77,8 +77,8 @@ class SkillSettings(dict):
                 # first look at all other devices on user account to see
                 # if the settings exist. if it does then sync with this device
                 if skill_settings is not None:
-                    # is_synced flags the that this settings is loaded from
-                    # another device if a skill settings doesn't have
+                    # is_synced flags that this settings is loaded from
+                    # another device. If a skill settings doesn't have
                     # is_synced, then the skill is created from that device
                     self.__setitem__('is_synced', True)
                     self.save_skill_settings(skill_settings)
@@ -126,7 +126,7 @@ class SkillSettings(dict):
         return data
 
     def _send_settings_meta(self, settings_meta):
-        """ Send settingsmeta.json to the backend.
+        """ Send settingsmeta.json to the server.
 
             Args:
                 settings_meta (dict): dictionary of the current settings meta
@@ -174,7 +174,7 @@ class SkillSettings(dict):
         return uuid
 
     def _save_uuid(self, uuid):
-        """ Saves uuid to the settings directory.
+        """ Saves uuid.
 
             Args:
                 str: uuid, unique id of new settingsmeta
@@ -356,10 +356,10 @@ class SkillSettings(dict):
         return None
 
     def _get_remote_settings(self):
-        """ Get all skill settings for this device from backend.
+        """ Get all skill settings for this device from server.
 
             Returns:
-                dict: dictionary with settings collected from the web backend.
+                dict: dictionary with settings collected from the server.
         """
         settings = self.api.request({
             "method": "GET",


### PR DESCRIPTION
====  Tech Notes ====
If there are multiple devices with the same skill, the devices will now automatically share the settings set in home.mycroft.ai. If the settingsmeta.json changes for one device, then there will be an additional settings box for that skill in home.mycroft.ai until they other skills are updated to the same settingsmeta.json

You can also make changes to the settings and it will push it up to the web UI if the device is the creator of the skill. Eventually, we will want any device to be able to change settings if they are linked to the specific skill settings but the backend currently does not allow that. 