### PR TITLE
Feature/time metrics

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -75,7 +75,7 @@ def handle_speak(event):
                               utterance)
             for chunk in chunks:
                 try:
-                    mute_and_speak(chunk)
+                    mute_and_speak(chunk, ident)
                 except KeyboardInterrupt:
                     raise
                 except Exception:
@@ -84,7 +84,7 @@ def handle_speak(event):
                         check_for_signal('buttonPress')):
                     break
         else:
-            mute_and_speak(utterance)
+            mute_and_speak(utterance, ident)
 
         stopwatch.stop()
     report_metric('timing',
@@ -95,12 +95,13 @@ def handle_speak(event):
                    'time': stopwatch.time})
 
 
-def mute_and_speak(utterance):
+def mute_and_speak(utterance, ident):
     """
         Mute mic and start speaking the utterance using selected tts backend.
 
         Args:
-            utterance: The sentence to be spoken
+            utterance:  The sentence to be spoken
+            ident:      Ident tying the utterance to the source query
     """
     global tts_hash
 
@@ -116,7 +117,7 @@ def mute_and_speak(utterance):
         tts_hash = hash(str(config.get('tts', '')))
 
     LOG.info("Speak: " + utterance)
-    tts.execute(utterance)
+    tts.execute(utterance, ident)
 
 
 def handle_stop(event):

--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -46,6 +46,12 @@ def handle_speak(event):
     Configuration.init(ws)
     global _last_stop_signal
 
+    # Get conversation ID
+    if event.context and 'ident' in event.context:
+        ident = event.context['ident']
+    else:
+        ident = 'unknown'
+
     with lock:
         stopwatch = Stopwatch()
         stopwatch.start()
@@ -82,7 +88,7 @@ def handle_speak(event):
 
         stopwatch.stop()
     report_metric('timing',
-                  {'id': 'unknown',
+                  {'id': ident,
                    'system': 'speech',
                    'utterance': utterance,
                    'start_time': stopwatch.timestamp,

--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -20,7 +20,7 @@ from mycroft.configuration import Configuration
 from mycroft.tts import TTSFactory
 from mycroft.util import create_signal, check_for_signal
 from mycroft.util.log import LOG
-from mycroft.metrics import report_metric, Stopwatch
+from mycroft.metrics import report_timing, Stopwatch
 
 ws = None  # TODO:18.02 - Rename to "messagebus"
 config = None
@@ -87,12 +87,7 @@ def handle_speak(event):
             mute_and_speak(utterance, ident)
 
         stopwatch.stop()
-    report_metric('timing',
-                  {'id': ident,
-                   'system': 'speech',
-                   'utterance': utterance,
-                   'start_time': stopwatch.timestamp,
-                   'time': stopwatch.time})
+    report_timing(ident, 'speech', stopwatch, {'utterance': utterance})
 
 
 def mute_and_speak(utterance, ident):

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -24,7 +24,7 @@ import mycroft.dialog
 from mycroft.client.speech.hotword_factory import HotWordFactory
 from mycroft.client.speech.mic import MutableMicrophone, ResponsiveRecognizer
 from mycroft.configuration import Configuration
-from mycroft.metrics import MetricsAggregator, Stopwatch, report_metric
+from mycroft.metrics import MetricsAggregator, Stopwatch, report_timing
 from mycroft.session import SessionManager
 from mycroft.stt import STTFactory
 from mycroft.util.log import LOG
@@ -152,11 +152,8 @@ class AudioConsumer(Thread):
                 self.emitter.emit("recognizer_loop:utterance", payload)
                 self.metrics.attr('utterances', [transcription])
                 # Report timing metrics
-                report_metric('timing', {'id': ident,
-                                         'system': 'stt',
-                                         'transcription': transcription,
-                                         'start_time': stopwatch.timestamp,
-                                         'time': stopwatch.time})
+                report_timing(ident, 'stt', stopwatch,
+                              {'transcription': transcription})
 
     def transcribe(self, audio):
         text = None

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -24,7 +24,7 @@ import mycroft.dialog
 from mycroft.client.speech.hotword_factory import HotWordFactory
 from mycroft.client.speech.mic import MutableMicrophone, ResponsiveRecognizer
 from mycroft.configuration import Configuration
-from mycroft.metrics import MetricsAggregator
+from mycroft.metrics import MetricsAggregator, Stopwatch, report_metric
 from mycroft.session import SessionManager
 from mycroft.stt import STTFactory
 from mycroft.util.log import LOG
@@ -137,7 +137,26 @@ class AudioConsumer(Thread):
         if self._audio_length(audio) < self.MIN_AUDIO_SIZE:
             LOG.warning("Audio too short to be processed")
         else:
-            self.transcribe(audio)
+            stopwatch = Stopwatch()
+            with stopwatch:
+                transcription = self.transcribe(audio)
+            if transcription:
+                ident = str(stopwatch.timestamp) + str(hash(transcription))
+                # STT succeeded, send the transcribed speech on for processing
+                payload = {
+                    'utterances': [transcription],
+                    'lang': self.stt.lang,
+                    'session': SessionManager.get().session_id,
+                    'ident': ident
+                }
+                self.emitter.emit("recognizer_loop:utterance", payload)
+                self.metrics.attr('utterances', [transcription])
+                # Report timing metrics
+                report_metric('timing', {'id': ident,
+                                         'system': 'stt',
+                                         'transcription': transcription,
+                                         'start_time': stopwatch.timestamp,
+                                         'time': stopwatch.time})
 
     def transcribe(self, audio):
         text = None
@@ -158,15 +177,7 @@ class AudioConsumer(Thread):
             self.emitter.emit('recognizer_loop:speech.recognition.unknown')
             LOG.error(e)
             LOG.error("Speech Recognition could not understand audio")
-        if text:
-            # STT succeeded, send the transcribed speech on for processing
-            payload = {
-                'utterances': [text],
-                'lang': self.stt.lang,
-                'session': SessionManager.get().session_id
-            }
-            self.emitter.emit("recognizer_loop:utterance", payload)
-            self.metrics.attr('utterances', [text])
+        return text
 
     def __speak(self, utterance):
         payload = {

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -151,9 +151,11 @@ class AudioConsumer(Thread):
                 }
                 self.emitter.emit("recognizer_loop:utterance", payload)
                 self.metrics.attr('utterances', [transcription])
-                # Report timing metrics
-                report_timing(ident, 'stt', stopwatch,
-                              {'transcription': transcription})
+            else:
+                ident = str(stopwatch.timestamp)
+            # Report timing metrics
+            report_timing(ident, 'stt', stopwatch,
+                          {'transcription': transcription})
 
     def transcribe(self, audio):
         text = None

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -59,7 +59,11 @@ def handle_wakeword(event):
 
 def handle_utterance(event):
     LOG.info("Utterance: " + str(event['utterances']))
-    ws.emit(Message('recognizer_loop:utterance', event))
+    context = {'client_name': 'mycroft_listener'}
+    if 'ident' in event:
+        ident = event.pop('ident')
+        context['ident'] = ident
+    ws.emit(Message('recognizer_loop:utterance', event, context))
 
 
 def handle_unknown():

--- a/mycroft/metrics/__init__.py
+++ b/mycroft/metrics/__init__.py
@@ -23,6 +23,7 @@ from mycroft.configuration import Configuration
 from mycroft.session import SessionManager
 from mycroft.util.log import LOG
 from mycroft.util.setup_base import get_version
+from copy import copy
 
 
 def report_metric(name, data):
@@ -39,6 +40,25 @@ def report_metric(name, data):
     except (requests.HTTPError, requests.exceptions.ConnectionError) as e:
         LOG.error('Metric couldn\'t be uploaded, due to a network error ({})'
                   .format(e))
+
+
+def report_timing(ident, system, timing, additional_data=None):
+    """
+        Create standardized message for reporting timing.
+
+        ident (str):            identifier of user interaction
+        system (str):           system the that's generated the report
+        timing (stopwatch):     Stopwatch object with recorded timing
+        additional_data (dict): dictionary with related data
+    """
+    additional_data = additional_data or {}
+    report = copy(additional_data)
+    report['id'] = ident
+    report['system'] = system
+    report['start_time'] = timing.timestamp
+    report['time'] = timing.time
+
+    report_metric('timing', report)
 
 
 class Stopwatch(object):

--- a/mycroft/metrics/__init__.py
+++ b/mycroft/metrics/__init__.py
@@ -42,11 +42,17 @@ def report_metric(name, data):
 
 
 class Stopwatch(object):
+    """
+        Simple time measuring class.
+    """
     def __init__(self):
         self.timestamp = None
         self.time = None
 
     def start(self):
+        """
+            Start a time measurement
+        """
         self.timestamp = time.time()
 
     def lap(self):
@@ -56,15 +62,24 @@ class Stopwatch(object):
         return cur_time - start_time
 
     def stop(self):
+        """
+            Stop a running time measurement. returns the measured time
+        """
         cur_time = time.time()
         start_time = self.timestamp
         self.time = cur_time - start_time
         return self.time
 
     def __enter__(self):
+        """
+            Start stopwatch when entering with-block.
+        """
         self.start()
 
     def __exit__(self, tpe, value, tb):
+        """
+            Stop stopwatch when exiting with-block.
+        """
         self.stop()
 
     def __str__(self):

--- a/mycroft/metrics/__init__.py
+++ b/mycroft/metrics/__init__.py
@@ -40,6 +40,7 @@ def report_metric(name, data):
 class Stopwatch(object):
     def __init__(self):
         self.timestamp = None
+        self.time = None
 
     def start(self):
         self.timestamp = time.time()
@@ -53,8 +54,21 @@ class Stopwatch(object):
     def stop(self):
         cur_time = time.time()
         start_time = self.timestamp
-        self.timestamp = None
-        return cur_time - start_time
+        self.time = cur_time - start_time
+        return self.time
+
+    def __enter__(self):
+        self.start()
+
+    def __exit__(self, tpe, value, tb):
+        self.stop()
+
+    def __str__(self):
+        cur_time = time.time()
+        if self.timestamp:
+            return str(self.time or cur_time - self.timestamp)
+        else:
+            return 'Not started'
 
 
 class MetricsAggregator(object):

--- a/mycroft/metrics/__init__.py
+++ b/mycroft/metrics/__init__.py
@@ -33,8 +33,12 @@ def report_metric(name, data):
         name (str): Name of metric. Must use only letters and hyphens
         data (dict): JSON dictionary to report. Must be valid JSON
     """
-    if Configuration().get()['opt_in']:
-        DeviceApi().report_metric(name, data)
+    try:
+        if Configuration().get()['opt_in']:
+            DeviceApi().report_metric(name, data)
+    except (requests.HTTPError, requests.exceptions.ConnectionError) as e:
+        LOG.error('Metric couldn\'t be uploaded, due to a network error ({})'
+                  .format(e))
 
 
 class Stopwatch(object):

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -34,7 +34,7 @@ from mycroft.configuration import Configuration
 from mycroft.dialog import DialogLoader
 from mycroft.filesystem import FileSystemAccess
 from mycroft.messagebus.message import Message
-from mycroft.metrics import report_metric, Stopwatch
+from mycroft.metrics import report_metric, report_timing, Stopwatch
 from mycroft.skills.settings import SkillSettings
 from mycroft.util import resolve_resource_file
 from mycroft.util.log import LOG
@@ -648,12 +648,8 @@ class MycroftSkill(object):
                 # Send timing metrics
                 context = message.context
                 if context and 'ident' in context:
-                    report_metric('timing',
-                                  {'id': context['ident'],
-                                   'system': 'skill_handler',
-                                   'handler': handler.__name__,
-                                   'start_time': stopwatch.timestamp,
-                                   'time': stopwatch.time})
+                    report_timing(context['ident'], 'skill_handler', stopwatch,
+                                  {'handler': handler.__name__})
 
             except Exception as e:
                 # Convert "MyFancySkill" to "My Fancy Skill" for speaking
@@ -1111,12 +1107,8 @@ class FallbackSkill(MycroftSkill):
             # Send timing metric
             if message.context and message.context['ident']:
                 ident = message.context['ident']
-                report_metric('timing',
-                              {'id': ident,
-                               'handler': handler_name,
-                               'system': 'fallback_handler',
-                               'start_time': stopwatch.timestamp,
-                               'time': stopwatch.time})
+                report_timing(ident, 'fallback_handler', stopwatch,
+                              {'handler': handler_name})
         return handler
 
     @classmethod

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -21,7 +21,7 @@ from mycroft.messagebus.message import Message
 from mycroft.skills.core import open_intent_envelope
 from mycroft.util.log import LOG
 from mycroft.util.parse import normalize
-from mycroft.metrics import report_metric, Stopwatch
+from mycroft.metrics import report_timing, Stopwatch
 # python 2+3 compatibility
 from past.builtins import basestring
 from future.builtins import range
@@ -251,20 +251,11 @@ class IntentService(object):
             intent_type = self.get_skill_name(parts[0])
             if len(parts) > 1:
                 intent_type = ':'.join([intent_type] + parts[1:])
-
-            report_metric('timing',
-                          {'id': ident,
-                           'system': 'intent_service',
-                           'intent_type': intent_type,
-                           'start_time': stopwatch.timestamp,
-                           'time': stopwatch.time})
+            report_timing(ident, 'intent_service', stopwatch,
+                          {'intent_type': intent_type})
         else:
-            report_metric('timing',
-                          {'id': ident,
-                           'intent_type': 'intent_failure',
-                           'system': 'intent_service',
-                           'start_time': stopwatch.timestamp,
-                           'time': stopwatch.time})
+            report_timing(ident, 'intent_service', stopwatch,
+                          {'intent_type': 'intent_failure'})
 
     def handle_utterance(self, message):
         """

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -300,6 +300,10 @@ class SkillManager(Thread):
                                            self.ws, skill["id"],
                                            BLACKLISTED_SKILLS)
             skill["last_modified"] = modified
+            if skill and skill['instance']:
+                ws.emit(Message('mycroft.skills.loaded',
+                                {'id': skill['id'],
+                                 'name': skill['instance'].name}))
 
     def load_skill_list(self, skills_to_load):
         """ Load the specified list of skills from disk

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -28,7 +28,7 @@ from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
 from mycroft.util import play_wav, play_mp3, check_for_signal, create_signal
 from mycroft.util.log import LOG
-from mycroft.metrics import report_metric, Stopwatch
+from mycroft.metrics import report_timing, Stopwatch
 import sys
 if sys.version_info[0] < 3:
     from Queue import Queue, Empty
@@ -41,11 +41,7 @@ def send_playback_metric(stopwatch, ident):
         Send playback metrics in a background thread
     """
     def do_send(stopwatch, ident):
-        report_metric('timing',
-                      {'id': ident,
-                       'system': 'speech_playback',
-                       'start_time': stopwatch.timestamp,
-                       'time': stopwatch.time})
+        report_timing(ident, 'speech_playback', stopwatch)
 
     t = Thread(target=do_send, args=(stopwatch, ident))
     t.daemon = True

--- a/mycroft/tts/espeak_tts.py
+++ b/mycroft/tts/espeak_tts.py
@@ -21,7 +21,7 @@ class ESpeak(TTS):
     def __init__(self, lang, voice):
         super(ESpeak, self).__init__(lang, voice, ESpeakValidator(self))
 
-    def execute(self, sentence):
+    def execute(self, sentence, ident=None):
         self.begin_audio()
         subprocess.call(
             ['espeak', '-v', self.lang + '+' + self.voice, sentence])

--- a/mycroft/tts/remote_tts.py
+++ b/mycroft/tts/remote_tts.py
@@ -35,7 +35,7 @@ class RemoteTTS(TTS):
         self.url = remove_last_slash(url)
         self.session = FuturesSession()
 
-    def execute(self, sentence):
+    def execute(self, sentence, ident=None):
         phrases = self.__get_phrases(sentence)
 
         if len(phrases) > 0:

--- a/mycroft/tts/spdsay_tts.py
+++ b/mycroft/tts/spdsay_tts.py
@@ -21,7 +21,7 @@ class SpdSay(TTS):
     def __init__(self, lang, voice):
         super(SpdSay, self).__init__(lang, voice, SpdSayValidator(self))
 
-    def execute(self, sentence):
+    def execute(self, sentence, ident=None):
         self.begin_audio()
         subprocess.call(
             ['spd-say', '-l', self.lang, '-t', self.voice, sentence])


### PR DESCRIPTION
STT, intent handling, intent fallbacks, skill handlers, TTS execution and TTS playback are now timed and
tied together with an `ident` (consistent through the chain so the flow from
STT until completion of the skill handler can be followed.


The report is always called "timing" and always contain the following
fields:

- id: Identifier grouping the metrics into interactions
- system: Which part (STT, intent service, skill handler, etc)
- start_time: timestamp for when the action started
- time: how long it took to execute the action

The different system adds their own specific information, for example
the intent_service adds the intent_type, i.e. which handler was matched.

`mycroft.skills.loaded` is sent together with skill id and skill name
whenever a skill is loaded. This is used in the intent_service to
convert from id to skill name when reporting.

## Future work
- Add a layer to reduce the number of sends to the server