### PR TITLE
Fix simple typo in switch to Github

### DIFF
--- a/scripts/mycroft-use.sh
+++ b/scripts/mycroft-use.sh
@@ -310,7 +310,7 @@ elif [ "${change_to}" = "github" ]; then
     fi
 
     echo "Switching to github..."
-    if [! -d ${path} ]; then
+    if [ ! -d ${path} ]; then
         mkdir --parents "${path}"
         cd "${path}"
         cd ..


### PR DESCRIPTION
The missing space breaks the shell path test when switching to a Github install