### PR TITLE
Blacklist spotify-skill

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -93,7 +93,7 @@
     // Enable auto update by msm
     "auto_update": true,
     // blacklisted skills to not load
-    "blacklisted_skills": ["skill-media", "send_sms", "skill-wolfram-alpha"],
+    "blacklisted_skills": ["skill-media", "send_sms", "skill-wolfram-alpha", "spotify-skill"],
     // priority skills to be loaded first
     "priority_skills": ["skill-pairing"],
     // Minimum time since last skill updata to force an update on startup


### PR DESCRIPTION
## Description

Blacklists the spotify skill to ensure it won't take down our servers.

## How to test
Start Mycroft, start the cli, allow skills to load, do `touch /opt/mycroft/skills/spotify-skill/__init__.py` the cli should show `SKILL IS BLACKLISTED` 

## Contributor license agreement signed?
CLA [Yes]