### PR TITLE
Run pip after any update to skills managed by msm.

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -471,6 +471,7 @@ function update() {
         git fetch
         git reset --hard origin/master
         rm -f *.pyc
+        run_pip "${d}"
       else
         echo "Ignoring ${d}, skill has been modified."
       fi


### PR DESCRIPTION
Run pip after any updates to skills, to ensure that libraries are
updated per the lateset version of the skill. This may cause pip to run
twice (if mycroft has re-PIPed), however, given that the cost of this
is very low (basically a no-op on the second run), and the re-PIP logic
is flagged for removal, it seems safest to not touch that logic for
now.

==== Fixed Issues ====

## Description
Fixes #1387 

## How to test
1) Install a skill using `msm`.
1) Updates it's `requirements.txt` to include a new library.
1) Run `msm update`
1) Run `pip freeze`

Without this fix, the new library should not be installed. With this fix, the new library will be installed.

## Contributor license agreement signed?
CLA [X] 
