### PR TITLE
Fix platform comment in config

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -164,7 +164,8 @@
   // Mark 1 enclosure settings
   // Override: SYSTEM (e.g. Picroft)
   "enclosure": {
-    // Platform name (e.g. 'Picroft', 'Mark_1'
+    // Platform name
+    // Options: 'picroft', 'mycroft_mark_1'
     // Override: SYSTEM (set by specific enclosures)
     # "platform": "picroft",
     


### PR DESCRIPTION
## Description
This adds the real, valid options to the config to prevent confusion

## How to test
Make sure the config loads properly and something like `what time is it` still works