### PR TITLE
clean audio service shutdown

### DIFF
--- a/mycroft/audio/services/__init__.py
+++ b/mycroft/audio/services/__init__.py
@@ -120,3 +120,7 @@ class AudioBackend():
         ret['artist'] = ''
         ret['album'] = ''
         return ret
+
+    def shutdown(self):
+        """ perform clean shutdown """
+        pass

--- a/mycroft/audio/services/__init__.py
+++ b/mycroft/audio/services/__init__.py
@@ -123,4 +123,4 @@ class AudioBackend():
 
     def shutdown(self):
         """ perform clean shutdown """
-        pass
+        self.stop()


### PR DESCRIPTION
## Description
Adds a shutdown method to AudioBackend, this may be required by some backends that interact with other programs

Also cleanly removes listeners

## How to test
Currently no audio backend needs this, in the mpv backend PR #1489  this is necessary and correctly performs shutdown, without this audio continues playing

## Contributor license agreement signed?
CLA [ yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
