### PR TITLE
Fix error on wait_for_response timeout.

### DIFF
--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -116,7 +116,14 @@ class WebsocketClient(object):
         while len(response) == 0:
             time.sleep(0.2)
             if monotonic.monotonic() - start_time > (timeout or 3.0):
-                self.remove(reply_type, handler)
+                try:
+                    self.remove(reply_type, handler)
+                except (ValueError, KeyError):
+                    # ValueError occurs on pyee 1.0.1 removing handlers
+                    # registered with once.
+                    # KeyError may theoretically occur if the event occurs as
+                    # the handler is removbed
+                    pass
                 return None
         return response[0]
 


### PR DESCRIPTION
## Description
Using pyee 1.0.1 handlers registered with once can't be removed. This handles the value error raised in this case.

## How to test
- on Dev Start Mycroft, stop skills service and start CLI
- enter `:skills` command in CLI. A stack trace will be shown if pyee 1.0.1 is installed
- Checkout PR and repeat above process, CLI should continue without issue

## Contributor license agreement signed?
CLA [Yes]