### PR TITLE
is_remote_list check

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -51,7 +51,7 @@ def is_remote_list(values):
     for v in values:
         if not isinstance(v, dict):
             return False
-        if not "@type" in v.keys():
+        if "@type" not in v.keys():
             return False
     return True
 

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -45,6 +45,17 @@ def merge_dict(base, delta):
             base[k] = dv
 
 
+def is_remote_list(values):
+    ''' check if this list corresponds to a backend formatted collection of
+    dictionaries '''
+    for v in values:
+        if not isinstance(v, dict):
+            return False
+        if not "@type" in v.keys():
+            return False
+    return True
+
+
 def translate_remote(config, setting):
     """
         Translate config names from server to equivalents usable
@@ -65,9 +76,12 @@ def translate_remote(config, setting):
                 config[key] = config.get(key, {})
                 translate_remote(config[key], v)
             elif isinstance(v, list):
-                if key not in config:
-                    config[key] = {}
-                translate_list(config[key], v)
+                if is_remote_list(v):
+                    if key not in config:
+                        config[key] = {}
+                    translate_list(config[key], v)
+                else:
+                    config[key] = v
             else:
                 config[key] = v
 


### PR DESCRIPTION
## Description

when getting remote configuration all lists are considered a list of dicts, this does not allow lists to be sent to the device

this PR adds a method to check if a list is remote formatted or a normal list

If using [another backend](https://github.com/JarbasAl/personal-mycroft-backend/) this is good functionality to have, and also allows mycroft-home to expand better without accidentally screwing the configs

in my case i was sending a list of blacklisted skills from my backend to the device when i noticed this

## How to test

on remote config update verify nothing different happens

## Contributor license agreement signed?
CLA [**yes** ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
