### PR TITLE
Add callback on settings change from backend

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -99,10 +99,19 @@ class SkillSettings(dict):
         self._device_identity = None
         self._api_path = None
         self._user_identity = None
+        self.changed_callback = None
 
         # if settingsmeta exist
         if isfile(self._meta_path):
             self._poll_skill_settings()
+
+    def set_changed_callback(self, callback):
+        """
+            Set callback to perform when server settings have changed.
+
+            callback: function/method to call when settings have changed
+        """
+        self.changed_callback = callback
 
     # TODO: break this up into two classes
     def initialize_remote_settings(self):
@@ -380,7 +389,12 @@ class SkillSettings(dict):
                 if not self._complete_intialization:
                     return  # unable to do remote sync
             else:
+                original = hash(str(self))
                 self.update_remote()
+                # Call callback for updated settings
+                if self.changed_callback and hash(str(self)) != original:
+                    self.changed_callback()
+
         except Exception as e:
             LOG.error(e)
             LOG.exception("")


### PR DESCRIPTION
## Description
If settings are updated a callback can be set to notify the skill that a
change has occurred.

## How to test
Create a simple skill:
`__init__.py:
```python

from mycroft import MycroftSkill, intent_file_handler
from adapt.intent import IntentBuilder
from mycroft.util.log import LOG

class TestSkill(MycroftSkill):
    def __init__(self):
        super(TestSkill, self).__init__()
        self.settings.set_callback(self.settings_callback)

    def settings_callback(self):
        self.speak('settings have changed')

def create_skill():
    return TestSkill()
```

and a settingsmeta.json:
```json
{
    "name": "TEST",
    "skillMetadata": {
        "sections": [
            {
                "name": "",
                "fields": [
                    {
                        "name": "TEST",
                        "type": "Number",
                        "value": 0
                    }
                ]
            }
        ]
    }
}
```

Start the skill and go to home.mycroft.ai and change the TEST value. Within a minute the skill should speak that settings have changed.
 
## Contributor license agreement signed?
CLA [Yes]