### PR TITLE
wait_for_response method for synchronous messagebus communication

### DIFF
--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -843,20 +843,14 @@ def handle_cmd(cmd):
         cy_chat_area = lines
     elif "skills" in cmd:
         # List loaded skill
-        def handler(message):
-            """
-                Show screen listing available skills.
-            """
-            if message and 'skills' in message.data:
-                show_skills(message.data['skills'])
+        message = ws.wait_for_response(
+            Message('skillmanager.list'), reply_type='mycroft.skills.list')
 
-        ws.once('mycroft.skills.list', handler)
-        ws.emit(Message('skillmanager.list'))
-
-        # Here due to trouble restoring screen  when run from different thread
-        c = scr.getch()  # blocks
-        screen_mode = 0  # back to main screen
-        draw_screen()
+        if message and 'skills' in message.data:
+            show_skills(message.data['skills'])
+            c = scr.getch()  # blocks
+            screen_mode = 0  # back to main screen
+            draw_screen()
     # TODO: More commands
     return 0  # do nothing upon return
 

--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -95,11 +95,11 @@ class WebsocketClient(object):
 
         Args:
             message (Message): message to send
-            reply_type (str): the message type of the reply. Defaults to
-                              "<original message type>.response".
-            timeout: wait timeout before returning
+            reply_type (str): the message type of the expected reply.
+                              Defaults to "<message.type>.response".
+            timeout: seconds to wait before timeout, defaults to 3
         Returns:
-            The recieved message or None if the response timed out
+            The received message or None if the response timed out
         """
         response = []
 

--- a/mycroft/messagebus/message.py
+++ b/mycroft/messagebus/message.py
@@ -105,6 +105,22 @@ class Message(object):
             context['target'] = context['client_name']
         return Message(type, data, context=new_context)
 
+    def response(self, data=None, context=None):
+        """Construct a response message for the message
+
+        Constructs a reply with the data and appends the expected
+        ".response" to the message
+
+        Args:
+            data (dict): message data
+            context (dict): message context
+        Returns
+            (Message) message with the type modified to match default response
+        """
+        response_message = self.reply(self.type, data or {}, context)
+        response_message.type += '.response'
+        return response_message
+
     def publish(self, type, data, context=None):
         """
         Copy the original context and add passed in context.  Delete


### PR DESCRIPTION
## Description
The client handles the basic case when wanting to do a syncronous
request-response action.

The method sets up a handler waits for the response and handles timeout.

The expected format is that the reply message should have the same type as
the original message with ".response" appended.

An method in the Message class has been added to create a standard response for
a message.

## How to test
Run cli and make sure :skills works as intended.

## Contributor license agreement signed?
CLA [Yes]