### PR TITLE
Update Speech recognition module to 3.8.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ gTTS-token==1.1.1
 backports.ssl-match-hostname==3.4.0.2
 PyAudio==0.2.11
 pyee==1.0.1
-SpeechRecognition==3.7.1
+SpeechRecognition==3.8.1
 tornado==4.2.1
 websocket-client==0.32.0
 adapt-parser==0.3.0


### PR DESCRIPTION
## Description

As suggested by @turboproc this restores GoogleCloudSTT. For details on the change see https://github.com/Uberi/speech_recognition/releases

==== Fixed Issues ====
#1329

==== Environment Notes ====
SpeechRecognition updated to 3.8.1

## How to test
Start mycroft assert that normal speechrecognition still work as expected.

## Contributor license agreement signed?
- [x] CLA
