### PR TITLE
Add interface to Mark 1 faceplate capabilities

### DIFF
--- a/mycroft/client/enclosure/api.py
+++ b/mycroft/client/enclosure/api.py
@@ -171,7 +171,7 @@ class EnclosureAPI:
             volume (int): 0 to 11
         """
         if volume < 0 or volume > 11:
-            raise ValueError('volume ({}) must be between 0-100'.
+            raise ValueError('volume ({}) must be between 0-11'.
                              format(str(volume)))
         self.ws.emit(Message("enclosure.eyes.volume", {'volume': volume}))
 

--- a/mycroft/client/enclosure/api.py
+++ b/mycroft/client/enclosure/api.py
@@ -117,6 +117,29 @@ class EnclosureAPI:
         self.ws.emit(Message("enclosure.eyes.color",
                              {'r': r, 'g': g, 'b': b}))
 
+    def eyes_setpixel(self, idx, r=255, g=255, b=255):
+        """Set individual pixels of the Mark 1 neopixel eyes
+        Args:
+            neopixel_idx (int): 0-11 for the right eye, 12-23 for the left
+            r (int): The red value to apply
+            g (int): The green value to apply
+            b (int): The blue value to apply
+        """
+        if idx < 0 or idx > 23:
+            return
+        self.ws.emit(Message("enclosure.eyes.setpixel",
+                             {'idx': idx, 'r': r, 'g': g, 'b': b}))
+
+    def eyes_fill(self, percentage):
+        """Use the eyes as a type of progress meter
+        Args:
+            amount (int): 0-49 fills the right eye, 50-100 also covers left
+        """
+        if percentage < 0 or percentage > 100:
+            return
+        self.ws.emit(Message("enclosure.eyes.fill",
+                             {'percentage': percentage}))
+
     def eyes_brightness(self, level=30):
         """Set the brightness of the eyes in the display.
         Args:
@@ -146,6 +169,8 @@ class EnclosureAPI:
         Args:
             volume (int): 0 to 11
         """
+        if volume < 0 or volume > 11:
+            return
         self.ws.emit(Message("enclosure.eyes.volume", {'volume': volume}))
 
     def mouth_reset(self):

--- a/mycroft/client/enclosure/api.py
+++ b/mycroft/client/enclosure/api.py
@@ -120,13 +120,13 @@ class EnclosureAPI:
     def eyes_setpixel(self, idx, r=255, g=255, b=255):
         """Set individual pixels of the Mark 1 neopixel eyes
         Args:
-            neopixel_idx (int): 0-11 for the right eye, 12-23 for the left
+            idx (int): 0-11 for the right eye, 12-23 for the left
             r (int): The red value to apply
             g (int): The green value to apply
             b (int): The blue value to apply
         """
         if idx < 0 or idx > 23:
-            return
+            raise ValueError('idx ({}) must be between 0-23'.format(str(idx)))
         self.ws.emit(Message("enclosure.eyes.setpixel",
                              {'idx': idx, 'r': r, 'g': g, 'b': b}))
 
@@ -136,7 +136,8 @@ class EnclosureAPI:
             amount (int): 0-49 fills the right eye, 50-100 also covers left
         """
         if percentage < 0 or percentage > 100:
-            return
+            raise ValueError('percentage ({}) must be between 0-100'.
+                             format(str(percentage)))
         self.ws.emit(Message("enclosure.eyes.fill",
                              {'percentage': percentage}))
 
@@ -170,7 +171,8 @@ class EnclosureAPI:
             volume (int): 0 to 11
         """
         if volume < 0 or volume > 11:
-            return
+            raise ValueError('volume ({}) must be between 0-100'.
+                             format(str(volume)))
         self.ws.emit(Message("enclosure.eyes.volume", {'volume': volume}))
 
     def mouth_reset(self):

--- a/mycroft/client/enclosure/eyes.py
+++ b/mycroft/client/enclosure/eyes.py
@@ -84,7 +84,7 @@ class EnclosureEyes:
         amount = 0
         if event and event.data:
             percent = int(event.data.get("percentage", 0))
-            amount = round(23.0 * percent / 100.0)
+            amount = int(round(23.0 * percent / 100.0))
         self.writer.write("eyes.fill=" + str(amount))
 
     def brightness(self, event=None):

--- a/mycroft/client/enclosure/eyes.py
+++ b/mycroft/client/enclosure/eyes.py
@@ -37,6 +37,8 @@ class EnclosureEyes:
         self.ws.on('enclosure.eyes.spin', self.spin)
         self.ws.on('enclosure.eyes.timedspin', self.timed_spin)
         self.ws.on('enclosure.eyes.reset', self.reset)
+        self.ws.on('enclosure.eyes.setpixel', self.set_pixel)
+        self.ws.on('enclosure.eyes.fill', self.fill)
 
     def on(self, event=None):
         self.writer.write("eyes.on")
@@ -66,6 +68,24 @@ class EnclosureEyes:
             b = int(event.data.get("b", b))
         color = (r * 65536) + (g * 256) + b
         self.writer.write("eyes.color=" + str(color))
+
+    def set_pixel(self, event=None):
+        idx = 0
+        r, g, b = 255, 255, 255
+        if event and event.data:
+            idx = int(event.data.get("idx", idx))
+            r = int(event.data.get("r", r))
+            g = int(event.data.get("g", g))
+            b = int(event.data.get("b", b))
+        color = (r * 65536) + (g * 256) + b
+        self.writer.write("eyes.set=" + str(idx) + "," + str(color))
+
+    def fill(self, event=None):
+        amount = 0
+        if event and event.data:
+            percent = int(event.data.get("percentage", 0))
+            amount = round(23.0 * percent / 100.0)
+        self.writer.write("eyes.fill=" + str(amount))
 
     def brightness(self, event=None):
         level = 30


### PR DESCRIPTION
This adds API interfaces for two Mark 1 faceplate capabilities to the
mycroft.client.enclosure.EnclosureAPI()

EnclosureAPI.setpixel(index, r,g,b)
- Set individual eye pixels to any color.  The indices go from 0-23 with
  the 0-12 corresponding to the right eye and 11-23 to the left.

EnclosureAPI.fill(percentage)
- Fill the eyes to a percentage, for use in meters or countdowns.  The
  right eye is 0-50%, the left eye also fills if going up to 100%.
