### PR TITLE
Converse deactivate  calback

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -261,7 +261,7 @@ class MycroftSkill(object):
         if emitter:
             self.emitter = emitter
             self.enclosure = EnclosureAPI(emitter, self.name)
-            self.add_event("converse.deactivate", self.on_deactivate)
+            self.add_event("converse.deactivate", self._deactivate_skill)
             self.__register_stop()
 
     def __register_stop(self):
@@ -292,7 +292,12 @@ class MycroftSkill(object):
         """
         return None
 
-    def on_deactivate(self, message):
+    def _deactivate_skill(self, message):
+        skill_id = message.data.get("skill_id")
+        if skill_id == self.skill_id:
+            self.on_deactivate()
+
+    def on_deactivate(self):
         """
         Invoked when the skill is removed from active skill list
         """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -261,6 +261,7 @@ class MycroftSkill(object):
         if emitter:
             self.emitter = emitter
             self.enclosure = EnclosureAPI(emitter, self.name)
+            self.add_event("converse.deactivate", self.on_deactivate)
             self.__register_stop()
 
     def __register_stop(self):
@@ -290,6 +291,12 @@ class MycroftSkill(object):
             str: message that will be spoken to the user
         """
         return None
+
+    def on_deactivate(self, message):
+        """
+        Invoked when the skill is removed from active skill list
+        """
+        pass
 
     def converse(self, utterances, lang="en-us"):
         """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -300,15 +300,16 @@ class MycroftSkill(object):
 
     def converse(self, utterances, lang="en-us"):
         """
-            Handle conversation. This method can be used to override the normal
-            intent handler after the skill has been invoked once.
+            Handle conversation. This method can be used to override the
+            normal intent handler during the 5 minutes after the skill has
+            been invoked.
 
-            To enable this override thise converse method and return True to
+            To enable this override this converse method and return True to
             indicate that the utterance has been handled.
 
             Args:
                 utterances (list): The utterances from the user
-                lang:       language the utterance is in
+                lang       (str): language the utterance is in
 
             Returns:    True if an utterance was handled, otherwise False
         """

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -317,9 +317,11 @@ class IntentService(object):
         """
 
         # check for conversation time-out
-        self.active_skills = [skill for skill in self.active_skills
-                              if time.time() - skill[
-                                  1] <= self.converse_timeout * 60]
+        for skill in list(self.active_skills):
+            if time.time() - skill[1] <= self.converse_timeout * 60:
+                self.emitter.emit(Message("converse.deactivate",
+                                          {"skill_id": skill[0]}))
+                self.active_skills.remove(skill)
 
         # check if any skill wants to handle utterance
         for skill in self.active_skills:


### PR DESCRIPTION
## Description
adds a callback for when a skill is removed from active skills list

allows for example a skill to keep itself always active, or reset states if it was expecting to use converse method but didn't 

Used in my [utils_package](https://github.com/JarbasAl/mycroft_jarbas_utils/tree/master/mycroft_jarbas_utils/skills) to allow you to do things like passive skills that are always active

## How to test

make a skill, override on_deactivate method to Log something, trigger an intent from that skill, wait 5 minutes, check that log is there

## Contributor license agreement signed?
CLA [ yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
