### PR TITLE
Remove redundant except (SystemExit, KeyboardInterrupt) clauses

### DIFF
--- a/mycroft/audio/main.py
+++ b/mycroft/audio/main.py
@@ -78,8 +78,6 @@ def get_services(services_folder):
                     continue
                 try:
                     services.append(create_service_descriptor(name))
-                except (KeyboardInterrupt, SystemExit):
-                    raise
                 except Exception:
                     LOG.error('Failed to create service from ' + name,
                               exc_info=True)
@@ -88,8 +86,6 @@ def get_services(services_folder):
             continue
         try:
             services.append(create_service_descriptor(location))
-        except (KeyboardInterrupt, SystemExit):
-            raise
         except Exception:
             LOG.error('Failed to create service from ' + name,
                       exc_info=True)
@@ -117,8 +113,6 @@ def load_services(config, ws, path=None):
         try:
             service_module = imp.load_module(descriptor["name"] + MAINMODULE,
                                              *descriptor["info"])
-        except (KeyboardInterrupt, SystemExit):
-            raise
         except Exception:
             LOG.error('Failed to import module ' + descriptor['name'],
                       exc_info=True)
@@ -127,8 +121,6 @@ def load_services(config, ws, path=None):
             try:
                 s = service_module.autodetect(config, ws)
                 service += s
-            except (KeyboardInterrupt, SystemExit):
-                raise
             except Exception:
                 LOG.error('Failed to autodetect...',
                           exc_info=True)
@@ -136,8 +128,6 @@ def load_services(config, ws, path=None):
             try:
                 s = service_module.load_service(config, ws)
                 service += s
-            except (KeyboardInterrupt, SystemExit):
-                raise
             except Exception:
                 LOG.error('Failed to load service...',
                           exc_info=True)
@@ -290,8 +280,6 @@ class AudioService(object):
         try:
             if self.pulse_quiet:
                 self.pulse_quiet()
-        except (KeyboardInterrupt, SystemExit):
-            raise
         except Exception as exc:
             LOG.error(exc)
 
@@ -473,8 +461,6 @@ def main():
             if 'mycroft.audio.service' not in _message.get('type'):
                 return
             message = json.dumps(_message)
-        except (KeyboardInterrupt, SystemExit):
-            raise
         except Exception as e:
             LOG.exception(e)
         LOG.debug(message)

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -273,8 +273,6 @@ class HotWordFactory(object):
         clazz = HotWordFactory.CLASSES.get(module)
         try:
             return clazz(hotword, config, lang=lang)
-        except (KeyboardInterrupt, SystemExit):
-            raise
-        except:
+        except Exception:
             LOG.exception('Could not create hotword. Falling back to default.')
             return HotWordFactory.CLASSES['pocketsphinx']()


### PR DESCRIPTION
## Description
I realized that it's not actually necessary to add the SystemExit and KeyboardInterrupt except clauses if the broad clause uses `except Exception`. This works because SystemExit and KeyboardInterrupt do not inherit from the base `Exception` class

## How to test
Make sure the wake word still falls back to `hey mycroft` when using incorrect phonemes in Pocketsphinx.
