### PR TITLE
allow google stt by default, using test key

### DIFF
--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -84,6 +84,8 @@ class KeySTT(STT):
 class GoogleSTT(TokenSTT):
     def __init__(self):
         super(GoogleSTT, self).__init__()
+        if self.token == "None":
+            self.token = None
 
     def execute(self, audio, language=None):
         self.lang = language or self.lang


### PR DESCRIPTION
## Description

if no key is provided for google stt, the speech recognition python package uses a default test key that works

because of the type casting to string an invalid key is passed, this PR changes it in order for google STT to work out of the box

## How to test

change stt module to google, verify it works without key

## Contributor license agreement signed?
CLA [yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
