### PR TITLE
Make keywords per skill to fix overlapping keyword names

### DIFF
--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -1,3 +1,18 @@
+# Copyright 2018 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 """Module containing methods needed to load skill
 data such as dialogs, intents and regular expressions.
 """
@@ -10,15 +25,14 @@ from mycroft.messagebus.message import Message
 
 
 def load_vocab_from_file(path, vocab_type, emitter):
-    """
-        Load mycroft vocabulary from file. and send it on the message bus for
-        the intent handler.
+    """Load Mycroft vocabulary from file
+    The vocab is sent to the intent handler using the message bus
 
-        Args:
-            path:           path to vocabulary file (*.voc)
-            vocab_type:     keyword name
-            emitter:        emitter to access the message bus
-            skill_id(str):  skill id
+    Args:
+        path:           path to vocabulary file (*.voc)
+        vocab_type:     keyword name
+        emitter:        emitter to access the message bus
+        skill_id(str):  skill id
     """
     if path.endswith('.voc'):
         with open(path, 'r') as voc_file:
@@ -35,13 +49,12 @@ def load_vocab_from_file(path, vocab_type, emitter):
 
 
 def load_regex_from_file(path, emitter, skill_id):
-    """
-        Load regex from file and send it on the message bus for
-        the intent handler.
+    """Load regex from file
+    The regex is sent to the intent handler using the message bus
 
-        Args:
-            path:       path to vocabulary file (*.voc)
-            emitter:    emitter to access the message bus
+    Args:
+        path:       path to vocabulary file (*.voc)
+        emitter:    emitter to access the message bus
     """
     if path.endswith('.rx'):
         with open(path, 'r') as reg_file:
@@ -75,7 +88,7 @@ def load_regex(basedir, emitter, skill_id):
         basedir (str): path of directory to load from
         emitter (messagebus emitter): websocket used to send the vocab to
                                       the intent service
-        skill_id: (int) skill identifier
+        skill_id (int): skill identifier
     """
     for regex_type in listdir(basedir):
         if regex_type.endswith(".rx"):
@@ -113,10 +126,10 @@ def munge_regex(regex, skill_id):
 
 
 def munge_intent_parser(intent_parser, name, skill_id):
-    """Rename the intent keywords to make them skill exclusive and gives the
-    intent parser an exclusive name.
-    The format of the intent parser name is <skill_id>:<name>.
-    The format of the keywords is <Skill id as letters><Intent name>.
+    """Rename intent keywords to make them skill exclusive
+    This gives the intent parser an exclusive name in the
+    format <skill_id>:<name>.  The keywords are given unique
+    names in the format <Skill id as letters><Intent name>.
 
     Args:
         intent_parser: (IntentParser) object to update

--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -1,0 +1,150 @@
+"""Module containing methods needed to load skill
+data such as dialogs, intents and regular expressions.
+"""
+
+from os import listdir
+from os.path import splitext, join
+import re
+
+from mycroft.messagebus.message import Message
+
+
+def load_vocab_from_file(path, vocab_type, emitter):
+    """
+        Load mycroft vocabulary from file. and send it on the message bus for
+        the intent handler.
+
+        Args:
+            path:           path to vocabulary file (*.voc)
+            vocab_type:     keyword name
+            emitter:        emitter to access the message bus
+            skill_id(str):  skill id
+    """
+    if path.endswith('.voc'):
+        with open(path, 'r') as voc_file:
+            for line in voc_file.readlines():
+                parts = line.strip().split("|")
+                entity = parts[0]
+                emitter.emit(Message("register_vocab", {
+                    'start': entity, 'end': vocab_type
+                }))
+                for alias in parts[1:]:
+                    emitter.emit(Message("register_vocab", {
+                        'start': alias, 'end': vocab_type, 'alias_of': entity
+                    }))
+
+
+def load_regex_from_file(path, emitter, skill_id):
+    """
+        Load regex from file and send it on the message bus for
+        the intent handler.
+
+        Args:
+            path:       path to vocabulary file (*.voc)
+            emitter:    emitter to access the message bus
+    """
+    if path.endswith('.rx'):
+        with open(path, 'r') as reg_file:
+            for line in reg_file.readlines():
+                re.compile(munge_regex(line.strip(), skill_id))
+                emitter.emit(
+                    Message("register_vocab",
+                            {'regex': munge_regex(line.strip(), skill_id)}))
+
+
+def load_vocabulary(basedir, emitter, skill_id):
+    """Load vocabulary from all files in the specified directory.
+
+    Args:
+        basedir (str): path of directory to load from
+        emitter (messagebus emitter): websocket used to send the vocab to
+                                      the intent service
+        skill_id: skill the data belongs to
+    """
+    for vocab_file in listdir(basedir):
+        if vocab_file.endswith(".voc"):
+            vocab_type = to_letters(skill_id) + splitext(vocab_file)[0]
+            load_vocab_from_file(
+                join(basedir, vocab_file), vocab_type, emitter)
+
+
+def load_regex(basedir, emitter, skill_id):
+    """Load regex from all files in the specified directory.
+
+    Args:
+        basedir (str): path of directory to load from
+        emitter (messagebus emitter): websocket used to send the vocab to
+                                      the intent service
+        skill_id: (int) skill identifier
+    """
+    for regex_type in listdir(basedir):
+        if regex_type.endswith(".rx"):
+            load_regex_from_file(
+                join(basedir, regex_type), emitter, skill_id)
+
+
+def to_letters(number):
+    """Convert number to string of letters.
+
+    0 -> A, 1 -> B, etc.
+
+    Args:
+        number (int): number to be converted
+    Returns:
+        (str) String of letters
+    """
+    ret = ''
+    for n in str(number).strip('-'):
+        ret += chr(65 + int(n))
+    return ret
+
+
+def munge_regex(regex, skill_id):
+    """Insert skill id as letters into match groups.
+
+    Args:
+        regex (str): regex string
+        skill_id (int): skill identifier
+    Returns:
+        (str) munged regex
+    """
+    base = '(?P<' + to_letters(skill_id)
+    return base.join(regex.split('(?P<'))
+
+
+def munge_intent_parser(intent_parser, name, skill_id):
+    """Rename the intent keywords to make them skill exclusive and gives the
+    intent parser an exclusive name.
+    The format of the intent parser name is <skill_id>:<name>.
+    The format of the keywords is <Skill id as letters><Intent name>.
+
+    Args:
+        intent_parser: (IntentParser) object to update
+        name: (str) Skill name
+        skill_id: (int) skill identifier
+    """
+    # Munge parser name
+    intent_parser.name = str(skill_id) + ':' + name
+
+    # Munge keywords
+    skill_id = to_letters(skill_id)
+    # Munge required keyword
+    reqs = []
+    for i in intent_parser.requires:
+        kw = (skill_id + i[0], skill_id + i[0])
+        reqs.append(kw)
+    intent_parser.requires = reqs
+
+    # Munge optional keywords
+    opts = []
+    for i in intent_parser.optional:
+        kw = (skill_id + i[0], skill_id + i[0])
+        opts.append(kw)
+    intent_parser.optional = opts
+
+    # Munge at_least_one keywords
+    at_least_one = []
+    for i in intent_parser.at_least_one:
+        element = [skill_id + e for e in i]
+        at_least_one.append(tuple(element))
+    intent_parser.at_least_one = at_least_one

--- a/test/unittests/skills/core.py
+++ b/test/unittests/skills/core.py
@@ -23,9 +23,10 @@ from re import error
 
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
-from mycroft.skills.core import load_regex_from_file, load_regex, \
-    load_vocab_from_file, load_vocabulary, MycroftSkill, \
-    load_skill, create_skill_descriptor, open_intent_envelope
+from mycroft.skills.skill_data import load_regex_from_file, load_regex, \
+    load_vocab_from_file, load_vocabulary
+from mycroft.skills.core import MycroftSkill, load_skill, \
+    create_skill_descriptor, open_intent_envelope
 
 
 class MockEmitter(object):
@@ -67,17 +68,17 @@ class MycroftSkillTest(unittest.TestCase):
 
     def check_regex_from_file(self, filename, result_list=None):
         result_list = result_list or []
-        load_regex_from_file(join(self.regex_path, filename), self.emitter)
+        load_regex_from_file(join(self.regex_path, filename), self.emitter, 0)
         self.check_emitter(result_list)
 
     def check_vocab(self, path, result_list=None):
         result_list = result_list or []
-        load_vocabulary(path, self.emitter)
+        load_vocabulary(path, self.emitter, 0)
         self.check_emitter(result_list)
 
     def check_regex(self, path, result_list=None):
         result_list = result_list or []
-        load_regex(path, self.emitter)
+        load_regex(path, self.emitter, 0)
         self.check_emitter(result_list)
 
     def check_emitter(self, result_list):
@@ -89,12 +90,12 @@ class MycroftSkillTest(unittest.TestCase):
 
     def test_load_regex_from_file_single(self):
         self.check_regex_from_file('valid/single.rx',
-                                   [{'regex': '(?P<SingleTest>.*)'}])
+                                   [{'regex': '(?P<ASingleTest>.*)'}])
 
     def test_load_regex_from_file_multiple(self):
         self.check_regex_from_file('valid/multiple.rx',
-                                   [{'regex': '(?P<MultipleTest1>.*)'},
-                                    {'regex': '(?P<MultipleTest2>.*)'}])
+                                   [{'regex': '(?P<AMultipleTest1>.*)'},
+                                    {'regex': '(?P<AMultipleTest2>.*)'}])
 
     def test_load_regex_from_file_none(self):
         self.check_regex_from_file('invalid/none.rx')
@@ -114,9 +115,9 @@ class MycroftSkillTest(unittest.TestCase):
 
     def test_load_regex_full(self):
         self.check_regex(join(self.regex_path, 'valid'),
-                         [{'regex': '(?P<MultipleTest1>.*)'},
-                          {'regex': '(?P<MultipleTest2>.*)'},
-                          {'regex': '(?P<SingleTest>.*)'}])
+                         [{'regex': '(?P<AMultipleTest1>.*)'},
+                          {'regex': '(?P<AMultipleTest2>.*)'},
+                          {'regex': '(?P<ASingleTest>.*)'}])
 
     def test_load_regex_empty(self):
         self.check_regex(join(dirname(__file__),
@@ -164,17 +165,17 @@ class MycroftSkillTest(unittest.TestCase):
 
     def test_load_vocab_full(self):
         self.check_vocab(join(self.vocab_path, 'valid'),
-                         [{'start': 'test', 'end': 'single'},
-                          {'start': 'water', 'end': 'singlealias'},
-                          {'start': 'watering', 'end': 'singlealias',
+                         [{'start': 'test', 'end': 'Asingle'},
+                          {'start': 'water', 'end': 'Asinglealias'},
+                          {'start': 'watering', 'end': 'Asinglealias',
                            'alias_of': 'water'},
-                          {'start': 'animal', 'end': 'multiple'},
-                          {'start': 'animals', 'end': 'multiple'},
-                          {'start': 'chair', 'end': 'multiplealias'},
-                          {'start': 'chairs', 'end': 'multiplealias',
+                          {'start': 'animal', 'end': 'Amultiple'},
+                          {'start': 'animals', 'end': 'Amultiple'},
+                          {'start': 'chair', 'end': 'Amultiplealias'},
+                          {'start': 'chairs', 'end': 'Amultiplealias',
                            'alias_of': 'chair'},
-                          {'start': 'table', 'end': 'multiplealias'},
-                          {'start': 'tables', 'end': 'multiplealias',
+                          {'start': 'table', 'end': 'Amultiplealias'},
+                          {'start': 'tables', 'end': 'Amultiplealias',
                            'alias_of': 'table'}])
 
     def test_load_vocab_empty(self):
@@ -218,7 +219,7 @@ class MycroftSkillTest(unittest.TestCase):
         expected = [{'at_least_one': [],
                      'name': '0:a',
                      'optional': [],
-                     'requires': [('Keyword', 'Keyword')]}]
+                     'requires': [('AKeyword', 'AKeyword')]}]
         self.check_register_intent(expected)
 
         # Test register IntentBuilder object
@@ -228,7 +229,7 @@ class MycroftSkillTest(unittest.TestCase):
         expected = [{'at_least_one': [],
                      'name': '0:a',
                      'optional': [],
-                     'requires': [('Keyword', 'Keyword')]}]
+                     'requires': [('AKeyword', 'AKeyword')]}]
 
         self.check_register_intent(expected)
 
@@ -289,7 +290,7 @@ class MycroftSkillTest(unittest.TestCase):
         expected = [{'at_least_one': [],
                      'name': '0:a',
                      'optional': [],
-                     'requires': [('Keyword', 'Keyword')]},
+                     'requires': [('AKeyword', 'AKeyword')]},
                     {
                      'file_name': join(dirname(__file__), 'intent_file',
                                        'test.intent'),
@@ -319,17 +320,17 @@ class MycroftSkillTest(unittest.TestCase):
         s.bind(self.emitter)
         # No context content
         s.set_context('TurtlePower')
-        expected = [{'context': 'TurtlePower', 'word': ''}]
+        expected = [{'context': 'ATurtlePower', 'word': ''}]
         check_set_context(expected)
 
         # context with content
         s.set_context('Technodrome', 'Shredder')
-        expected = [{'context': 'Technodrome', 'word': 'Shredder'}]
+        expected = [{'context': 'ATechnodrome', 'word': 'Shredder'}]
         check_set_context(expected)
 
         # UTF-8 context
         s.set_context(u'Smörgåsbord€15')
-        expected = [{'context': u'Smörgåsbord€15', 'word': ''}]
+        expected = [{'context': u'ASmörgåsbord€15', 'word': ''}]
         check_set_context(expected)
 
         self.emitter.reset()


### PR DESCRIPTION
## Description
Convert keyword names to unique names by prepending the keyword with a
letter string derived from the unique skill id.

This commit modifies required keywords, optional keywords, one_of
keywords and regex matches.

This also munges the context keyword when that is sent to match the
intent correctly.

## How to test
Things to test location regex overlaps, "what is the time for london" should work but "what's the weather for london should fail.

Context internal to skills should still work, for example the wikipedia skill "Tell me about donald duck" followed by "tell me more"

## Contributor license agreement signed?
CLA [Yes]