### PR TITLE
Intent service data

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -810,7 +810,9 @@ class MycroftSkill(object):
         # Default to the handler's function name if none given
         name = intent_parser.name or handler.__name__
         munge_intent_parser(intent_parser, name, self.skill_id)
-        self.bus.emit(Message("register_intent", intent_parser.__dict__))
+        data = intent_parser.__dict__
+        data["skill_id"] = self.skill_id
+        self.bus.emit(Message("register_intent", data))
         self.registered_intents.append((name, intent_parser))
         self.add_event(intent_parser.name, handler, 'mycroft.skill.handler')
 
@@ -849,7 +851,8 @@ class MycroftSkill(object):
 
         data = {
             "file_name": filename,
-            "name": name
+            "name": name,
+            "skill_id": self.skill_id
         }
         self.bus.emit(Message("padatious:register_intent", data))
         self.registered_intents.append((intent_file, data))
@@ -917,7 +920,8 @@ class MycroftSkill(object):
         if intent_name in names:
             LOG.debug('Disabling intent ' + intent_name)
             name = str(self.skill_id) + ':' + intent_name
-            self.bus.emit(Message("detach_intent", {"intent_name": name}))
+            self.bus.emit(Message("detach_intent", {"intent_name": name,
+                                                    "skill_id": self.skill_id}))
             return True
 
         LOG.error('Could not disable ' + intent_name +

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -196,6 +196,15 @@ class IntentService(object):
         """
         return self.skill_names.get(skill_id, skill_id)
 
+    def handle_skill_shutdown(self, message):
+        name = message.data.get("name")
+        id = message.data.get("id")
+        self.skills_map[id] = name
+
+    def handle_skill_load(self, message):
+        id = message.data.get("id")
+        self.skills_map.pop(id)
+
     def handle_skill_manifest(self, message):
         self.bus.emit(Message("skill.manifest.response", self.skills_map))
 

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -183,7 +183,7 @@ class IntentService(object):
             Messagebus handler, updates dictionary of if to skill name
             conversions.
         """
-        self.skill_names[message.data['id']] = message.data['name']
+        self.skills_names[message.data['id']] = message.data['name']
 
     def get_skill_name(self, skill_id):
         """ Get skill name from skill ID.
@@ -194,16 +194,16 @@ class IntentService(object):
         Returns:
             (str) Skill name or the skill id if the skill wasn't found
         """
-        return self.skill_names.get(skill_id, skill_id)
+        return self.skills_names.get(skill_id, skill_id)
 
     def handle_skill_shutdown(self, message):
         name = message.data.get("name")
         id = message.data.get("id")
-        self.skills_map[id] = name
+        self.skills_names[id] = name
 
     def handle_skill_load(self, message):
         id = message.data.get("id")
-        self.skills_map.pop(id)
+        self.skills_names.pop(id)
 
     def handle_skill_manifest(self, message):
         self.bus.emit(Message("skill.manifest.response", self.skills_map))


### PR DESCRIPTION
## Description

adds new bus messages to allow getting data from intent service, for example in a manifest skill or in converse method to know what intent would trigger

works together with #1350 

"skill.manifest" - get loaded skills 
"skill.manifest.response" - {"skill id": "skill name"}
"vocab.manifest" - get loaded vocab
"vocab.manifest.response" - {"word": "MatchingKeyword"}
"intent.manifest" - get loaded intents
"intent.manifest.response" - {"skill id": ["intent1", "intent2]}
"intent.get" - get intent that will trigger - {"utterance": "an utterance", "lang":"en-us"}
"intent.response" - {"utterance": "utterance", "intent_data":{message of intent}}

## How to test

emit one of the messages and catch the response

## Contributor license agreement signed?
CLA [x ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)

  