### PR TITLE
Fix misspelling in a text resource

### DIFF
--- a/mycroft/res/text/en-us/i am awake.dialog
+++ b/mycroft/res/text/en-us/i am awake.dialog
@@ -1,2 +1,0 @@
-I am awake
-I'm awake now

--- a/mycroft/res/text/en-us/sorry I couldn't install default skills.dialog
+++ b/mycroft/res/text/en-us/sorry I couldn't install default skills.dialog
@@ -1,1 +1,1 @@
-an error occured while updating skills
+an error occurred while updating skills


### PR DESCRIPTION
Fixes a misspelling and removes the "i am awake.dialog" which is
no longer used.  (The dialog is handled by the (Sleep skill)[https://github.com/MycroftAI/skill-naptime] instead.