### PR TITLE
fixed skill settings migration for web ui

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -134,6 +134,7 @@ def load_skill(skill_descriptor, emitter, skill_id, BLACKLISTED_SKILLS=None):
             # v2 skills framework
             skill = skill_module.create_skill()
             skill.settings.allow_overwrite = True
+            skill.settings.load_skill_settings_from_file()
             skill.bind(emitter)
             skill.skill_id = skill_id
             skill.load_data_files(dirname(skill_descriptor['info'][1]))

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -103,7 +103,6 @@ class SkillSettings(dict):
         # if settingsmeta exist
         if isfile(self._meta_path):
             self._poll_skill_settings()
-        self.load_skill_settings()
 
     # TODO: break this up into two classes
     def initialize_remote_settings(self):
@@ -256,6 +255,7 @@ class SkillSettings(dict):
     def _migrate_settings(self, settings_meta):
         """ sync settings.json and settingsmeta.json in memory """
         meta = settings_meta.copy()
+        self.load_skill_settings_from_file()
         sections = meta['skillMetadata']['sections']
         for i, section in enumerate(sections):
             for j, field in enumerate(section['fields']):
@@ -391,7 +391,7 @@ class SkillSettings(dict):
             t.daemon = True
             t.start()
 
-    def load_skill_settings(self):
+    def load_skill_settings_from_file(self):
         """ If settings.json exist, open and read stored values into self """
         if isfile(self._settings_path):
             with open(self._settings_path) as f:

--- a/test/unittests/skills/settings.py
+++ b/test/unittests/skills/settings.py
@@ -42,6 +42,8 @@ class SkillSettingsTest(unittest.TestCase):
     def test_store(self):
         s = SkillSettings(join(dirname(__file__), 'settings'),
                           "test-skill-settings")
+        s.allow_overwrite = True
+        s.load_skill_settings_from_file()
         s['bool'] = True
         s['int'] = 42
         s['float'] = 4.2
@@ -51,16 +53,22 @@ class SkillSettingsTest(unittest.TestCase):
 
         s2 = SkillSettings(join(dirname(__file__), 'settings'),
                            "test-skill-settings")
+        s2.allow_overwrite = True
+        s2.load_skill_settings_from_file()
         for key in s:
             self.assertEqual(s[key], s2[key])
 
     def test_update_list(self):
         s = SkillSettings(join(dirname(__file__), 'settings'),
                           "test-skill-settings")
+        s.allow_overwrite = True
+        s.load_skill_settings_from_file()
         s['l'] = ['a', 'b', 'c']
         s.store()
         s2 = SkillSettings(join(dirname(__file__), 'settings'),
                            "test-skill-settings")
+        s2.allow_overwrite = True
+        s2.load_skill_settings_from_file()
         self.assertEqual(s['l'], s2['l'])
 
         # Update list
@@ -68,15 +76,20 @@ class SkillSettingsTest(unittest.TestCase):
         s2.store()
         s3 = SkillSettings(join(dirname(__file__), 'settings'),
                            "test-skill-settings")
+        s3.allow_overwrite = True
+        s3.load_skill_settings_from_file()
         self.assertEqual(s2['l'], s3['l'])
 
     def test_update_dict(self):
         s = SkillSettings(join(dirname(__file__), 'settings'),
                           "test-skill-settings")
+        s.allow_overwrite = True
         s['d'] = {'a': 1, 'b': 2}
         s.store()
         s2 = SkillSettings(join(dirname(__file__), 'settings'),
                            "test-skill-settings")
+        s2.allow_overwrite = True
+        s2.load_skill_settings_from_file()
         self.assertEqual(s['d'], s2['d'])
 
         # Update dict
@@ -84,16 +97,21 @@ class SkillSettingsTest(unittest.TestCase):
         s2.store()
         s3 = SkillSettings(join(dirname(__file__), 'settings'),
                            "test-skill-settings")
+        s3.allow_overwrite = True
+        s3.load_skill_settings_from_file()
         self.assertEqual(s2['d'], s3['d'])
 
     def test_no_change(self):
         s = SkillSettings(join(dirname(__file__), 'settings'),
                           "test-skill-settings")
+        s.allow_overwrite = True
         s['d'] = {'a': 1, 'b': 2}
         s.store()
 
         s2 = SkillSettings(join(dirname(__file__), 'settings'),
                            "test-skill-settings")
+        s2.allow_overwrite = True
+        s2.load_skill_settings_from_file()
         self.assertTrue(len(s) == len(s2))
 
     def test_load_existing(self):
@@ -102,6 +120,8 @@ class SkillSettingsTest(unittest.TestCase):
             json.dump({"test": "1"}, f)
         s = SkillSettings(join(dirname(__file__), 'settings'),
                           "test-skill-settings")
+        s.allow_overwrite = True
+        s.load_skill_settings_from_file()
         self.assertEqual(len(s), 1)
 
 


### PR DESCRIPTION
==== Fixed Issues ====
The settings migration stopped working due to this code in settings.py  

```python
skill.allow_overwrite = False
```

This is because when a settingsmeta get's modified, the settings in settings.json is prevented from loading onto the skillsettings class because the flag for allow_overwrite was set to false. This change will now load settings from settings.json on startup, as well as load settings from settings.json before any migration takes place. 