### PR TITLE
issue #1083: limit history size to fix crash

### DIFF
--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -840,6 +840,9 @@ def handle_cmd(cmd):
         lines = int(_get_cmd_param(cmd))
         if lines < 1:
             lines = 1
+        max_chat_area = curses.LINES - 7
+        if lines > max_chat_area:
+            lines = max_chat_area
         cy_chat_area = lines
     elif "skills" in cmd:
         # List loaded skill


### PR DESCRIPTION
The calulated limit ensures that at least one message will be displayed.
Using a hard-coded constant is ugly, but such are scattered throughout
the script.  Untangling those constants has been left for future patches.

## Description
Fixes issue #1083

## How to test
Run the CLI and type `: history 1000`.

Without patch, CLI crashes inside a curses library call.

With patch, CLI displays maximal chat history lines and the most recent log message.

## Contributor license agreement signed?
Requested