### PR TITLE
Ignore .files when checking for skill modification

### DIFF
--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -182,7 +182,8 @@ def _get_last_modified_date(path):
 
     # check files of interest in the skill root directory
     files = [f for f in files
-             if not f.endswith('.pyc') and f != 'settings.json']
+             if not f.endswith('.pyc') and f != 'settings.json' and
+             not f.startswith('.')]
     for f in files:
         last_date = max(last_date, os.path.getmtime(os.path.join(path, f)))
     return last_date


### PR DESCRIPTION
## Description
This ignores all files starting with . when checking for modifications
of skills. For me this is an issue since swap-files starting with `.` are created and updated in the skill directory when editing. 

## How to test
Check the cli and run the command `touch /opt/mycroft/skills/skill-weather/.test.txt`

## Contributor license agreement signed?
CLA [Yes]