### PR TITLE
Bugfix/msm list

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -638,15 +638,25 @@ case ${OPT} in
           exit ${exit_code}
       fi
 
-      submodules=$(echo "${LIST_CACHE}" | grep 'submodule "' | sed 's/\[submodule "//g'| sed 's/"\]//g' | sort)
-      while read -r submod
-      do
-          if [[ -d "$mycroft_skill_folder/$submod" ]] ; then
-              printf "$submod ${RED}[${GREEN}installed${RED}]${NOCOLOR}\n\r"
+      # Get name and path
+      submods=($(echo "${LIST_CACHE}" | grep 'submodule "' | sed 's/\[submodule "//g'| sed 's/"\]//g'))
+      paths=($(echo "${LIST_CACHE}" | grep 'path =' | sed 's/\path = //g'| sed 's/"\]//g'))
+      # Determine which have been installed
+      results=()
+      for ((i=0;i<${#submods[@]};++i)); do
+          if [[ -d "$mycroft_skill_folder/${paths[i]}" ]] ; then
+              results+=("${submods[i]} ${RED}[${GREEN}installed${RED}]${NOCOLOR}\n\r")
           else
-              printf "$submod\n\r"
+              results+=("${submods[i]}\n\r")
           fi
-      done <<< "$submodules"
+      done
+      # Sort the result alphabetically
+      readarray -t sorted < <(for a in "${results[@]}"; do echo "$a"; done | sort)
+      # Print the output
+      for ((i=0;i<${#sorted[@]};++i)); do
+        printf "${sorted[i]}"
+      done
+
       exit_code=$?
       ;;
   "update")

--- a/msm/msm
+++ b/msm/msm
@@ -103,7 +103,6 @@ LIST_CACHE=''
 
 function get_skill_list() {
   if ! [[ ${LIST_CACHE} ]] ; then
-    echo "1" >> ~/count.txt
     if hash curl ; then
       # retrieve using curl
       LIST_CACHE=$( curl -s "https://raw.githubusercontent.com/MycroftAI/mycroft-skills/master/.gitmodules" )


### PR DESCRIPTION
Msm failed to list many skills as installed if the submodule name != repository name, this includes most of the default skills (which has been renamed from skill-X to mycroft-X while the repo name is still skill-X)

This PR makes msm use the submodule _path_ when checking if a skill is installed.


This PR also removes the write to `~/count.txt` (I've been wondering why this file turns up all the time)