### PR TITLE
Add support for deepspeech_server

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -196,11 +196,15 @@
   // Speech to Text parameters
   // Override: REMOTE
   "stt": {
-    // Engine.  Options: "mycroft", "google", "wit", "ibm", "kaldi", "bing", "houndify"
+    // Engine.  Options: "mycroft", "google", "wit", "ibm", "kaldi", "bing",
+    //                   "houndify, deepspeech_server"
     "module": "mycroft"
+    // "deepspeech_server": {
+    //   "uri": "http://localhost:8080/stt"
+    // },
     // "kaldi": {
     //   "uri": "http://localhost:8080/client/dynamic/recognize"
-    // }
+    // },
   },
 
   // Text to Speech parameters

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -134,6 +134,22 @@ class MycroftSTT(STT):
             return self.api.stt(audio.get_flac_data(), self.lang, 1)[0]
 
 
+class DeepSpeechServerSTT(STT):
+    """
+        STT interface for the deepspeech-server:
+        https://github.com/MainRo/deepspeech-server
+    """
+    def __init__(self):
+        super(DeepSpeechServerSTT, self).__init__()
+
+    def execute(self, audio, language=None):
+        language = language or self.lang
+        if not language.startswith("en"):
+            raise ValueError("Deepspeech is currently english only")
+        response = post(self.config.get("uri"), data=audio.get_wav_data())
+        return response.text
+
+
 class KaldiSTT(STT):
     def __init__(self):
         super(KaldiSTT, self).__init__()
@@ -179,7 +195,8 @@ class STTFactory(object):
         "ibm": IBMSTT,
         "kaldi": KaldiSTT,
         "bing": BingSTT,
-        "houndify": HoundifySTT
+        "houndify": HoundifySTT,
+        "deepspeech_server": DeepSpeechServerSTT
     }
 
     @staticmethod


### PR DESCRIPTION
## Description
[deepspeech_server](https://github.com/MainRo/deepspeech-server) is a server running deepspeech (obviously). It's quite
easy to install and run (package available in pip and then a config file
pointing to the model)

This pr adds the DeepSpeechServerSTT class, a STT interface allowing
mycroft to use one of these servers.

config needed:
```json
  "stt": {
    "module": "deepspeech_server",
    "deepspeech_server": {
      "uri": "http://IP-ADDRESS:PORT/stt"
    }
  }
```

## How to test

setup a deepspeech server:
```bash
mkvirtualenv -p python3 deepspeechserver
pip install deepspeech # or deepspeech-gpu if you have an nvidia gpu
pip install deepspeech-server
```

Download and extract the model:
```bash
wget https://github.com/mozilla/DeepSpeech/releases/download/v0.1.0/deepspeech-0.1.0-models.tar.gz
tar -xzvf models.tar.gz
```

create the file config.json:

```json
{
  "deepspeech": {
    "model" :"models/output_graph.pb",
    "alphabet": "models/alphabet.txt",
    "lm": "models/lm.binary",
    "trie": "models/trie"
  },
  "server": {
    "http": {
      "host": "0.0.0.0",
      "port": 8080,
      "request_max_size": 1048576
    }
  }
}
```

start the server

`deepspeech-server --config config.json`

The server should now start up and be ready to accept connections

set the stt to deepspeech_server by adding a section to ~/.mycroft.conf

```json
  "stt": {
    },
      "deepspeech_server": {
          "uri": "http://localhost:8080/stt"
      },
      "module": "deepspeech_server"
  }
```

As you speak, the terminal running the deep speech server should show the transcription and mycroft should answer your queries. (The model seem to get a lot of things wrong but simple queries like  "tell me a joke" and "what's the weather like" seem to work)

## Contributor license agreement signed?
CLA [yes]