### PR TITLE
Add model hash to wake word upload

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -118,12 +118,7 @@ class PreciseHotword(HotWordEngine):
         self.models_url = precise_config['models_url']
         self.exe_name = 'precise-stream'
 
-        ww = Configuration.get()['listener']['wake_word']
-        model_name = ww.replace(' ', '-') + '.pb'
-        model_folder = expanduser('~/.mycroft/precise')
-        if not isdir(model_folder):
-            mkdir(model_folder)
-        model_path = join(model_folder, model_name)
+        model_name, model_path = self.get_model_info()
 
         exe_file = self.find_download_exe()
         LOG.info('Found precise executable: ' + exe_file)
@@ -136,6 +131,15 @@ class PreciseHotword(HotWordEngine):
         t = Thread(target=self.check_stdout)
         t.daemon = True
         t.start()
+
+    def get_model_info(self):
+        ww = Configuration.get()['listener']['wake_word']
+        model_name = ww.replace(' ', '-') + '.pb'
+        model_folder = expanduser('~/.mycroft/precise')
+        if not isdir(model_folder):
+            mkdir(model_folder)
+        model_path = join(model_folder, model_name)
+        return model_name, model_path
 
     def find_download_exe(self):
         exe_file = resolve_resource_file(self.exe_name)


### PR DESCRIPTION
## Description
This adds the model version to the wake word metrics system

## How to test
 - Opt in to the Mycroft Open Dataset at https://home.mycroft.ai/
 - `hey mycroft, update config`
 - `hey mycroft, change the wakeword listener to pocketsphinx`
 - `hey mycroft, what time is it`. You should see the usual `Uploading jiafpasif.asfa...0.wav` where the last field is `.0.wav` since pocketsphinx has no model
 - `hey mycroft, change the wake word listener to precise`
 - `hey mycroft, what time is it`. You should see the say `Uploading jafaa.asf.asf.6a....wav` where the last field is no longer 0 but a long hash.
