### PR TITLE
Reduce verbosity when skill settings fetch fails.

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -398,8 +398,7 @@ class SkillSettings(dict):
                 self.update_remote()
 
         except Exception as e:
-            LOG.error(e)
-            LOG.exception("")
+            LOG.error('Failed to fetch skill settings:\n{}'.format(e))
         finally:
             # Call callback for updated settings
             if self.changed_callback and hash(str(self)) != original:


### PR DESCRIPTION
## Description
Replace the stack trace with a shorter message, briefly printing the cause of the failure.

## How to test
Start CLI and check that no stack trace occurs when the fetching of settings fails.

## Contributor license agreement signed?
CLA [Yes]