### PR TITLE
fix audio service previous

### DIFF
--- a/mycroft/audio/main.py
+++ b/mycroft/audio/main.py
@@ -253,7 +253,7 @@ class AudioService(object):
                 message: message bus message, not used but required
         """
         if self.current:
-            self.current.prev()
+            self.current.previous()
 
     def _stop(self, message=None):
         """


### PR DESCRIPTION
## Description
Previous track is not working because audio service uses .prev() and the base class was updated to .previous()

## How to test
play some playlist with audio service, test by saying "next track" and "previous track"

## Contributor license agreement signed?
CLA [ yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
