### PR TITLE
bugfix: honor "active" flag for audio backends

### DIFF
--- a/mycroft/audio/services/mopidy/__init__.py
+++ b/mycroft/audio/services/mopidy/__init__.py
@@ -115,6 +115,7 @@ class MopidyService(AudioBackend):
 def load_service(base_config, emitter):
     backends = base_config.get('backends', [])
     services = [(b, backends[b]) for b in backends
-                if backends[b]['type'] == 'mopidy']
+                if backends[b]['type'] == 'mopidy' and
+                backends[b].get('active', True)]
     instances = [MopidyService(s[1], emitter, s[0]) for s in services]
     return instances

--- a/mycroft/audio/services/mpg123/__init__.py
+++ b/mycroft/audio/services/mpg123/__init__.py
@@ -115,6 +115,7 @@ class Mpg123Service(AudioBackend):
 def load_service(base_config, emitter):
     backends = base_config.get('backends', [])
     services = [(b, backends[b]) for b in backends
-                if backends[b]['type'] == 'mpg123']
+                if backends[b]['type'] == 'mpg123' and
+                backends[b].get('active', True)]
     instances = [Mpg123Service(s[1], emitter, s[0]) for s in services]
     return instances

--- a/mycroft/audio/services/vlc/__init__.py
+++ b/mycroft/audio/services/vlc/__init__.py
@@ -96,6 +96,7 @@ class VlcService(AudioBackend):
 def load_service(base_config, emitter):
     backends = base_config.get('backends', [])
     services = [(b, backends[b]) for b in backends
-                if backends[b]['type'] == 'vlc']
+                if backends[b]['type'] == 'vlc' and
+                backends[b].get('active', True)]
     instances = [VlcService(s[1], emitter, s[0]) for s in services]
     return instances


### PR DESCRIPTION
## Description
all audio backends are loaded,  the "active" flag is currently ignored, this PR fixes this

chromecast uses an auto discover mechanism and ignores this

#1489 and #1490 need changes to reflect this

## How to test
in config file set a audio backend to not active, verify it does not load in the audio service logs

## Contributor license agreement signed?
CLA [yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
