### PR TITLE
Add :skills command to list skills in cli

### DIFF
--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -208,6 +208,7 @@ class SkillManager(Thread):
 
         # Update upon request
         ws.on('skillmanager.update', self.schedule_update_skills)
+        ws.on('skillmanager.list', self.send_skill_list)
 
         # Register handlers for external MSM signals
         ws.on('msm.updating', self.block_msm)
@@ -406,6 +407,16 @@ class SkillManager(Thread):
                 self.loaded_skills[skill]['instance'].shutdown()
             except BaseException:
                 pass
+
+    def send_skill_list(self, message=None):
+        """
+            Send list of loaded skills.
+        """
+        try:
+            self.ws.emit(Message('mycroft.skills.list',
+                                 data={'skills': self.loaded_skills.keys()}))
+        except Exception as e:
+            LOG.exception(e)
 
     def wait_loaded_priority(self):
         """ Block until all priority skills have loaded """


### PR DESCRIPTION
The command will display a list of all loaded skills in a similar manner to how the help is shown.

SkillManager now handles the `skillmanager.list message` and will reply with the
`mycroft.skills.list` message including a list of the loaded skills.

==== Protocol Notes ====
Added messages:
- skillmanager.list: skill manager send list of skills on messagebus
- mycroft.skills.list message with skill list

## How to test
Start mycroft open the cli enter :skills and verify that the a view presenting a list of the loaded skills is shown.

## Contributor license agreement signed?
CLA [Yes]