### PR TITLE
Fix multiple triggering of repeating events

### DIFF
--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -27,6 +27,23 @@ else:
     from queue import Queue
 
 
+def repeat_time(sched_time, repeat):
+    """Next scheduled time for repeating event. Asserts that the
+    time is not in the past.
+
+    Args:
+        sched_time (float): Scheduled unix time for the event
+        repeat (float):     Repeat period in seconds
+
+    Returns: (float) time for next event
+    """
+    next_time = sched_time + repeat
+    if next_time < time.time():
+        # Schedule at an offset to assure no doubles
+        next_time = time.time() + repeat
+    return next_time
+
+
 class EventScheduler(Thread):
     def __init__(self, emitter, schedule_file='/opt/mycroft/schedule.json'):
         """
@@ -137,7 +154,8 @@ class EventScheduler(Thread):
                 self.emitter.emit(Message(event, data))
                 # if this is a repeated event add a new trigger time
                 if repeat:
-                    remaining.append((sched_time + repeat, repeat, data))
+                    next_time = repeat_time(sched_time, repeat)
+                    remaining.append((next_time, repeat, data))
             # update list of events
             self.events[event] = remaining
 


### PR DESCRIPTION
## Description
If the scheduler was frozen for some time (for example a suspended laptop) and the repeating event
scheduled time passes it would trigger the event constantly until the next time is in the future again.

This PR make the scheduler to disallow scheduling in the past and instead schedule the next call one repeat period from now.


## How to test
Make sure nothing explodes.

The following repeating event should only trigger every 60 second, not 2 times/second.
```python

from mycroft import MycroftSkill, intent_handler
from adapt.intent import IntentBuilder
from mycroft.util.log import LOG

from datetime import datetime

class TestSkill(MycroftSkill):

    def initialize(self):
        self.schedule_repeating_event(self.weird_handler,
                                      datetime(year=1970, month=1,day=1),
                                      60, name='test')

    def weird_handler(self, message):
        LOG.info('EVENT TRIGGERED !!!!!!!!!!!!!!')

def create_skill():
    return TestSkill()
```

## Contributor license agreement signed?
CLA [Yes]