### PR TITLE
Fix self parameter in decorator functions with single argument

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -594,7 +594,7 @@ class MycroftSkill(object):
                             handler(self, unmunge_message(message,
                                                           self.skill_id))
                         elif len(getargspec(handler).args) == 1:
-                            handler(unmunge_message(message, self.skill_id))
+                            handler(self)
                         elif len(getargspec(handler).args) == 0:
                             # Zero may indicate multiple decorators, trying the
                             # usual call signatures


### PR DESCRIPTION
## Description
This fixes the self parameter in decorator functions with single argument.

## How to test
Create a skill that has a handler with a decorator but no message parameter:
```Python
    @intent_file_handler('my.intent')
    def handle_me(self):
        self.speak('hello')
```
You can use the `repeat recent` skill, which behaves this way. (`install repeat`, `what did I just say?`)
When activating this handler before the change, it errors saying `Message` has no attribute `speak`. After this change, it should work properly and not error.

## Contributor license agreement signed?
 - [x] CLA
