### PR TITLE
Setup python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ scripts/*.screen
 doc/_build/
 .installed
 .mypy_cache
+.venv/
 
 # Created by unit tests
 test/unittests/skills/test_skill/settings.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 before_install:
  - sudo apt-get update -qq
- - sudo apt-get install -qq mpg123 portaudio19-dev libglib2.0-dev swig bison libtool autoconf libglib2.0-dev libicu-dev libfann-dev
+ - sudo apt-get install -qq mpg123 portaudio19-dev libglib2.0-dev swig bison libtool autoconf libglib2.0-dev libicu-dev libfann-dev realpath
 python:
-  - "2.7"
+  - "3.4"
 # don't rebuild pocketsphinx for every build
 cache: pocketsphinx-python
 # command to install dependencies

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -91,7 +91,7 @@ install_deps() {
     fi
 
     if found_exe apt-get; then
-        $SUDO apt-get install -y git python python-dev python-setuptools python-venv python-gobject-dev libtool libffi-dev libssl-dev autoconf automake bison swig libglib2.0-dev s3cmd portaudio19-dev mpg123 screen flac curl libicu-dev pkg-config automake libjpeg-dev libfann-dev build-essential jq
+        $SUDO apt-get install -y git python python-dev python-setuptools python-gobject-dev libtool libffi-dev libssl-dev autoconf automake bison swig libglib2.0-dev s3cmd portaudio19-dev mpg123 screen flac curl libicu-dev pkg-config automake libjpeg-dev libfann-dev build-essential jq
     elif found_exe pacman; then
         $SUDO pacman -S --needed git python2 python2-pip python2-setuptools python2-virtualenv python2-gobject python-virtualenvwrapper libtool libffi openssl autoconf bison swig glib2 s3cmd portaudio mpg123 screen flac curl pkg-config icu automake libjpeg-turbo base-devel jq
     elif found_exe dnf; then
@@ -113,10 +113,11 @@ TOP=$(cd $(dirname $0) && pwd -L)
 VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${TOP}/.venv"}
 
 install_venv() {
-    python3 -m venv .venv/
-    curl https://bootstrap.pypa.io/get-pip.py | .venv/bin/python
+    python3 -m venv "${VIRTUALENV_ROOT}/"
+    curl https://bootstrap.pypa.io/get-pip.py | "${VIRTUALENV_ROOT}/bin/python"
 }
-#install_deps
+
+install_deps
 
 # Configure to use the standard commit template for
 # this repo only.

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -117,10 +117,11 @@ git config commit.template .gitmessage
 
 TOP=$(cd $(dirname $0) && pwd -L)
 
+MYCROFT_VENV=${MYCROFT_VENV:-"mycroft"}
 if [ -z "$WORKON_HOME" ]; then
-    VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${HOME}/.virtualenvs/mycroft"}
+    VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${HOME}/.virtualenvs/$MYCROFT_VENV"}
 else
-    VIRTUALENV_ROOT="$WORKON_HOME/mycroft"
+    VIRTUALENV_ROOT="$WORKON_HOME/$MYCROFT_VENV"
 fi
 
 # Check whether to build mimic (it takes a really long time!)
@@ -147,10 +148,12 @@ else
   fi
 fi
 
+# get correct python directory
+PYTHON=`python -c "import sys;print('python{}.{}'.format(sys.version_info[0], sys.version_info[1]))"`
 # create virtualenv, consistent with virtualenv-wrapper conventions
 if [ ! -d "${VIRTUALENV_ROOT}" ]; then
    mkdir -p $(dirname "${VIRTUALENV_ROOT}")
-  virtualenv -p python2.7 "${VIRTUALENV_ROOT}"
+  virtualenv -p python3 "${VIRTUALENV_ROOT}"
 fi
 source "${VIRTUALENV_ROOT}/bin/activate"
 cd "${TOP}"
@@ -160,7 +163,7 @@ pip install --upgrade virtualenv
 # Add mycroft-core to the virtualenv path
 # (This is equivalent to typing 'add2virtualenv $TOP', except
 # you can't invoke that shell function from inside a script)
-VENV_PATH_FILE="${VIRTUALENV_ROOT}/lib/python2.7/site-packages/_virtualenv_path_extensions.pth"
+VENV_PATH_FILE="${VIRTUALENV_ROOT}/lib/$PYTHON/site-packages/_virtualenv_path_extensions.pth"
 if [ ! -f "$VENV_PATH_FILE" ] ; then
     echo "import sys; sys.__plen = len(sys.path)" > "$VENV_PATH_FILE" || return 1
     echo "import sys; new=sys.path[sys.__plen:]; del sys.path[sys.__plen:]; p=getattr(sys,'__egginsert',0); sys.path[p:p]=new; sys.__egginsert = p+len(new)" >> "$VENV_PATH_FILE" || return 1

--- a/msm/msm
+++ b/msm/msm
@@ -18,6 +18,10 @@ RED='\033[0;31m'
 NOCOLOR='\033[0m'
 GREEN='\033[0;32m'
 
+# Set virtualenv for git clone install of mycroft
+TOP=$(cd $(dirname $0) && pwd -L)/..
+VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${TOP}/.venv"}
+ACTIVATE=$VIRTUALENV_ROOT/bin/activate
 
 script=${0}
 script=${script##*/}
@@ -83,19 +87,6 @@ picroft_mk1="false"
 vwrap="true"
 if [[ "${mycroft_platform}" == "picroft" ]] || [[ "${mycroft_platform}" == "mycroft_mark_1" ]] ; then
   picroft_mk1="true"
-else
-  if [[ -r /etc/bash_completion.d/virtualenvwrapper ]]; then
-    source /etc/bash_completion.d/virtualenvwrapper
-   elif [[ -r /usr/bin/virtualenvwrapper.sh ]]; then
-    source /usr/bin/virtualenvwrapper.sh
-  else
-    if locate virtualenvwrapper ; then
-      if ! source $(locate virtualenvwrapper) ; then
-        echo "WARNING: Unable to locate virtualenvwrapper.sh, not able to install skills!"
-        vwrap="false"
-      fi
-    fi
-  fi
 fi
 
 # Cache to only retrieve list once per MSM invocation
@@ -364,14 +355,14 @@ function run_pip() {
     if [[ -f "requirements.txt" ]]; then
       echo "  Installing requirements..."
       if [[ "${picroft_mk1}" == "false" ]]; then
-        if [[ "${VIRTUAL_ENV}" =~ .mycroft$ ]] ; then
+        if [[ "${VIRTUAL_ENV}" =~ .mycroft-core/.venv$ ]] ; then
           if ! pip install -r requirements.txt ; then
             echo "ERROR: Unable to install requirements for skill '${name}'"
             send_install_fail "${name}" 121
             return 121
           fi
         else
-          if workon mycroft ; then
+          if source "${ACTIVATE}" ; then
             if ! pip install -r requirements.txt ; then
               echo "ERROR: Unable to install requirements for skill '${name}'"
               deactivate mycroft

--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -23,8 +23,6 @@ from mycroft.configuration.config import DEFAULT_CONFIG, SYSTEM_CONFIG, \
 from mycroft.identity import IdentityManager
 from mycroft.version import VersionManager
 from mycroft.util import get_arch
-# python 2/3 compatibility
-from future.utils import iteritems
 
 _paired_cache = False
 
@@ -115,7 +113,7 @@ class Api(object):
     def build_json(self, params):
         json = params.get("json")
         if json and params["headers"]["Content-Type"] == "application/json":
-            for k, v in iteritems(json):
+            for k, v in json.items():
                 if v == "":
                     json[k] = None
             params["json"] = json

--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -35,10 +35,7 @@ from mycroft.util import play_wav, create_signal, connected, \
     wait_while_speaking
 from mycroft.util.audio_test import record
 from mycroft.util.log import LOG
-if sys.version_info[0] < 3:
-    from Queue import Queue
-else:
-    from queue import Queue
+from queue import Queue
 
 
 class EnclosureReader(Thread):

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -178,11 +178,7 @@ class PreciseHotword(HotWordEngine):
     def download(url, filename):
         import shutil
 
-        # python 2/3 compatibility
-        if sys.version_info[0] >= 3:
-            from urllib.request import urlopen
-        else:
-            from urllib2 import urlopen
+        from urllib.request import urlopen
         LOG.info('Downloading: ' + url)
         req = urlopen(url)
         with open(filename, 'wb') as fp:

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -28,10 +28,7 @@ from mycroft.metrics import MetricsAggregator, Stopwatch, report_timing
 from mycroft.session import SessionManager
 from mycroft.stt import STTFactory
 from mycroft.util.log import LOG
-if sys.version_info[0] < 3:
-    from Queue import Queue, Empty
-else:
-    from queue import Queue, Empty
+from queue import Queue, Empty
 
 
 class AudioProducer(Thread):

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -461,7 +461,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                         str(int(1000 * get_time())),
                         SessionManager.get().session_id,
                         self.account_id,
-                        model_hash
+                        str(model_hash)
                     ]
                     fn = join(dr, '.'.join(components) + '.wav')
                     with open(fn, 'wb') as f:

--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 from __future__ import print_function
+from builtins import str
 import sys
 import io
 
@@ -27,8 +28,12 @@ def custom_except_hook(exctype, value, traceback):           # noqa
 sys.excepthook = custom_except_hook  # noqa
 
 # capture any output
-sys.stdout = io.BytesIO()  # noqa
-sys.stderr = io.BytesIO()  # noqa
+if sys.version_info[0] < 3:  # noqa
+    sys.stdout = io.BytesIO()  # noqa
+    sys.stderr = io.BytesIO()  # noqa
+else:  # noqa
+    sys.stdout = io.StringIO()  # noqa
+    sys.stderr = io.StringIO()  # noqa
 
 import os
 import os.path
@@ -157,7 +162,7 @@ def save_settings():
     config["show_last_key"] = show_last_key
     config["max_log_lines"] = max_log_lines
     with io.open(config_file, 'w') as f:
-        f.write(unicode(json.dumps(config, ensure_ascii=False)))
+        f.write(str(json.dumps(config, ensure_ascii=False)))
 
 
 ##############################################################################

--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -409,7 +409,7 @@ def scroll_log(up, num_lines=None):
 
     # default to a half-page
     if not num_lines:
-        num_lines = size_log_area/2
+        num_lines = size_log_area // 2
 
     if up:
         log_line_offset -= num_lines

--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import print_function
-from builtins import str
 import sys
 import io
 
@@ -27,13 +25,8 @@ def custom_except_hook(exctype, value, traceback):           # noqa
 
 sys.excepthook = custom_except_hook  # noqa
 
-# capture any output
-if sys.version_info[0] < 3:  # noqa
-    sys.stdout = io.BytesIO()  # noqa
-    sys.stderr = io.BytesIO()  # noqa
-else:  # noqa
-    sys.stdout = io.StringIO()  # noqa
-    sys.stderr = io.StringIO()  # noqa
+sys.stdout = io.StringIO()  # noqa
+sys.stderr = io.StringIO()  # noqa
 
 import os
 import os.path

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -24,8 +24,10 @@ from mycroft.util.json_helper import load_commented_json
 from mycroft.util.log import LOG
 
 # Python 2+3 compatibility
+import sys
 from future.utils import iteritems
-from past.builtins import basestring
+if sys.version_info[0] >= 3:
+    basestring = str
 
 
 def merge_dict(base, delta):

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -23,12 +23,6 @@ from requests import HTTPError
 from mycroft.util.json_helper import load_commented_json
 from mycroft.util.log import LOG
 
-# Python 2+3 compatibility
-import sys
-from future.utils import iteritems
-if sys.version_info[0] >= 3:
-    basestring = str
-
 
 def merge_dict(base, delta):
     """
@@ -39,7 +33,7 @@ def merge_dict(base, delta):
             delta: Dictionary to merge into base
     """
 
-    for k, dv in iteritems(delta):
+    for k, dv in delta.items():
         bv = base.get(k)
         if isinstance(dv, dict) and isinstance(bv, dict):
             merge_dict(bv, dv)
@@ -69,7 +63,7 @@ def translate_remote(config, setting):
     """
     IGNORED_SETTINGS = ["uuid", "@type", "active", "user", "device"]
 
-    for k, v in iteritems(setting):
+    for k, v in setting.items():
         if k not in IGNORED_SETTINGS:
             # Translate the CamelCase values stored remotely into the
             # Python-style names used within mycroft-core.
@@ -226,7 +220,7 @@ class Configuration(object):
         else:
             # Handle strings in stack
             for index, item in enumerate(configs):
-                if isinstance(item, basestring):
+                if isinstance(item, str):
                     configs[index] = LocalConf(item)
 
         # Merge all configs into one

--- a/mycroft/messagebus/send.py
+++ b/mycroft/messagebus/send.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Backport python 3 print function
-from __future__ import print_function
-
 import sys
 import json
 from mycroft.messagebus.client.ws import WebsocketClient

--- a/mycroft/skills/audioservice.py
+++ b/mycroft/skills/audioservice.py
@@ -16,8 +16,6 @@ import time
 from os.path import abspath
 
 from mycroft.messagebus.message import Message
-# Python 2+3 compatibility
-from past.builtins import basestring
 
 
 def ensure_uri(s):
@@ -63,7 +61,7 @@ class AudioService():
                 tracks: track uri or list of track uri's
         """
         tracks = tracks or []
-        if isinstance(tracks, basestring):
+        if isinstance(tracks, str):
             tracks = [tracks]
         elif not isinstance(tracks, list):
             raise ValueError

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -39,7 +39,9 @@ from mycroft.skills.settings import SkillSettings
 from mycroft.util import resolve_resource_file
 from mycroft.util.log import LOG
 # python 2+3 compatibility
-from past.builtins import basestring
+import sys
+if sys.version_info[0] >= 3:
+    basestring = str
 
 MainModule = '__init__'
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -38,10 +38,7 @@ from mycroft.metrics import report_metric, report_timing, Stopwatch
 from mycroft.skills.settings import SkillSettings
 from mycroft.util import resolve_resource_file
 from mycroft.util.log import LOG
-# python 2+3 compatibility
 import sys
-if sys.version_info[0] >= 3:
-    basestring = str
 
 MainModule = '__init__'
 
@@ -798,9 +795,9 @@ class MycroftSkill(object):
                 context:    Keyword
                 word:       word connected to keyword
         """
-        if not isinstance(context, basestring):
+        if not isinstance(context, str):
             raise ValueError('context should be a string')
-        if not isinstance(word, basestring):
+        if not isinstance(word, str):
             raise ValueError('word should be a string')
         self.emitter.emit(Message('add_context',
                                   {'context': context, 'word': word}))
@@ -809,7 +806,7 @@ class MycroftSkill(object):
         """
             remove_context removes a keyword from from the context manager.
         """
-        if not isinstance(context, basestring):
+        if not isinstance(context, str):
             raise ValueError('context should be a string')
         self.emitter.emit(Message('remove_context', {'context': context}))
 

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -20,11 +20,7 @@ from os.path import isfile
 
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
-import sys
-if sys.version_info[0] < 3:
-    from Queue import Queue
-else:
-    from queue import Queue
+from queue import Queue
 
 
 class EventScheduler(Thread):

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -22,9 +22,6 @@ from mycroft.skills.core import open_intent_envelope
 from mycroft.util.log import LOG
 from mycroft.util.parse import normalize
 from mycroft.metrics import report_timing, Stopwatch
-# python 2+3 compatibility
-from past.builtins import basestring
-from future.builtins import range
 
 
 class ContextManager(object):
@@ -389,7 +386,7 @@ class IntentService(object):
         context = message.data.get('context')
         word = message.data.get('word') or ''
         # if not a string type try creating a string from it
-        if not isinstance(word, basestring):
+        if not isinstance(word, str):
             word = str(word)
         entity['data'] = [(word, context)]
         entity['match'] = word

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -94,7 +94,7 @@ class SkillSettings(dict):
         self._settings_path = join(directory, 'settings.json')
         self._meta_path = join(directory, 'settingsmeta.json')
         self.is_alive = True
-        self.loaded_hash = hash(frozenset(self.items()))
+        self.loaded_hash = hash(json.dumps(self, sort_keys=True))
         self._complete_intialization = False
         self._device_identity = None
         self._api_path = None
@@ -162,7 +162,7 @@ class SkillSettings(dict):
 
     @property
     def _is_stored(self):
-        return hash(bytes(str(self), 'utf-8')) == self.loaded_hash
+        return hash(json.dumps(self, sort_keys=True)) == self.loaded_hash
 
     def __getitem__(self, key):
         """ Get key """
@@ -538,7 +538,7 @@ class SkillSettings(dict):
         if force or not self._is_stored:
             with open(self._settings_path, 'w') as f:
                 json.dump(self, f)
-            self.loaded_hash = hash(bytes(str((self)), 'utf-8'))
+            self.loaded_hash = hash(json.dumps(self, sort_keys=True))
 
         if self._should_upload_from_change:
             settings_meta = self._load_settings_meta()

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -94,7 +94,7 @@ class SkillSettings(dict):
         self._settings_path = join(directory, 'settings.json')
         self._meta_path = join(directory, 'settingsmeta.json')
         self.is_alive = True
-        self.loaded_hash = hash(str(self))
+        self.loaded_hash = hash(frozenset(self.items()))
         self._complete_intialization = False
         self._device_identity = None
         self._api_path = None
@@ -162,7 +162,7 @@ class SkillSettings(dict):
 
     @property
     def _is_stored(self):
-        return hash(str(self)) == self.loaded_hash
+        return hash(bytes(str(self), 'utf-8')) == self.loaded_hash
 
     def __getitem__(self, key):
         """ Get key """
@@ -305,9 +305,9 @@ class SkillSettings(dict):
             except Exception as e:
                 LOG.info(e)
 
-    def hash(self, str):
+    def hash(self, string):
         """ md5 hasher for consistency across cpu architectures """
-        return hashlib.md5(str).hexdigest()
+        return hashlib.md5(bytes(string, 'utf-8')).hexdigest()
 
     def _get_meta_hash(self, settings_meta):
         """ Get's the hash of skill
@@ -538,7 +538,7 @@ class SkillSettings(dict):
         if force or not self._is_stored:
             with open(self._settings_path, 'w') as f:
                 json.dump(self, f)
-            self.loaded_hash = hash(str(self))
+            self.loaded_hash = hash(bytes(str((self)), 'utf-8'))
 
         if self._should_upload_from_change:
             settings_meta = self._load_settings_meta()

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -32,11 +32,7 @@ from mycroft.util import (
 )
 from mycroft.util.log import LOG
 from mycroft.metrics import report_timing, Stopwatch
-import sys
-if sys.version_info[0] < 3:
-    from Queue import Queue, Empty
-else:
-    from queue import Queue, Empty
+from queue import Queue, Empty
 
 
 def send_playback_metric(stopwatch, ident):

--- a/mycroft/util/audio_test.py
+++ b/mycroft/util/audio_test.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from __future__ import print_function
 import argparse
 
 from speech_recognition import Recognizer

--- a/mycroft/util/lang/parse_pt.py
+++ b/mycroft/util/lang/parse_pt.py
@@ -1026,7 +1026,7 @@ def extract_datetime_pt(input_str, currentDate=None):
                                 remainder = "am"
                                 used += 1
                             elif wordNextNextNext == "noite":
-                                if 0 > strHH > 6:
+                                if 0 > int(strHH) > 6:
                                     remainder = "am"
                                 else:
                                     remainder = "pm"

--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -43,7 +43,7 @@ def match_one(query, choices):
         Returns: tuple with best match, score
     """
     if isinstance(choices, dict):
-        _choices = choices.keys()
+        _choices = list(choices.keys())
     elif isinstance(choices, list):
         _choices = choices
     else:

--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -22,12 +22,7 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 scripts_dir="$DIR/scripts"
 mkdir -p $scripts_dir/logs
 
-MYCROFT_VENV=${MYCROFT_VENV:-"mycroft"}
-if [ -z "$WORKON_HOME" ]; then
-    VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${HOME}/.virtualenvs/$MYCROFT_VENV"}
-else
-    VIRTUALENV_ROOT="$WORKON_HOME/$MYCROFT_VENV"
-fi
+VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${DIR}/.venv"}
 
 function help() {
   echo "${script}:  Mycroft command/service launcher"

--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -22,10 +22,11 @@ DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
 scripts_dir="$DIR/scripts"
 mkdir -p $scripts_dir/logs
 
+MYCROFT_VENV=${MYCROFT_VENV:-"mycroft"}
 if [ -z "$WORKON_HOME" ]; then
-    VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${HOME}/.virtualenvs/mycroft"}
+    VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${HOME}/.virtualenvs/$MYCROFT_VENV"}
 else
-    VIRTUALENV_ROOT="$WORKON_HOME/mycroft"
+    VIRTUALENV_ROOT="$WORKON_HOME/$MYCROFT_VENV"
 fi
 
 function help() {

--- a/test/unittests/client/audio_consumer_test.py
+++ b/test/unittests/client/audio_consumer_test.py
@@ -20,11 +20,7 @@ from speech_recognition import WavFile, AudioData
 
 from mycroft.client.speech.listener import AudioConsumer, RecognizerLoop
 from mycroft.stt import MycroftSTT
-import sys
-if sys.version_info[0] < 3:
-    from Queue import Queue
-else:
-    from queue import Queue
+from queue import Queue
 
 
 class MockRecognizer(object):

--- a/test/unittests/client/audio_consumer_test.py
+++ b/test/unittests/client/audio_consumer_test.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 import unittest
-from Queue import Queue
 
 import speech_recognition
 from os.path import dirname, join
@@ -21,6 +20,11 @@ from speech_recognition import WavFile, AudioData
 
 from mycroft.client.speech.listener import AudioConsumer, RecognizerLoop
 from mycroft.stt import MycroftSTT
+import sys
+if sys.version_info[0] < 3:
+    from Queue import Queue
+else:
+    from queue import Queue
 
 
 class MockRecognizer(object):

--- a/test/unittests/client/hotword_factory_test.py
+++ b/test/unittests/client/hotword_factory_test.py
@@ -44,7 +44,6 @@ class PocketSphinxTest(unittest.TestCase):
         self.assertEquals(p.key_phrase, 'hey mycroft')
 
     def testVictoria(self):
-        print "VICTORIA!"
         config = {
             'hey victoria': {
                 'module': 'pocketsphinx',

--- a/test/unittests/skills/core.py
+++ b/test/unittests/skills/core.py
@@ -27,6 +27,9 @@ from mycroft.skills.core import load_regex_from_file, load_regex, \
     load_vocab_from_file, load_vocabulary, MycroftSkill, \
     load_skill, create_skill_descriptor, open_intent_envelope
 
+if sys.version_info[0] >= 3:
+    basestring = str
+
 
 class MockEmitter(object):
     def __init__(self):
@@ -83,8 +86,9 @@ class MycroftSkillTest(unittest.TestCase):
     def check_emitter(self, result_list):
         for type in self.emitter.get_types():
             self.assertEquals(type, 'register_vocab')
-        self.assertEquals(sorted(self.emitter.get_results()),
-                          sorted(result_list))
+        self.assertEquals(sorted(self.emitter.get_results(),
+                                 key=lambda d: sorted(d.items())),
+                          sorted(result_list, key=lambda d: sorted(d.items())))
         self.emitter.reset()
 
     def test_load_regex_from_file_single(self):
@@ -100,17 +104,12 @@ class MycroftSkillTest(unittest.TestCase):
         self.check_regex_from_file('invalid/none.rx')
 
     def test_load_regex_from_file_invalid(self):
-        try:
+        with self.assertRaises(error):
             self.check_regex_from_file('invalid/invalid.rx')
-        except error as e:
-            self.assertEquals(e.__str__(),
-                              'unexpected end of regular expression')
 
     def test_load_regex_from_file_does_not_exist(self):
-        try:
+        with self.assertRaises(IOError):
             self.check_regex_from_file('does_not_exist.rx')
-        except IOError as e:
-            self.assertEquals(e.strerror, 'No such file or directory')
 
     def test_load_regex_full(self):
         self.check_regex(join(self.regex_path, 'valid'),
@@ -241,8 +240,9 @@ class MycroftSkillTest(unittest.TestCase):
     def check_register_object_file(self, types_list, result_list):
         self.assertEquals(sorted(self.emitter.get_types()),
                           sorted(types_list))
-        self.assertEquals(sorted(self.emitter.get_results()),
-                          sorted(result_list))
+        self.assertEquals(sorted(self.emitter.get_results(),
+                                 key=lambda d: sorted(d.items())),
+                          sorted(result_list, key=lambda d: sorted(d.items())))
         self.emitter.reset()
 
     def test_register_intent_file(self):
@@ -272,8 +272,9 @@ class MycroftSkillTest(unittest.TestCase):
         self.check_register_object_file(expected_types, expected_results)
 
     def check_register_decorators(self, result_list):
-        self.assertEquals(sorted(self.emitter.get_results()),
-                          sorted(result_list))
+        self.assertEquals(sorted(self.emitter.get_results(),
+                                 key=lambda d: sorted(d.items())),
+                          sorted(result_list, key=lambda d: sorted(d.items())))
         self.emitter.reset()
 
     def test_register_decorators(self):

--- a/test/unittests/skills/core.py
+++ b/test/unittests/skills/core.py
@@ -27,9 +27,6 @@ from mycroft.skills.core import load_regex_from_file, load_regex, \
     load_vocab_from_file, load_vocabulary, MycroftSkill, \
     load_skill, create_skill_descriptor, open_intent_envelope
 
-if sys.version_info[0] >= 3:
-    basestring = str
-
 
 class MockEmitter(object):
     def __init__(self):

--- a/test/unittests/skills/intent_service.py
+++ b/test/unittests/skills/intent_service.py
@@ -46,7 +46,6 @@ class ContextManagerTest(unittest.TestCase):
         entity = {'confidence': 1.0}
         context = 'TestContext'
         word = 'TestWord'
-        print "Adding " + context
         entity['data'] = [(word, context)]
         entity['match'] = word
         entity['key'] = word
@@ -59,7 +58,6 @@ class ContextManagerTest(unittest.TestCase):
         entity = {'confidence': 1.0}
         context = 'TestContext'
         word = 'TestWord'
-        print "Adding " + context
         entity['data'] = [(word, context)]
         entity['match'] = word
         entity['key'] = word

--- a/test/unittests/skills/test_event_scheduler.py
+++ b/test/unittests/skills/test_event_scheduler.py
@@ -19,7 +19,7 @@ class TestEventScheduler(unittest.TestCase):
             Test creating and shutting down event_scheduler.
         """
         mock_load.return_value = ''
-        mock_open.return_value = mock.MagicMock(spec=file)
+        mock_open.return_value = mock.MagicMock()
         emitter = mock.MagicMock()
         es = EventScheduler(emitter)
         es.shutdown()
@@ -36,7 +36,7 @@ class TestEventScheduler(unittest.TestCase):
         """
         # Thread start is mocked so will not actually run the thread loop
         mock_load.return_value = ''
-        mock_open.return_value = mock.MagicMock(spec=file)
+        mock_open.return_value = mock.MagicMock()
         emitter = mock.MagicMock()
         es = EventScheduler(emitter)
 
@@ -63,7 +63,7 @@ class TestEventScheduler(unittest.TestCase):
             Test save functionality.
         """
         mock_load.return_value = ''
-        mock_open.return_value = mock.MagicMock(spec=file)
+        mock_open.return_value = mock.MagicMock()
         emitter = mock.MagicMock()
         es = EventScheduler(emitter)
 
@@ -87,7 +87,7 @@ class TestEventScheduler(unittest.TestCase):
             Test save functionality.
         """
         mock_load.return_value = ''
-        mock_open.return_value = mock.MagicMock(spec=file)
+        mock_open.return_value = mock.MagicMock()
         emitter = mock.MagicMock()
         es = EventScheduler(emitter)
 

--- a/test/unittests/util/test_json_helper.py
+++ b/test/unittests/util/test_json_helper.py
@@ -26,7 +26,7 @@ class TestFileLoad(unittest.TestCase):
         root_dir = dirname(__file__)
         # Load normal JSON file
         plainfile = join(root_dir, 'plain.json')
-        with open(plainfile, 'rw') as f:
+        with open(plainfile, 'r') as f:
             data_from_plain = json.load(f)
 
         # Load commented JSON file

--- a/test/unittests/util/test_log.py
+++ b/test/unittests/util/test_log.py
@@ -14,7 +14,7 @@
 #
 import unittest
 import sys
-from cStringIO import StringIO
+from io import StringIO
 from threading import Thread
 from mycroft.util.log import LOG
 
@@ -65,6 +65,7 @@ class TestLog(unittest.TestCase):
                 if 'testing ' + msg in line:
                     found_msg = True
             assert found_msg
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -83,7 +83,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_en(self):
         def extractWithFormat(text):
-            date = datetime(2017, 06, 27, 00, 00)
+            date = datetime(2017, 6, 27, 0, 0)
             [extractedDate, leftover] = extract_datetime(text, date)
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")
             return [extractedDate, leftover]

--- a/test/unittests/util/test_parse_it.py
+++ b/test/unittests/util/test_parse_it.py
@@ -175,7 +175,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_it(self):
         def extractWithFormat(text):
-            date = datetime(2018, 01, 13, 00, 00)
+            date = datetime(2018, 1, 13, 0, 0)
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang="it")
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")

--- a/test/unittests/util/test_parse_pt.py
+++ b/test/unittests/util/test_parse_pt.py
@@ -140,7 +140,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_extractdatetime_pt(self):
         def extractWithFormat(text):
-            date = datetime(2017, 06, 27, 00, 00)
+            date = datetime(2017, 6, 27, 0, 0)
             [extractedDate, leftover] = extract_datetime(text, date,
                                                          lang="pt")
             extractedDate = extractedDate.strftime("%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## Description
- Fixes a few incompatibilities with python 3 to make the stack running fairly well
- Sets up the virtualenv with python3
This also adds the possibility to set the environment variable MYCROFT_VENV to separate the virtualenv for python3 from the stable version.

Example:
```bash
export MYCROFT_VENV=mycroft-18.02
./dev_setup.sh
./start-mycroft.sh all
```

- Upgrade tests and travis

## How to test

## Contributor license agreement signed?
CLA [Yes]