### PR TITLE
Libfann Arch Linux

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -94,6 +94,13 @@ install_deps() {
         $SUDO apt-get install -y git python python-dev python-setuptools python-virtualenv python-gobject-dev virtualenvwrapper libtool libffi-dev libssl-dev autoconf automake bison swig libglib2.0-dev s3cmd portaudio19-dev mpg123 screen flac curl libicu-dev pkg-config automake libjpeg-dev libfann-dev build-essential jq
     elif found_exe pacman; then
         $SUDO pacman -S --needed git python2 python2-pip python2-setuptools python2-virtualenv python2-gobject python-virtualenvwrapper libtool libffi openssl autoconf bison swig glib2 s3cmd portaudio mpg123 screen flac curl pkg-config icu automake libjpeg-turbo base-devel jq
+        pacman -Qs "^libfann$" &> /dev/null || (
+            git clone  https://aur.archlinux.org/libfann.git
+            cd libfann
+            makepkg -srci
+            cd ..
+            rm -rf libfann
+        )
     elif found_exe dnf; then
         $SUDO dnf install -y git python python-devel python-pip python-setuptools python-virtualenv pygobject2-devel python-virtualenvwrapper libtool libffi-devel openssl-devel autoconf bison swig glib2-devel s3cmd portaudio-devel mpg123 mpg123-plugins-pulseaudio screen curl pkgconfig libicu-devel automake libjpeg-turbo-devel fann-devel gcc-c++ redhat-rpm-config jq
     else

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -93,11 +93,11 @@ install_deps() {
     if found_exe apt-get; then
         $SUDO apt-get install -y git python python-dev python-setuptools python-virtualenv python-gobject-dev virtualenvwrapper libtool libffi-dev libssl-dev autoconf automake bison swig libglib2.0-dev s3cmd portaudio19-dev mpg123 screen flac curl libicu-dev pkg-config automake libjpeg-dev libfann-dev build-essential jq
     elif found_exe pacman; then
-        $SUDO pacman -S --needed git python2 python2-pip python2-setuptools python2-virtualenv python2-gobject python-virtualenvwrapper libtool libffi openssl autoconf bison swig glib2 s3cmd portaudio mpg123 screen flac curl pkg-config icu automake libjpeg-turbo base-devel jq
+        $SUDO pacman -S --needed --noconfirm git python2 python2-pip python2-setuptools python2-virtualenv python2-gobject python-virtualenvwrapper libtool libffi openssl autoconf bison swig glib2 s3cmd portaudio mpg123 screen flac curl pkg-config icu automake libjpeg-turbo base-devel jq
         pacman -Qs "^libfann$" &> /dev/null || (
             git clone  https://aur.archlinux.org/libfann.git
             cd libfann
-            makepkg -srci
+            makepkg -srci --noconfirm
             cd ..
             rm -rf libfann
         )


### PR DESCRIPTION
## Description
Fixes #1361 Firsts checks whether libfann is installed. If libfann is not found, clones the repository, runs makepkg -srci inside and removes the directory.

## How to test
Install on a Clean Arch Linux Installation

## Contributor license agreement signed?
CLA [Yes]
