### PR TITLE
Flexible lang dialect support

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -575,7 +575,8 @@ class MycroftSkill(object):
         """
         if old_dirname:
             # Try the old directory (dialog/vocab/regex)
-            root_path = get_language_dir(join(self.root_dir, old_dirname), self.lang)
+            root_path = get_language_dir(join(self.root_dir, old_dirname),
+                                         self.lang)
             path = join(root_path, res_name)
             if exists(path):
                 return path
@@ -1009,8 +1010,10 @@ class MycroftSkill(object):
     def init_dialog(self, root_directory):
         # If "<skill>/dialog/<lang>" exists, load from there.  Otherwise
         # load dialog from "<skill>/locale/<lang>"
-        dialog_dir = get_language_dir(join(root_directory, 'dialog'), self.lang)
-        locale_dir = get_language_dir(join(root_directory, 'locale'), self.lang)
+        dialog_dir = get_language_dir(join(root_directory, 'dialog'),
+                                      self.lang)
+        locale_dir = get_language_dir(join(root_directory, 'locale'),
+                                      self.lang)
         if exists(dialog_dir):
             self.dialog_renderer = DialogLoader().load(dialog_dir)
         elif exists(locale_dir):
@@ -1025,8 +1028,10 @@ class MycroftSkill(object):
         self.load_regex_files(root_directory)
 
     def load_vocab_files(self, root_directory):
-        vocab_dir = get_language_dir(join(root_directory, 'vocab'), self.lang)
-        locale_dir = get_language_dir(join(root_directory, 'locale'), self.lang)
+        vocab_dir = get_language_dir(join(root_directory, 'vocab'),
+                                     self.lang)
+        locale_dir = get_language_dir(join(root_directory, 'locale'),
+                                      self.lang)
         if exists(vocab_dir):
             load_vocabulary(vocab_dir, self.bus, self.skill_id)
         elif exists(locale_dir):
@@ -1035,8 +1040,10 @@ class MycroftSkill(object):
             LOG.debug('No vocab loaded')
 
     def load_regex_files(self, root_directory):
-        regex_dir = get_language_dir(join(root_directory, 'regex'), self.lang)
-        locale_dir = get_language_dir(join(root_directory, 'locale'), self.lang)
+        regex_dir = get_language_dir(join(root_directory, 'regex'),
+                                     self.lang)
+        locale_dir = get_language_dir(join(root_directory, 'locale'),
+                                      self.lang)
         if exists(regex_dir):
             load_regex(regex_dir, self.bus, self.skill_id)
         elif exists(locale_dir):

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1009,12 +1009,12 @@ class MycroftSkill(object):
     def init_dialog(self, root_directory):
         # If "<skill>/dialog/<lang>" exists, load from there.  Otherwise
         # load dialog from "<skill>/locale/<lang>"
-        dialog_dir = join(root_directory, 'dialog', self.lang)
+        dialog_dir = get_language_dir(join(root_directory, 'dialog'), self.lang)
+        locale_dir = get_language_dir(join(root_directory, 'locale'), self.lang)
         if exists(dialog_dir):
             self.dialog_renderer = DialogLoader().load(dialog_dir)
-        elif exists(join(root_directory, 'locale', self.lang)):
-            locale_path = join(root_directory, 'locale', self.lang)
-            self.dialog_renderer = DialogLoader().load(locale_path)
+        elif exists(locale_dir):
+            self.dialog_renderer = DialogLoader().load(locale_dir)
         else:
             LOG.debug('No dialog loaded')
 
@@ -1025,22 +1025,22 @@ class MycroftSkill(object):
         self.load_regex_files(root_directory)
 
     def load_vocab_files(self, root_directory):
-        vocab_dir = join(root_directory, 'vocab', self.lang)
+        vocab_dir = get_language_dir(join(root_directory, 'vocab'), self.lang)
+        locale_dir = get_language_dir(join(root_directory, 'locale'), self.lang)
         if exists(vocab_dir):
             load_vocabulary(vocab_dir, self.bus, self.skill_id)
-        elif exists(join(root_directory, 'locale', self.lang)):
-            load_vocabulary(join(root_directory, 'locale', self.lang),
-                            self.bus, self.skill_id)
+        elif exists(locale_dir):
+            load_vocabulary(locale_dir, self.bus, self.skill_id)
         else:
             LOG.debug('No vocab loaded')
 
     def load_regex_files(self, root_directory):
-        regex_dir = join(root_directory, 'regex', self.lang)
+        regex_dir = get_language_dir(join(root_directory, 'regex'), self.lang)
+        locale_dir = get_language_dir(join(root_directory, 'locale'), self.lang)
         if exists(regex_dir):
             load_regex(regex_dir, self.bus, self.skill_id)
-        elif exists(join(root_directory, 'locale', self.lang)):
-            load_regex(join(root_directory, 'locale', self.lang),
-                       self.bus, self.skill_id)
+        elif exists(locale_dir):
+            load_regex(locale_dir, self.bus, self.skill_id)
 
     def __handle_stop(self, event):
         """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -41,7 +41,7 @@ from mycroft.metrics import report_metric, report_timing, Stopwatch
 from mycroft.skills.settings import SkillSettings
 from mycroft.skills.skill_data import (load_vocabulary, load_regex, to_alnum,
                                        munge_regex, munge_intent_parser)
-from mycroft.util import camel_case_split, resolve_resource_file
+from mycroft.util import camel_case_split, resolve_resource_file, get_language_dir
 from mycroft.util.log import LOG
 
 MainModule = '__init__'
@@ -575,12 +575,13 @@ class MycroftSkill(object):
         """
         if old_dirname:
             # Try the old directory (dialog/vocab/regex)
-            path = join(self.root_dir, old_dirname, self.lang, res_name)
+            root_path = get_language_dir(join(self.root_dir, old_dirname), self.lang)
+            path = join(root_path, res_name)
             if exists(path):
                 return path
 
         # New scheme:  search for res_name under the 'locale' folder
-        root_path = join(self.root_dir, 'locale', self.lang)
+        root_path = get_language_dir(join(self.root_dir, 'locale'), self.lang)
         for path, _, files in os.walk(root_path):
             if res_name in files:
                 return join(path, res_name)

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -41,7 +41,8 @@ from mycroft.metrics import report_metric, report_timing, Stopwatch
 from mycroft.skills.settings import SkillSettings
 from mycroft.skills.skill_data import (load_vocabulary, load_regex, to_alnum,
                                        munge_regex, munge_intent_parser)
-from mycroft.util import camel_case_split, resolve_resource_file, get_language_dir
+from mycroft.util import camel_case_split, resolve_resource_file, \
+    get_language_dir
 from mycroft.util.log import LOG
 
 MainModule = '__init__'

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -370,3 +370,28 @@ def camel_case_split(identifier: str) -> str:
     regex = '.+?(?:(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|$)'
     matches = re.finditer(regex, identifier)
     return ' '.join([m.group(0) for m in matches])
+
+
+def get_language_dir(base_path, lang="en-us"):
+    # checks for all language variations and returns best path
+    lang_path = os.path.join(base_path, lang)
+    # base_path/en-us
+    if os.path.isdir(lang_path):
+        return lang_path
+    if "-" in lang:
+        main = lang.split("-")[0]
+        # base_path/en
+        general_lang_path = os.path.join(base_path, main)
+        if os.path.isdir(general_lang_path):
+            return general_lang_path
+    else:
+        main = lang
+    # base_path/en-uk, base_path/en-au...
+    if os.path.isdir(base_path):
+        candidates = [f for f in os.listdir(base_path) if f.startswith(main)]
+        candidates = [os.path.join(base_path, c) for c in candidates]
+        paths = [p for p in candidates if os.path.isdir(p)]
+        # TODO how to choose best local dialect?
+        if len(paths):
+            return paths[0]
+    return os.path.join(base_path, lang)

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -373,7 +373,7 @@ def camel_case_split(identifier: str) -> str:
 
 
 def get_language_dir(base_path, lang="en-us"):
-    # checks for all language variations and returns best path
+    """ checks for all language variations and returns best path """
     lang_path = os.path.join(base_path, lang)
     # base_path/en-us
     if os.path.isdir(lang_path):
@@ -388,8 +388,7 @@ def get_language_dir(base_path, lang="en-us"):
         main = lang
     # base_path/en-uk, base_path/en-au...
     if os.path.isdir(base_path):
-        candidates = [f for f in os.listdir(base_path) if f.startswith(main)]
-        candidates = [os.path.join(base_path, c) for c in candidates]
+        candidates = [os.path.join(base_path, f) for f in os.listdir(base_path) if f.startswith(main)]
         paths = [p for p in candidates if os.path.isdir(p)]
         # TODO how to choose best local dialect?
         if len(paths):

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -244,7 +244,7 @@ def curate_cache(directory, min_free_percent=5.0, min_free_disk=50):
             try:
                 os.remove(path)
                 space_freed += fsize
-            except:
+            except Exception as e:
                 pass
 
             if space_freed > bytes_needed:
@@ -388,7 +388,8 @@ def get_language_dir(base_path, lang="en-us"):
         main = lang
     # base_path/en-uk, base_path/en-au...
     if os.path.isdir(base_path):
-        candidates = [os.path.join(base_path, f) for f in os.listdir(base_path) if f.startswith(main)]
+        candidates = [os.path.join(base_path, f)
+                      for f in os.listdir(base_path) if f.startswith(main)]
         paths = [p for p in candidates if os.path.isdir(p)]
         # TODO how to choose best local dialect?
         if len(paths):


### PR DESCRIPTION
support language code variations, adds a utility function and implements it in skills core where relevant

these check for language code variations, lets say we want to access "path/en-uk" , but it does not exist, this PR adds methods to check for "path/en" , "path/en-us" etc, and returns the best language alternative

skills in "en-us" will still work if i configure mycroft for "en-uk", or "es-es" skills will work if i configure mycroft lang for "es"