### PR TITLE
modified identifier, add .mypy_cache to git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ mycroft/audio-accuracy-test/data/*
 scripts/*.screen
 doc/_build/
 .installed
+.mypy_cache
 
 # Created by unit tests
 test/unittests/skills/test_skill/settings.json

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -319,7 +319,7 @@ class SkillSettings(dict):
                 _hash (str): hashed to identify skills
         """
         _hash = self.hash(str(settings_meta) + str(self._user_identity))
-        return "{}-{}".format(basename(self.directory), _hash)
+        return "{}--{}".format(basename(self.directory), _hash)
 
     def _save_hash(self, hashed_meta):
         """ Saves hashed_meta to settings directory.


### PR DESCRIPTION
## Description
This is the final modification needed to fix issue #1382. The bug was due to identifier collisions in the backend as well as settingsmeta schemas with a label field with no name attribute. Fix was to automatically add the name attribute in the backend for schemas with a label field. This fix will make sure there are no more identifier collisions with already existing broken settingsmeta schemas in the database.

## How to test
* delete a device that owns the skills, skills should disappear from home. 
* Re-pair the device with home and skills should re-appear (settings will not transfer since the settings will be deleted once the device is deleted).

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
