### PR TITLE
Bug fix for skills erroring out when attempting to save.

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -216,7 +216,7 @@ class SkillSettings(dict):
         sections = skill_settings['skillMetadata']['sections']
         for section in sections:
             for field in section["fields"]:
-                if "name" in field:  # no name for 'label' fields
+                if "name" in field and "value" in field:
                     self[field['name']] = field['value']
         self.store()
 


### PR DESCRIPTION
## Description
```python
Traceback (most recent call last):
File "/home/carsten/Mycroft/dev/mycroft-core/mycroft/skills/settings.py", line 388, in _poll_skill_settings
self.initialize_remote_settings()
File "/home/carsten/Mycroft/dev/mycroft-core/mycroft/skills/settings.py", line 160, in initialize_remote_settings
self.save_skill_settings(settings)
File "/home/carsten/Mycroft/dev/mycroft-core/mycroft/skills/settings.py", line 220, in save_skill_settings
self[field['name']] = field['value']
KeyError: 'value' (edited)
```

The error happens because labels field in settingsmeta now has an auto-generated "name" attribute. This causes the skill to error out when attempting to save the settings. The fix now checks to see if the fields have a "value" and "name" attribute.

## How to test
boot up mycroft-core. If the skills are syncing correctly like below, then the error above is resolved.

```python
18:45:10.665 - mycroft.skills.settings:_request_my_settings:433 - INFO - getting skill settings from server for InternetRadioSkill
18:45:11.879 - mycroft.skills.settings:_request_other_settings:466 - INFO - syncing settings with other devices from server for PianobarSkill
18:46:06.289 - mycroft.skills.settings:_request_other_settings:466 - INFO - syncing settings with other devices from server for WeatherSkill
```

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
