### PR TITLE
fixed settings disappearing on load

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -398,7 +398,6 @@ class SkillSettings(dict):
             with open(self._settings_path) as f:
                 try:
                     json_data = json.load(f)
-                    LOG.info(self.name+str(json_data))
                     for key in json_data:
                         self[key] = json_data[key]
                 except Exception as e:

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -110,6 +110,7 @@ class SkillSettings(dict):
         # if settingsmeta.json exists (and is valid)
         # this block of code is a control flow for
         # different scenarios that may arises with settingsmeta
+        self.load_skill_settings_from_file()  # loads existing settings.json
         settings_meta = self._load_settings_meta()
         if not settings_meta:
             return
@@ -397,6 +398,7 @@ class SkillSettings(dict):
             with open(self._settings_path) as f:
                 try:
                     json_data = json.load(f)
+                    LOG.info(self.name+str(json_data))
                     for key in json_data:
                         self[key] = json_data[key]
                 except Exception as e:


### PR DESCRIPTION
## Description
settings that were not in settingsmeta.json (if you had this) would disappear on load. This is due to  settings.json not being loaded in the initialize_remote_settings(). To fix this, a load_skill_settings_from_file() was invoked in the initialize_remote_settings.

## How to test
To test you can manually add a "test":"test" key value to a skills settings.json. The skill must also have settingsmeta.json since that is when the issue occurs. 