### PR TITLE
Add message on track start

### DIFF
--- a/mycroft/audio/main.py
+++ b/mycroft/audio/main.py
@@ -180,6 +180,11 @@ class AudioService(object):
 
         self.service = load_services(self.config, self.ws)
         LOG.info(self.service)
+        # Register end of track callback
+        for s in self.service:
+            s.set_track_start_callback(self.track_start)
+
+        # Find default backend
         default_name = self.config.get('default-backend', '')
         LOG.info('Finding default backend...')
         for s in self.service:
@@ -206,6 +211,14 @@ class AudioService(object):
         self.ws.on('recognizer_loop:audio_output_end', self._restore_volume)
         self.ws.on('recognizer_loop:record_end', self._restore_volume)
         self.ws.on('mycroft.stop', self._stop)
+
+    def track_start(self, track):
+        """
+            Callback method called from the services to indicate start of
+            playback of a track.
+        """
+        self.ws.emit(Message('mycroft.audio.playing_track',
+                             data={'track': track}))
 
     def _pause(self, message=None):
         """

--- a/mycroft/audio/services/__init__.py
+++ b/mycroft/audio/services/__init__.py
@@ -25,9 +25,8 @@ class AudioBackend():
     """
     __metaclass__ = ABCMeta
 
-    @abstractmethod
     def __init__(self, config, emitter):
-        pass
+        self._track_start_callback = None
 
     @abstractmethod
     def supported_uris(self):
@@ -66,6 +65,13 @@ class AudioBackend():
             Stop playback.
         """
         pass
+
+    def set_track_start_callback(self, callback_func):
+        """
+            Register callback on track start, should be called as each track
+            in a playlist is started.
+        """
+        self._track_start_callback = callback_func
 
     def pause(self):
         """

--- a/mycroft/audio/services/chromecast/__init__.py
+++ b/mycroft/audio/services/chromecast/__init__.py
@@ -47,6 +47,7 @@ class ChromecastService(AudioBackend):
             return
 
     def __init__(self, config, emitter, name='chromecast', cast=None):
+        super(ChromecastService, self).__init__(config, emitter)
         self.connection_attempts = 0
         self.emitter = emitter
         self.config = config
@@ -88,6 +89,9 @@ class ChromecastService(AudioBackend):
         self.cast.quit_app()
 
         track = self.tracklist[0]
+        # Report start of playback to audioservice
+        if self._track_start_callback:
+            self._track_start_callback(track)
         LOG.debug('track: {}, type: {}'.format(track, guess_type(track)))
         mime = guess_type(track)[0] or 'audio/mp3'
         self.cast.play_media(track, mime)

--- a/mycroft/audio/services/mpg123/__init__.py
+++ b/mycroft/audio/services/mpg123/__init__.py
@@ -27,6 +27,7 @@ class Mpg123Service(AudioBackend):
     """
 
     def __init__(self, config, emitter, name='mpg123'):
+        super(Mpg123Service, self).__init__(config, emitter)
         self.config = config
         self.process = None
         self.emitter = emitter
@@ -54,6 +55,9 @@ class Mpg123Service(AudioBackend):
         LOG.info('Mpg123Service._play')
         self._is_playing = True
         track = self.tracks[self.index]
+        # Indicate to audio service which track is being played
+        if self._track_start_callback:
+            self._track_start_callback(track)
 
         # Replace file:// uri's with normal paths
         track = track.replace('file://', '')
@@ -67,8 +71,8 @@ class Mpg123Service(AudioBackend):
             self.process.terminate()
             self.process = None
             self._is_playing = False
-
             return
+
         self.index += 1
         # if there are more tracks available play next
         if self.index < len(self.tracks):


### PR DESCRIPTION

## Description
When a new track starts playing the audio service will send a message ("mycroft.audio.service.track_start") indicating playback of a track has started.

Implemented for the vlc and mpg123 backends.

## How to test
- Install the demo skill: https://github.com/forslund/demo_skill.git
- Issue the command `play all`
- Check the log/cli for a _mycroft.audio.playing_track_ message
- Switch to next track and check that the message is sent now as well

## Contributor license agreement signed?
CLA [Yes]