### PR TITLE
Bugfix/subscriber archs

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -229,9 +229,10 @@ class DeviceApi(Api):
     def get_subscriber_voice_url(self, voice=None):
         self.check_token()
         archs = {'x86_64': 'x86_64', 'armv7l': 'arm'}
-        arch = archs[get_arch()]
-        path = '/' + self.identity.uuid + '/voice?arch=' + arch
-        return self.request({'path': path})['link']
+        arch = archs.get(get_arch())
+        if arch:
+            path = '/' + self.identity.uuid + '/voice?arch=' + arch
+            return self.request({'path': path})['link']
 
     def find(self):
         """ Deprecated, see get_location() """

--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -228,7 +228,7 @@ class DeviceApi(Api):
 
     def get_subscriber_voice_url(self, voice=None):
         self.check_token()
-        archs = {'x86_64': 'x86_64', 'armv7l': 'arm'}
+        archs = {'x86_64': 'x86_64', 'armv7l': 'arm', 'aarch64': 'arm'}
         arch = archs.get(get_arch())
         if arch:
             path = '/' + self.identity.uuid + '/voice?arch=' + arch

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -56,22 +56,32 @@ def download_subscriber_voices(selected_voice):
     # First download the selected voice if needed
     voice_file = SUBSCRIBER_VOICES.get(selected_voice)
     if voice_file is not None and not exists(voice_file):
-        LOG.info('voice foesn\'t exist, downloading')
-        dl = download(DeviceApi().get_subscriber_voice_url(selected_voice),
-                      voice_file, make_executable)
-        # Wait for completion
-        while not dl.done:
-            sleep(1)
+        LOG.info('voice doesn\'t exist, downloading')
+        url = DeviceApi().get_subscriber_voice_url(selected_voice)
+        # Check we got an url
+        if url:
+            dl = download(url, voice_file, make_executable)
+            # Wait for completion
+            while not dl.done:
+                sleep(1)
+        else:
+            LOG.debug('{} is not available for this architecture'
+                      .format(selected_voice))
 
     # Download the rest of the subsciber voices as needed
     for voice in SUBSCRIBER_VOICES:
         voice_file = SUBSCRIBER_VOICES[voice]
         if not exists(voice_file):
-            dl = download(DeviceApi().get_subscriber_voice_url(voice),
-                          voice_file, make_executable)
-            # Wait for completion
-            while not dl.done:
-                sleep(1)
+            url = DeviceApi().get_subscriber_voice_url(voice)
+            # Check we got an url
+            if url:
+                dl = download(url, voice_file, make_executable)
+                # Wait for completion
+                while not dl.done:
+                    sleep(1)
+            else:
+                LOG.debug('{} is not available for this architecture'
+                          .format(voice))
 
 
 class Mimic(TTS):


### PR DESCRIPTION
If the architecture of the system was not among the supported architectures the download thread would terminate quite messily. This adds checks to exit more cleanly.

Also adds support for the aarch64 architecture. (Hopefully)