### PR TITLE
Validate message before trying to demunge

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -69,9 +69,11 @@ def unmunge_message(message, skill_id):
     Returns:
         Message without clear keywords
     """
-    for key in message.data:
-        new_key = key.replace(to_letters(skill_id), '')
-        message.data[new_key] = message.data.pop(key)
+    if isinstance(message, Message) and isinstance(message.data, dict):
+        for key in message.data:
+            new_key = key.replace(to_letters(skill_id), '')
+            message.data[new_key] = message.data.pop(key)
+
     return message
 
 


### PR DESCRIPTION
## Description
The data field of the message sent to the event handler may not always be a dictionary, (Example case Timer skill, which sets data to the timer name)

This validates the message type and the type of the data field before trying to unmunge.

Issue reported originally by Peregryn on Mattermost.

## How to test
Ask mycroft (current dev branch) to `set a 1 minute timer`
Wait for the timer to complete, there should now be an error message.

Switch to this PR, restart the skills process and retry. The error should not remain.

## Contributor license agreement signed?
CLA [Yes]