### PR TITLE
Skip skill update on startup if recent

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -417,6 +417,7 @@ function install_from_url_list() {
           # keep the highest exit code
           exit_code=${rc}
         fi
+        echo ${name} >> ${mycroft_skill_folder}/.msm
       fi
     fi
   done
@@ -681,6 +682,8 @@ case ${OPT} in
          exit ${exit_code}
       fi
 
+      # Create .msm file to provide timestamp for last msm default
+      printf "" > ${mycroft_skill_folder}/.msm
       # These skills are automatically installed on all mycroft-core
       # installations.
       install_from_url_list "https://raw.githubusercontent.com/MycroftAI/mycroft-skills/master/DEFAULT-SKILLS"

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -92,7 +92,9 @@
     // blacklisted skills to not load
     "blacklisted_skills": ["skill-media", "send_sms", "skill-wolfram-alpha"],
     // priority skills to be loaded first
-    "priority_skills": ["skill-pairing"]
+    "priority_skills": ["skill-pairing"],
+    // Minimum time since last skill updata to force an update on startup
+    "startup_update_required_time": 12
   },
   
   // Address of the REMOTE server

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -61,10 +61,9 @@ MINUTES = 60  # number of seconds in a minute (syntatic sugar)
 
 
 def direct_update_needed():
-    """
-        Direct update is needed if the .msm file doesn't exist, if it's
-        older than 12 hour, as configured or if some of the skills installed
-        by default is missing.
+    """Determine need for an update
+    Direct update is needed if the .msm file doesn't exist, if it's older than
+    12 hours (or as configured) or if any of the default skills are missing.
     """
     dot_msm = join(SKILLS_DIR, '.msm')
     hours = skills_config.get('startup_update_required_time', 12)

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -60,6 +60,31 @@ MSM_BIN = installer_config.get("path", join(MYCROFT_ROOT_PATH, 'msm', 'msm'))
 MINUTES = 60  # number of seconds in a minute (syntatic sugar)
 
 
+def direct_update_needed():
+    """
+        Direct update is needed if the .msm file doesn't exist, if it's
+        older than 12 hour, as configured or if some of the skills installed
+        by default is missing.
+    """
+    dot_msm = join(SKILLS_DIR, '.msm')
+    hours = skills_config.get('startup_update_required_time', 12)
+    LOG.info('TIME LIMIT {}'.format(hours))
+    # if .msm file is missing or older than 1 hour update skills
+    if (not exists(dot_msm) or
+            os.path.getmtime(dot_msm) < time.time() - 60 * MINUTES * hours):
+        return True
+    else:  # verify that all default skills are installed
+        with open(dot_msm) as f:
+            default_skills = [line.strip() for line in f if line != '']
+        skills = os.listdir(SKILLS_DIR)
+        LOG.info(default_skills)
+        for d in default_skills:
+            if d not in skills:
+                LOG.info('{} has been removed, direct update needed'.format(d))
+                return True
+    return False
+
+
 def connect():
     global ws
     ws.run_forever()
@@ -135,6 +160,9 @@ def check_connection():
             # reboot
             ws.emit(Message("system.reboot"))
             return
+        else:
+            ws.emit(Message("enclosure.mouth.reset"))
+            time.sleep(0.5)
 
         ws.emit(Message('mycroft.internet.connected'))
         # check for pairing, if not automatically start pairing
@@ -146,11 +174,6 @@ def check_connection():
             }
             ws.emit(Message("recognizer_loop:utterance", payload))
         else:
-            if is_paired():
-                # Skip the  message when unpaired because the prompt to go
-                # to home.mycrof.ai will be displayed by the pairing skill
-                enclosure.mouth_text(mycroft.dialog.get("message_updating"))
-
             from mycroft.api import DeviceApi
             api = DeviceApi()
             api.update_version()
@@ -196,10 +219,14 @@ class SkillManager(Thread):
         super(SkillManager, self).__init__()
         self._stop_event = Event()
         self._loaded_priority = Event()
-        self.next_download = time.time() - 1    # download ASAP
+
         self.loaded_skills = {}
         self.msm_blocked = False
         self.ws = ws
+        self.enclosure = EnclosureAPI(ws)
+
+        # Schedule install/update of default skill
+        self.next_download = None
 
         # Conversation management
         ws.on('skill.converse.request', self.handle_converse_request)
@@ -208,7 +235,7 @@ class SkillManager(Thread):
         ws.on('mycroft.internet.connected', self.schedule_update_skills)
 
         # Update upon request
-        ws.on('skillmanager.update', self.schedule_update_skills)
+        ws.on('skillmanager.update', self.schedule_now)
         ws.on('skillmanager.list', self.send_skill_list)
 
         # Register handlers for external MSM signals
@@ -225,7 +252,20 @@ class SkillManager(Thread):
 
     def schedule_update_skills(self, message=None):
         """ Schedule a skill update to take place directly. """
-        # Update skills at next opportunity
+        if direct_update_needed():
+            # Update skills at next opportunity
+            LOG.info('Skills will be updated directly')
+            self.schedule_now()
+            # Skip the  message when unpaired because the prompt to go
+            # to home.mycrof.ai will be displayed by the pairing skill
+            if not is_paired():
+                self.enclosure.mouth_text(
+                    mycroft.dialog.get("message_updating"))
+        else:
+            LOG.info('Skills will be updated at a later time')
+            self.next_download = time.time() + 60 * MINUTES
+
+    def schedule_now(self, message=None):
         self.next_download = time.time() - 1
 
     def block_msm(self, message=None):
@@ -392,11 +432,13 @@ class SkillManager(Thread):
                                                                True)
 
             # Update skills once an hour if update is enabled
-            if time.time() >= self.next_download and update:
+            if (self.next_download and time.time() >= self.next_download and
+                    update):
                 self.download_skills()
 
             # Look for recently changed skill(s) needing a reload
-            if exists(SKILLS_DIR):
+            if (exists(SKILLS_DIR) and
+                    (self.next_download or not update)):
                 # checking skills dir and getting all skills there
                 list = filter(lambda x: os.path.isdir(
                     os.path.join(SKILLS_DIR, x)), os.listdir(SKILLS_DIR))


### PR DESCRIPTION
## Description
Skills aren't updated on startup if the last update was less than 12
hours ago.

- msm adds a .msm file in the skills directory with a timestamp and a
    list of the skills installed by default
- the UPDATING screen message is moved to the SkillManger when direct
    update is scheduled.
- On internet connection the skill update time is scheduled
- Skills (other than priority skills) are not loaded until
- The timeout for when direct update is necessary is settable in the
    config.
internet connection has been verified (message on messagebus)


## How to test
Start up mycroft and check that the skills are updated as expected. Restart the skills and check that the skills doesn't update but start up directly after SYNC message.
Stop mycroft and add the following section to the mycroft.conf:

```json
  "skills": {
     "startup_update_required_time": 0.5
  }
```

Wait 30 minutes, start up mycroft. Check that the skills are updated immediately at startup.

## Contributor license agreement signed?
CLA [Yes]