### PR TITLE
Fix hash method to work with python3

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -307,7 +307,10 @@ class SkillSettings(dict):
 
     def hash(self, str):
         """ md5 hasher for consistency across cpu architectures """
-        return hashlib.md5(str).hexdigest()
+        if type(str) == bytes:
+            return hashlib.md5(str).hexdigest()
+        else:
+            return hashlib.md5(str.encode('utf8')).hexdigest()
 
     def _get_meta_hash(self, settings_meta):
         """ Get's the hash of skill


### PR DESCRIPTION
## Description
In python3, unicode objects have to be encoded before being
hashed with hashlib so this commit fixes the hash method so
it works with both python2 and python3.

## How to test
I run mycroft-core with python3 and saw an exception being raised:
TypeError: Unicode-objects must be encoded before hashing
After applying this commit, it works successfully.

## Contributor license agreement signed?
CLA [yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
