### PR TITLE
Fix accessing non-existent attribute in except blocks

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -17,7 +17,7 @@ from threading import Thread
 import sys
 import speech_recognition as sr
 from pyee import EventEmitter
-from requests import RequestException
+from requests import RequestException, HTTPError
 from requests.exceptions import ConnectionError
 
 import mycroft.dialog
@@ -169,10 +169,14 @@ class AudioConsumer(Thread):
         except ConnectionError as e:
             LOG.error("Connection Error: {0}".format(e))
             self.emitter.emit("recognizer_loop:no_internet")
-        except RequestException as e:
+        except HTTPError as e:
             if e.response.status_code == 401:
                 text = "pair my device"  # phrase to start the pairing process
                 LOG.warning("Access Denied at mycroft.ai")
+            else:
+                LOG.error(e.__class__.__name__ + ': ' + str(e))
+        except RequestException as e:
+            LOG.error(e.__class__.__name__ + ': ' + str(e))
         except Exception as e:
             self.emitter.emit('recognizer_loop:speech.recognition.unknown')
             if isinstance(e, IndexError):

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -18,7 +18,7 @@ import re
 import json
 import inflection
 from os.path import exists, isfile, join, dirname, expanduser
-from requests import RequestException
+from requests import HTTPError
 
 from mycroft.util.json_helper import load_commented_json
 from mycroft.util.log import LOG
@@ -174,7 +174,7 @@ class RemoteConf(LocalConf):
                 self.__setitem__(key, config[key])
             self.store(cache)
 
-        except RequestException as e:
+        except HTTPError as e:
             LOG.error("RequestException fetching remote configuration: %s" %
                       e.response.status_code)
             self.load_local(cache)


### PR DESCRIPTION
## Description
.request.status_code is only available to HTTPError objects. This fixes an exception in the except clause on a `ReadTimeout`.

## How to test
 - Wait for the backend to go down (shouldn't take too much time)
 - Start up the speech client
 - Make sure it doesn't crash