### PR TITLE
Check for pairing before performing routine polling

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -154,6 +154,10 @@ class RemoteConf(LocalConf):
         super(RemoteConf, self).__init__(None)
 
         cache = cache or '/opt/mycroft/web_config_cache.json'
+        from mycroft.api import is_paired
+        if not is_paired():
+            self.load_local(cache)
+            return
 
         try:
             # Here to avoid cyclic import

--- a/mycroft/metrics/__init__.py
+++ b/mycroft/metrics/__init__.py
@@ -18,7 +18,7 @@ import time
 
 import requests
 
-from mycroft.api import DeviceApi
+from mycroft.api import DeviceApi, is_paired
 from mycroft.configuration import Configuration
 from mycroft.session import SessionManager
 from mycroft.util.log import LOG
@@ -35,7 +35,7 @@ def report_metric(name, data):
         data (dict): JSON dictionary to report. Must be valid JSON
     """
     try:
-        if Configuration().get()['opt_in']:
+        if is_paired() and Configuration().get()['opt_in']:
             DeviceApi().report_metric(name, data)
     except (requests.HTTPError, requests.exceptions.ConnectionError) as e:
         LOG.error('Metric couldn\'t be uploaded, due to a network error ({})'

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -64,7 +64,7 @@ import hashlib
 from threading import Timer
 from os.path import isfile, join, expanduser, basename
 
-from mycroft.api import DeviceApi
+from mycroft.api import DeviceApi, is_paired
 from mycroft.util.log import LOG
 from mycroft.configuration import ConfigurationManager
 
@@ -122,6 +122,9 @@ class SkillSettings(dict):
         self.load_skill_settings_from_file()  # loads existing settings.json
         settings_meta = self._load_settings_meta()
         if not settings_meta:
+            return
+
+        if not is_paired():
             return
 
         self._device_identity = self.api.identity.uuid
@@ -384,7 +387,9 @@ class SkillSettings(dict):
                 hashed_meta (int): the hashed identifier
         """
         try:
-            if not self._complete_intialization:
+            if not is_paired():
+                pass
+            elif not self._complete_intialization:
                 self.initialize_remote_settings()
                 if not self._complete_intialization:
                     return  # unable to do remote sync
@@ -394,7 +399,6 @@ class SkillSettings(dict):
                 # Call callback for updated settings
                 if self.changed_callback and hash(str(self)) != original:
                     self.changed_callback()
-
         except Exception as e:
             LOG.error(e)
             LOG.exception("")


### PR DESCRIPTION
## Description
This gets rid of HTTP error messages during the pairing process (which are expected)

## How to test
Remove your `identity.json` and look for scary error messages. Pair and make sure polling still works.