### PR TITLE
Add proper not loaded message

### DIFF
--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -15,6 +15,7 @@
 import sys
 from threading import Thread, Lock
 
+from mycroft import dialog
 from mycroft.client.enclosure.api import EnclosureAPI
 from mycroft.client.speech.listener import RecognizerLoop
 from mycroft.configuration import Configuration
@@ -79,9 +80,7 @@ def handle_speak(event):
 
 def handle_complete_intent_failure(event):
     LOG.info("Failed to find intent.")
-    # TODO: Localize
-    data = {'utterance':
-            "Sorry, I didn't catch that. Please rephrase your request."}
+    data = {'utterance': dialog.get('not.loaded')}
     ws.emit(Message('speak', data))
 
 

--- a/mycroft/res/text/en-us/not.loaded.dialog
+++ b/mycroft/res/text/en-us/not.loaded.dialog
@@ -1,0 +1,1 @@
+Please wait a moment as I finish booting up.


### PR DESCRIPTION
## Description
Once skills load, skill-unknown will handle all failed fallbacks. The only time this is spoken is when skills still aren't loaded yet

## How to test
Ask Mycroft a question before the bootup sequence is finished