### PR TITLE
Fix audio service loading

### DIFF
--- a/mycroft/audio/main.py
+++ b/mycroft/audio/main.py
@@ -122,6 +122,8 @@ def load_services(config, ws, path=None):
         except Exception:
             LOG.error('Failed to import module ' + descriptor['name'],
                       exc_info=True)
+            continue
+
         if (hasattr(service_module, 'autodetect') and
                 callable(service_module.autodetect)):
             try:


### PR DESCRIPTION
## Description
If service_module failed to load, it shouldn't continue loading it. This fixes NPR news

## How to test
 - Make sure no errors occur in the audio service on startup
 - Make sure NPR news works