### PR TITLE
Allow clients to target the replies from Mycroft

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -49,6 +49,13 @@ def handle_speak(event):
     Configuration.init(bus)
     global _last_stop_signal
 
+    # if the message is targeted and audio is not the target don't
+    # don't synthezise speech
+    if (event.context and 'destination' in event.context and
+            event.context['destination'] and
+            'audio' not in event.context['destination']):
+        return
+
     # Get conversation ID
     if event.context and 'ident' in event.context:
         ident = event.context['ident']

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -59,7 +59,8 @@ def handle_wakeword(event):
 
 def handle_utterance(event):
     LOG.info("Utterance: " + str(event['utterances']))
-    context = {'client_name': 'mycroft_listener'}
+    context = {'client_name': 'mycroft_listener',
+               'destination': None}
     if 'ident' in event:
         ident = event.pop('ident')
         context['ident'] = ident


### PR DESCRIPTION
## Description
The speech handling now checks the message context if it's the intended target for the message and will only speak in the following conditions:

- Explicitly targeted i.e. the target include `"audio"`
- target is set to `None`
- target is missing completely

The idea is that for example when the android app is used to access Mycroft the device at home shouldn't start to speak.

### Targeting Theory
- The context target parameter in the original message can be set to list with any number of intended targets:
```python
    ws.emit(Message('recognizer_loop:utterance', data, context={'destination': ['audio', 'kde']))
```
- A missing target or if the target is set to `None` is interpreted as a multicast and should trigger all output capable processes (be it the *mycroft-audio* process, a web-interface, the KDE plasmoid or maybe the android app)



## Contributor license agreement signed?
CLA [Yes]