### PR TITLE
Handle failure in _save_uuid

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -252,7 +252,8 @@ class SkillSettings(dict):
         meta = self._migrate_settings(settings_meta)
         meta['identifier'] = str(hashed_meta)
         response = self._send_settings_meta(meta)
-        self._save_uuid(response['uuid'])
+        if response:
+            self._save_uuid(response['uuid'])
         self._save_hash(hashed_meta)
 
     def _delete_old_meta(self):


### PR DESCRIPTION
_save_uuid() may return None on error. This needs to be caught to prevent skill from failing.