### PR TITLE
Feature/repeating event safety

### DIFF
--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -101,9 +101,15 @@ class EventScheduler(Thread):
             event, sched_time, repeat, data = self.add.get(timeout=1)
             # get current list of scheduled times for event, [] if missing
             event_list = self.events.get(event, [])
-            # add received event and time
-            event_list.append((sched_time, repeat, data))
-            self.events[event] = event_list
+
+            # Don't schedule if the event is repeating and already scheduled
+            if repeat and event in self.events:
+                LOG.debug('Repeating event {} is already scheduled, discarding'
+                          .format(event))
+            else:
+                # add received event and time
+                event_list.append((sched_time, repeat, data))
+                self.events[event] = event_list
 
     def remove_events(self):
         """


### PR DESCRIPTION
## Description
Add some safety regarding scheduling repeating events.

- Hinder skills from registering multiple repeating events with the same name
- Hinder the event_scheduler from register multiples of the same event if `repeat` is set.

## How to test
A simple case that will flood the log with messages on dev:
```python
from mycroft import MycroftSkill, intent_handler
from mycroft.util.log import LOG

class InfiniteRepeat(MycroftSkill):
    def initialize(self):
        self.scheduled_handler()

    def scheduled_handler(self):
        LOG.info('SCHEDULED EVENT!')
        self.schedule_repeating_event(self.scheduled_handler, None, 5,
                                      name='ScheduledEvent')

def create_skill():
    return InfiniteRepeat()
```

In the PR branch it should only trigger every 5 seconds

## Contributor license agreement signed?
CLA [Yes]