### PR TITLE
Fix local service crash when servers are down

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -17,7 +17,7 @@ from threading import Thread
 import sys
 import speech_recognition as sr
 from pyee import EventEmitter
-from requests import HTTPError
+from requests import RequestException
 from requests.exceptions import ConnectionError
 
 import mycroft.dialog
@@ -169,7 +169,7 @@ class AudioConsumer(Thread):
         except ConnectionError as e:
             LOG.error("Connection Error: {0}".format(e))
             self.emitter.emit("recognizer_loop:no_internet")
-        except HTTPError as e:
+        except RequestException as e:
             if e.response.status_code == 401:
                 text = "pair my device"  # phrase to start the pairing process
                 LOG.warning("Access Denied at mycroft.ai")

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -208,7 +208,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
         try:
             self.account_id = DeviceApi().get()['user']['uuid']
-        except (requests.HTTPError, requests.ConnectionError, AttributeError):
+        except (requests.RequestException, AttributeError):
             self.account_id = '0'
 
     def record_sound_chunk(self, source):

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -18,7 +18,7 @@ import re
 import json
 import inflection
 from os.path import exists, isfile, join, dirname, expanduser
-from requests import HTTPError
+from requests import RequestException
 
 from mycroft.util.json_helper import load_commented_json
 from mycroft.util.log import LOG
@@ -174,8 +174,8 @@ class RemoteConf(LocalConf):
                 self.__setitem__(key, config[key])
             self.store(cache)
 
-        except HTTPError as e:
-            LOG.error("HTTPError fetching remote configuration: %s" %
+        except RequestException as e:
+            LOG.error("RequestException fetching remote configuration: %s" %
                       e.response.status_code)
             self.load_local(cache)
 

--- a/mycroft/metrics/__init__.py
+++ b/mycroft/metrics/__init__.py
@@ -37,7 +37,7 @@ def report_metric(name, data):
     try:
         if is_paired() and Configuration().get()['opt_in']:
             DeviceApi().report_metric(name, data)
-    except (requests.HTTPError, requests.exceptions.ConnectionError) as e:
+    except requests.RequestException as e:
         LOG.error('Metric couldn\'t be uploaded, due to a network error ({})'
                   .format(e))
 


### PR DESCRIPTION
## Description
When the servers are not reacting properly, server requests can throw a `ReadTimeout` exception which was previously not handled in a few places. This PR changes the except to cover all request exceptions, in particular, preventing a crash if the speech service restarts during a server failure.

## How to test
 - Mess up the servers
 - Restart your services
 - Fix the servers
 - Make sure the speech client still works
