### PR TITLE
Fix cancel_scheduled_event for non-repeating events by updateing pyee to v5.0.0

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -661,7 +661,7 @@ class MycroftSkill(object):
                     pass
                 try:
                     self.emitter.remove(_name, _handler)
-                except ValueError:
+                except (ValueError, KeyError):
                     LOG.debug('{} is not registered in the emitter'.format(
                               _name))
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -664,6 +664,8 @@ class MycroftSkill(object):
                 except (ValueError, KeyError):
                     LOG.debug('{} is not registered in the emitter'.format(
                               _name))
+                removed = True
+        return removed
 
     def register_intent(self, intent_parser, handler, need_self=False):
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ gTTS==1.1.7
 gTTS-token==1.1.1
 backports.ssl-match-hostname==3.4.0.2
 PyAudio==0.2.11
-pyee==1.0.1
+pyee==5.0.0
 SpeechRecognition==3.8.1
 tornado==4.2.1
 websocket-client==0.32.0


### PR DESCRIPTION
## Description
The old version of pyee (1.0.1) could not remove events registered as "once" (instead of "on")

This fixes cancelling scheduled events 

## How to test
Run the update-dev.sh script and create a test skill like below. Check that the *!!!!!!!!!!!! SCHEDULED HANDLER !!!!!!!!!!!!* message isn't shown.

```python
# -*- coding: utf-8 -*-
from mycroft.skills.core import MycroftSkill, intent_handler
from mycroft.util.log import LOG
from adapt.intent import IntentBuilder
from datetime import datetime, timedelta
import time

class EventTestSkill(MycroftSkill):
    @intent_handler(IntentBuilder('').require('Testing'))
    def test_handler(self, message):
        LOG.info('Event in 10 secs!')
        self.schedule_event(self.handler,
                            datetime.now() + timedelta(seconds=10),
                            name='test-event')
        time.sleep(2)
        self.cancel_scheduled_event('test-event')

    def handler(self, message):
        LOG.info('!!!!!!!!!!!! SCHEDULED HANDLER !!!!!!!!!!!!')

def create_skill():
    return EventTestSkill()
```
## Contributor license agreement signed?
CLA [Yes]