### PR TITLE
Fix bug in nice_time() for times before noon

### DIFF
--- a/mycroft/util/lang/format_en.py
+++ b/mycroft/util/lang/format_en.py
@@ -202,7 +202,7 @@ def nice_time_en(dt, speech=True, use_24hour=False, use_ampm=False):
         if dt.hour == 0:
             speak = pronounce_number_en(12)
         elif dt.hour < 13:
-            speak = pronounce_number_en(dt.hour-12)
+            speak = pronounce_number_en(dt.hour)
         else:
             speak = pronounce_number_en(dt.hour-12)
 

--- a/test/unittests/util/test_format.py
+++ b/test/unittests/util/test_format.py
@@ -227,6 +227,26 @@ class TestNiceDateFormat(unittest.TestCase):
         self.assertEqual(nice_time(dt, use_24hour=True, use_ampm=False),
                          "zero zero zero two")
 
+        dt = datetime.datetime(2018, 2, 8,
+                               1, 2, 33)
+        self.assertEqual(nice_time(dt),
+                         "one oh two")
+        self.assertEqual(nice_time(dt, use_ampm=True),
+                         "one oh two AM")
+        self.assertEqual(nice_time(dt, speech=False),
+                         "1:02")
+        self.assertEqual(nice_time(dt, speech=False, use_ampm=True),
+                         "1:02 AM")
+        self.assertEqual(nice_time(dt, speech=False, use_24hour=True),
+                         "01:02")
+        self.assertEqual(nice_time(dt, speech=False, use_24hour=True,
+                                   use_ampm=True),
+                         "01:02")
+        self.assertEqual(nice_time(dt, use_24hour=True, use_ampm=True),
+                         "zero one zero two")
+        self.assertEqual(nice_time(dt, use_24hour=True, use_ampm=False),
+                         "zero one zero two")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Bonehead copy/paste and testing gap left a bug that reported things
like "negative 11 o'clock"

## How to test
cd test/unittest/util
python test_format.py

## Contributor license agreement signed?
CLA [X] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
