### PR TITLE
Make sure the cli locale is set to an UTF-8 type

### DIFF
--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -47,7 +47,15 @@ from mycroft.util.log import LOG
 import locale
 # Curses uses LC_ALL to determine how to display chars set it to system
 # default
-locale.setlocale(locale.LC_ALL, '.'.join(locale.getdefaultlocale()))
+try:
+    default_locale = '.'.join((locale.getdefaultlocale()[0], 'UTF-8'))
+    locale.setlocale(locale.LC_ALL, default_locale)
+except (locale.Error, ValueError):
+    print('Locale not supported, please try starting the command and '
+          'setting LANG="en_US.UTF-8"\n\n'
+          '\tExample: LANG="en_US.UTF-8" ./start-mycroft.sh cli\n',
+          file=sys.__stderr__)
+    sys.exit(1)
 
 ws = None
 mutex = Lock()


### PR DESCRIPTION
## Description
Try to explicitly set an Unicode encoding to the locale.
If the locale setting fails, exit with a simple error message suggesting workaround

## How to test
- Start the cli normally and make sure it works
- Exit cli and restart it with `LANG="l33t_5P33K" ./start-mycroft.sh cli` and make sure there is an message explaining the failure.

## Contributor license agreement signed?
CLA [YES]