### PR TITLE
Add MycroftSkill.translate_namedvalues()

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -534,7 +534,7 @@ class MycroftSkill(object):
             return result
         except:
             return {}
-            
+
     def translate_template(self, template_name, data=None):
         """
         Load a translatable template

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -16,6 +16,7 @@ import imp
 import operator
 import sys
 import time
+import csv
 from functools import wraps
 from inspect import getargspec
 
@@ -497,6 +498,43 @@ class MycroftSkill(object):
         """
         return self.dialog_renderer.render(text, data or {})
 
+    def translate_namedvalues(self, name, delim=None):
+        """
+        Load translation dict containing names and values.
+
+        This loads a simple CSV from the 'dialog' folders.
+        The name is the first list item, the value is the
+        second.  Lines prefixed with # or // get ignored
+
+        Args:
+            name (str): name of the .value file, no extension needed
+            delim (char): delimiter character used, default is ','
+
+        Returns:
+            dict: name and value dictionary, or [] if load fails
+        """
+
+        delim = delim or ','
+        result = {}
+        if not name.endswith(".value"):
+            name += ".value"
+
+        try:
+            with open(join(self.root_dir, 'dialog', self.lang, name)) as f:
+                reader = csv.reader(f, delimiter=delim)
+                for row in reader:
+                    # skip blank or comment lines
+                    if not row or row[0].startswith("#"):
+                        continue
+                    if len(row) != 2:
+                        continue
+
+                    result[row[0]] = row[1]
+
+            return result
+        except:
+            return {}
+            
     def translate_template(self, template_name, data=None):
         """
         Load a translatable template

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -532,7 +532,7 @@ class MycroftSkill(object):
                     result[row[0]] = row[1]
 
             return result
-        except:
+        except Exception:
             return {}
 
     def translate_template(self, template_name, data=None):


### PR DESCRIPTION
This method will load a translateable (and expandable) list of names
and values from the dialog/xx-xx/ folder of a skill.  For example:

dialog/en-en/Colors.value
```
# List colors and their hex RGB values
alice blue, #F0F8FF
antique white, #FAEBD7
aqua, #00FFFF
```