### PR TITLE
only NTP sync on certain enclosures

### DIFF
--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -133,9 +133,13 @@ def check_connection():
             # Skip the sync message when unpaired because the prompt to go to
             # home.mycrof.ai will be displayed by the pairing skill
             enclosure.mouth_text(mycroft.dialog.get("message_synching.clock"))
+
         # Force a sync of the local clock with the internet
-        ws.emit(Message("system.ntp.sync"))
-        time.sleep(15)   # TODO: Generate/listen for a message response...
+        config = Configuration.get()
+        platform = config['enclosure'].get("platform", "unknown")
+        if platform in ['mycroft_mark_1', 'picroft']:
+            ws.emit(Message("system.ntp.sync"))
+            time.sleep(15)   # TODO: Generate/listen for a message response...
 
         # Check if the time skewed significantly.  If so, reboot
         skew = abs((monotonic.monotonic() - start_ticks) -


### PR DESCRIPTION
## Description
This patch eliminates a 15 second delay when starting the skill server on platforms that do not implement a handler for the `system.ntp.sync` message.

## How to test
Run it on Linux and watch how much faster it starts up

## Contributor license agreement signed?
CLA [YES]