### PR TITLE
Bugfix/munging related issues

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -775,9 +775,9 @@ class MycroftSkill(object):
                 self.register_intent(intent, None)
                 LOG.debug('Enabling intent ' + intent_name)
                 break
-            else:
-                LOG.error('Could not enable ' + intent_name +
-                          ', it hasn\'t been registered.')
+        else:
+            LOG.error('Could not enable ' + intent_name +
+                      ', it hasn\'t been registered.')
 
     def set_context(self, context, word=''):
         """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -70,9 +70,11 @@ def unmunge_message(message, skill_id):
         Message without clear keywords
     """
     if isinstance(message, Message) and isinstance(message.data, dict):
+        skill_id = to_letters(skill_id)
         for key in message.data:
-            new_key = key.replace(to_letters(skill_id), '')
-            message.data[new_key] = message.data.pop(key)
+            if key[:len(skill_id)] == skill_id:
+                new_key = key[len(skill_id):]
+                message.data[new_key] = message.data.pop(key)
 
     return message
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -37,7 +37,7 @@ from mycroft.messagebus.message import Message
 from mycroft.metrics import report_metric, report_timing, Stopwatch
 from mycroft.skills.settings import SkillSettings
 from mycroft.skills.skill_data import (load_vocabulary, load_regex, to_letters,
-                                       munge_intent_parser)
+                                       munge_regex, munge_intent_parser)
 from mycroft.util import resolve_resource_file
 from mycroft.util.log import LOG
 # python 2+3 compatibility
@@ -813,12 +813,17 @@ class MycroftSkill(object):
                 entity_type:    Intent handler entity to tie the word to
         """
         self.emitter.emit(Message('register_vocab', {
-            'start': entity, 'end': entity_type
+            'start': entity, 'end': to_letters(self.skill_id) + entity_type
         }))
 
     def register_regex(self, regex_str):
-        re.compile(regex_str)  # validate regex
-        self.emitter.emit(Message('register_vocab', {'regex': regex_str}))
+        """ Register a new regex.
+            Args:
+                regex_str: Regex string
+        """
+        regex = munge_regex(regex_str, self.skill_id)
+        re.compile(regex)  # validate regex
+        self.emitter.emit(Message('register_vocab', {'regex': regex}))
 
     def speak(self, utterance, expect_response=False):
         """

--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -131,33 +131,45 @@ def munge_intent_parser(intent_parser, name, skill_id):
     format <skill_id>:<name>.  The keywords are given unique
     names in the format <Skill id as letters><Intent name>.
 
+    The function will not munge instances that's already been
+    munged
+
     Args:
         intent_parser: (IntentParser) object to update
         name: (str) Skill name
         skill_id: (int) skill identifier
     """
     # Munge parser name
-    intent_parser.name = str(skill_id) + ':' + name
+    if str(skill_id) + ':' not in name:
+        intent_parser.name = str(skill_id) + ':' + name
+    else:
+        intent_parser.name = name
 
     # Munge keywords
     skill_id = to_letters(skill_id)
     # Munge required keyword
     reqs = []
     for i in intent_parser.requires:
-        kw = (skill_id + i[0], skill_id + i[0])
-        reqs.append(kw)
+        if skill_id not in i[0]:
+            kw = (skill_id + i[0], skill_id + i[0])
+            reqs.append(kw)
+        else:
+            reqs.append(i)
     intent_parser.requires = reqs
 
     # Munge optional keywords
     opts = []
     for i in intent_parser.optional:
-        kw = (skill_id + i[0], skill_id + i[0])
-        opts.append(kw)
+        if skill_id not in i[0]:
+            kw = (skill_id + i[0], skill_id + i[0])
+            opts.append(kw)
+        else:
+            opts.append(i)
     intent_parser.optional = opts
 
     # Munge at_least_one keywords
     at_least_one = []
     for i in intent_parser.at_least_one:
-        element = [skill_id + e for e in i]
+        element = [skill_id + e.replace(skill_id, '') for e in i]
         at_least_one.append(tuple(element))
     intent_parser.at_least_one = at_least_one

--- a/test/unittests/skills/core.py
+++ b/test/unittests/skills/core.py
@@ -218,6 +218,13 @@ class MycroftSkillTest(unittest.TestCase):
                           sorted(result_list))
         self.emitter.reset()
 
+    def check_register_vocabulary(self, result_list):
+        for type in self.emitter.get_types():
+            self.assertEquals(type, 'register_vocab')
+        self.assertEquals(sorted(self.emitter.get_results()),
+                          sorted(result_list))
+        self.emitter.reset()
+
     def test_register_intent(self):
         # Test register Intent object
         s = TestSkill1()
@@ -263,6 +270,23 @@ class MycroftSkillTest(unittest.TestCase):
         self.check_detach_intent()
         s.enable_intent('a')
         self.check_register_intent(expected)
+
+    def test_register_vocab(self):
+        """Test disable/enable intent."""
+        # Setup basic test
+        s = TestSkill1()
+        s.bind(self.emitter)
+        s.initialize()
+
+        # Normal vocaubulary
+        self.emitter.reset()
+        expected = [{'start': 'hello', 'end': 'AHelloKeyword'}]
+        s.register_vocabulary('hello', 'HelloKeyword')
+        self.check_register_vocabulary(expected)
+        # Regex
+        s.register_regex('weird (?P<Weird>.+) stuff')
+        expected = [{'regex': 'weird (?P<AWeird>.+) stuff'}]
+        self.check_register_vocabulary(expected)
 
     def check_register_object_file(self, types_list, result_list):
         self.assertEquals(sorted(self.emitter.get_types()),

--- a/test/unittests/skills/core.py
+++ b/test/unittests/skills/core.py
@@ -205,6 +205,12 @@ class MycroftSkillTest(unittest.TestCase):
         self.assertEquals(s.skill_id, 847)
         self.assertEquals(s.name, 'LoadTestSkill')
 
+    def check_detach_intent(self):
+        self.assertTrue(len(self.emitter.get_types()) > 0)
+        for msg_type in self.emitter.get_types():
+            self.assertEquals(msg_type, 'detach_intent')
+        self.emitter.reset()
+
     def check_register_intent(self, result_list):
         for type in self.emitter.get_types():
             self.assertEquals(type, 'register_intent')
@@ -239,6 +245,24 @@ class MycroftSkillTest(unittest.TestCase):
             s = TestSkill3()
             s.bind(self.emitter)
             s.initialize()
+
+    def test_enable_disable_intent(self):
+        """Test disable/enable intent."""
+        # Setup basic test
+        s = TestSkill1()
+        s.bind(self.emitter)
+        s.initialize()
+        expected = [{'at_least_one': [],
+                     'name': '0:a',
+                     'optional': [],
+                     'requires': [('AKeyword', 'AKeyword')]}]
+        self.check_register_intent(expected)
+
+        # Test disable/enable cycle
+        s.disable_intent('a')
+        self.check_detach_intent()
+        s.enable_intent('a')
+        self.check_register_intent(expected)
 
     def check_register_object_file(self, types_list, result_list):
         self.assertEquals(sorted(self.emitter.get_types()),


### PR DESCRIPTION
## Description
Fixes an issue with enabling disabled intents identified by @penrods. The issue was introduced when intents were made per skill.

The changes include:
- munge_intent() will no longer modify already munged intents
- Fix cosmetic issue with error message for each intent not matching the requested in enable_intent()
- Fix register_vocabulary and register_regex
- Add unittest for enable/disable intent and register_vocabulary methods

## How to test
Test with the *feature/eye_countdown* branch of the mycroft-timer skill,

- at startup "cancel all timers" should not do anything
- Start a timer "set a 60 seconds timer" and then "cancel all timers" shall be identified and the timer should be cancelled
- afterwards "cancel all timers" should no longer be recognized

## Contributor license agreement signed?
CLA [Yes]