### PR TITLE
Check that value exists before checking for change

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -516,7 +516,10 @@ class SkillSettings(dict):
             for i, section in enumerate(sections):
                 for j, field in enumerate(section['fields']):
                     if 'name' in field:
-                        if field["name"] in self:
+                        # Ensure that the field exists in settings and that
+                        # it has a value to compare
+                        if (field["name"] in self and
+                                'value' in sections[i]['fields'][j]):
                             remote_val = sections[i]['fields'][j]["value"]
                             self_val = self.get(field['name'])
                             if str(remote_val) != str(self_val):


### PR DESCRIPTION
 ## Description
An error occured when testing skill settings when checking if the settings should be sent when trying to upload a field without a value. To guard against this there is a check if the field has a value before checking.

## Contributor license agreement signed?
CLA [Yes]