### PR TITLE
Bugfix for 1494: opt_in not honored in intent

### DIFF
--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -126,6 +126,7 @@ class ContextManager(object):
 class IntentService(object):
     def __init__(self, emitter):
         self.config = Configuration.get().get('context', {})
+        self.config_core = Configuration.get()
         self.engine = IntentDeterminationEngine()
 
         # Dictionary for translating a skill id to a name
@@ -241,6 +242,9 @@ class IntentService(object):
 
         NOTE: This only applies to those with Opt In.
         """
+        if not self.config_core.get('opt_in'):
+            return
+
         LOG.debug('Sending metric')
         ident = context['ident'] if context else None
         if intent:


### PR DESCRIPTION
The configuration parameter "opt_in" (added in 0569ba4) wasn't being
honored in the send_metrics function in intent_service.py:238, contrary
to the comment (added in c68ad44).

==== Fixed Issues ====
1494

## How to test
See #1494 message for steps to reproduce and expected behavior. Change opt_in parameter to true and false, verify "sending metrics" appears in the former and not the latter.

## Contributor license agreement signed?
NO: Request submitting, waiting on a response from team.
