### PR TITLE
improve output when no words are transcribed

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -175,7 +175,10 @@ class AudioConsumer(Thread):
                 LOG.warning("Access Denied at mycroft.ai")
         except Exception as e:
             self.emitter.emit('recognizer_loop:speech.recognition.unknown')
-            LOG.error(e)
+            if isinstance(e, IndexError):
+                LOG.info('no words were transcribed')
+            else:
+                LOG.error(e)
             LOG.error("Speech Recognition could not understand audio")
         return text
 


### PR DESCRIPTION
## Description
This patch improves the logging output of the speech client, displaying a meaningful message when no words are transcribed.

## How to test
Say `Hey Mycroft` and say nothing.  Without this patch, the log file records an `IndexError` message that can confuse users. With the patch, it logs "no words were transcribed".

## Contributor license agreement signed?
CLA [Y]