### PR TITLE
Add oauth token endpoint to device api

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -248,6 +248,21 @@ class DeviceApi(Api):
         # TODO: Eliminate ASAP, for backwards compatibility only
         return self.get_location()
 
+    def get_oauth_token(self, dev_cred):
+        """
+            Get Oauth token for dev_credential dev_cred.
+
+            Argument:
+                dev_cred:   development credentials identifier
+
+            Returns:
+                json string containing token and additional information
+        """
+        return self.request({
+            "method": "GET",
+            "path": "/" + self.identity.uuid + "/token/" + str(dev_cred)
+        })
+
 
 class STTApi(Api):
     """ Web API wrapper for performing Speech to Text (STT) """

--- a/test/unittests/api/test_api.py
+++ b/test/unittests/api/test_api.py
@@ -212,6 +212,21 @@ class TestApi(unittest.TestCase):
 
     @mock.patch('mycroft.api.IdentityManager.get')
     @mock.patch('mycroft.api.requests.request')
+    def test_device_get_oauth_token(self, mock_request, mock_identity_get):
+        mock_request.return_value = create_response(200, {})
+        mock_identity = mock.MagicMock()
+        mock_identity.is_expired.return_value = False
+        mock_identity.uuid = '1234'
+        mock_identity_get.return_value = mock_identity
+        device = mycroft.api.DeviceApi()
+        device.get_oauth_token(1)
+        url = mock_request.call_args[0][1]
+
+        self.assertEquals(
+            url, 'https://api-test.mycroft.ai/v1/device/1234/token/1')
+
+    @mock.patch('mycroft.api.IdentityManager.get')
+    @mock.patch('mycroft.api.requests.request')
     def test_device_get_location(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200, {})
         mock_identity = mock.MagicMock()


### PR DESCRIPTION
When a token has been generated for the provided developer credentials
id the method will return it as json, if it doesn't exist HTTPError will
be raised (404 not found)