### PR TITLE
Simple log output change to prevent confusion

### DIFF
--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -241,7 +241,7 @@ class IntentService(object):
 
         NOTE: This only applies to those with Opt In.
         """
-        LOG.debug('Sending metric')
+        LOG.debug('Sending metric if opt_in is enabled')
         ident = context['ident'] if context else None
         if intent:
             # Recreate skill name from skill id


### PR DESCRIPTION
Modified the debugging message output after an utterance is complete, to
make it clear that metric data is only sent if opt_in is enabled.

This addresses #1494, which I filed in error, thinking that opt_in was
never checked (due to reading the log output and not knowing it was
checked elsewhere)

==== Fixed Issues ====

==== Localization Notes ====
Slight change to existing, unlocalized text

## Contributor license agreement signed?
CLA [YES]
