### PR TITLE
Restore send platform code

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -34,6 +34,9 @@ class Api(object):
 
     def __init__(self, path):
         self.path = path
+
+        # Load the config, skipping the REMOTE_CONFIG since we are
+        # getting the info needed to get to it!
         config = Configuration.get([DEFAULT_CONFIG,
                                     SYSTEM_CONFIG,
                                     USER_CONFIG],
@@ -148,9 +151,15 @@ class DeviceApi(Api):
         version = VersionManager.get()
         platform = "unknown"
         platform_build = ""
+
+        # load just the local configs to get platform info
+        config = Configuration.get([SYSTEM_CONFIG,
+                                    USER_CONFIG],
+                                   cache=False)
         if "enclosure" in config:
             platform = config.get("enclosure").get("platform", "unknown")
             platform_build = config.get("enclosure").get("platform_build", "")
+
         return self.request({
             "method": "POST",
             "path": "/activate",
@@ -166,9 +175,15 @@ class DeviceApi(Api):
         version = VersionManager.get()
         platform = "unknown"
         platform_build = ""
+
+        # load just the local configs to get platform info
+        config = Configuration.get([SYSTEM_CONFIG,
+                                    USER_CONFIG],
+                                   cache=False)
         if "enclosure" in config:
             platform = config.get("enclosure").get("platform", "unknown")
             platform_build = config.get("enclosure").get("platform_build", "")
+
         return self.request({
             "method": "PATCH",
             "path": "/" + self.identity.uuid,

--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -146,21 +146,35 @@ class DeviceApi(Api):
 
     def activate(self, state, token):
         version = VersionManager.get()
+        platform = "unknown"
+        platform_build = ""
+        if "enclosure" in config:
+            platform = config.get("enclosure").get("platform", "unknown")
+            platform_build = config.get("enclosure").get("platform_build", "")
         return self.request({
             "method": "POST",
             "path": "/activate",
             "json": {"state": state,
                      "token": token,
                      "coreVersion": version.get("coreVersion"),
+                     "platform": platform,
+                     "platform_build": platform_build,
                      "enclosureVersion": version.get("enclosureVersion")}
         })
 
     def update_version(self):
         version = VersionManager.get()
+        platform = "unknown"
+        platform_build = ""
+        if "enclosure" in config:
+            platform = config.get("enclosure").get("platform", "unknown")
+            platform_build = config.get("enclosure").get("platform_build", "")
         return self.request({
             "method": "PATCH",
             "path": "/" + self.identity.uuid,
             "json": {"coreVersion": version.get("coreVersion"),
+                     "platform": platform,
+                     "platform_build": platform_build,
                      "enclosureVersion": version.get("enclosureVersion")}
         })
 


### PR DESCRIPTION
## Description
This PR restores the send platform information code added by @penrods before christmas. The backend has been updated to handle this in a better way so it can be included now.

## How to test
- Remove `~/.mycroft/identity/identity2.json`
- start mycroft
- Ensure that pairing can be completed successfully

## Contributor license agreement signed?
CLA Yes
