### PR TITLE
Add support for installing on openSUSE

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -90,7 +90,10 @@ install_deps() {
         SUDO=sudo
     fi
 
-    if found_exe apt-get; then
+    if found_exe zypper; then
+	$SUDO zypper install -y git python glibc-devel linux-glibc-devel python-devel python2-virtualenv python2-gobject-devel python-virtualenvwrapper libtool libffi-devel libopenssl-devel autoconf automake bison swig glib2-devel portaudio-devel mpg123 flac curl libicu-devel pkg-config pkg-config libjpeg-devel libfann-devel python-curses
+	$SUDO zypper install -y -t pattern devel_C_C++
+    elif found_exe apt-get; then
         $SUDO apt-get install -y git python python-dev python-setuptools python-virtualenv python-gobject-dev virtualenvwrapper libtool libffi-dev libssl-dev autoconf automake bison swig libglib2.0-dev s3cmd portaudio19-dev mpg123 screen flac curl libicu-dev pkg-config automake libjpeg-dev libfann-dev build-essential jq
     elif found_exe pacman; then
         $SUDO pacman -S --needed --noconfirm git python2 python2-pip python2-setuptools python2-virtualenv python2-gobject python-virtualenvwrapper libtool libffi openssl autoconf bison swig glib2 s3cmd portaudio mpg123 screen flac curl pkg-config icu automake libjpeg-turbo base-devel jq

--- a/scripts/prepare-msm.sh
+++ b/scripts/prepare-msm.sh
@@ -31,11 +31,12 @@ chmod +x ${DIR}/../msm/msm
 
 # Determine which user is running this script
 setup_user=$USER
+setup_group=$( id -gn $USER )
 
 # change ownership of ${mycroft_root_dir} to ${setup_user } recursively 
 function change_ownership {
-    echo "Changing ownership of" ${mycroft_root_dir} "to user:" ${setup_user} "with group:" ${setup_user}
-            sudo chown -Rvf ${setup_user}:${setup_user} ${mycroft_root_dir}
+    echo "Changing ownership of" ${mycroft_root_dir} "to user:" ${setup_user} "with group:" ${setup_group}
+            sudo chown -Rvf ${setup_user}:${setup_group} ${mycroft_root_dir}
 }
 
 


### PR DESCRIPTION
## Description

Running the dev_setup.sh script and getting mycroft up and running on openSUSE was not working (See #1330 and #1340), these modifications are tested to work on a fresh install of OpenSUSE Tumbleweed.

- Use Zypper to install packages
- use primary group of current user when changing owner of /opt/mycroft (openSuse has no user specific group by default)

## How to test
The big thing to test if `prepare_msm.sh` uses the correct group after this change. In my tests (debian and openSuse) this method seem to work.

## Contributor license agreement signed?
CLA [Yes]

  