### PR TITLE
Fix msm lock hanging forever

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -130,10 +130,7 @@ function send_start_install () {
     fi
 }
 function send_start_update () {
-    if [[ "${update_started}" == "false" ]] ; then
-        python -m mycroft.messagebus.send msm.updating
-        update_started="true"
-    fi
+    python -m mycroft.messagebus.send msm.updating
 }
 function send_start_remove () {
     if [[ "${remove_started}" == "false" ]] ; then
@@ -159,9 +156,7 @@ function send_end_install () {
     fi
 }
 function send_end_update () {
-    if [[ "${update_started}" == "true" ]] ; then
-        python -m mycroft.messagebus.send msm.updated
-    fi
+    python -m mycroft.messagebus.send msm.updated
 }
 function send_end_remove () {
     if [[ "${remove_started}" == "true" ]] ; then
@@ -531,8 +526,8 @@ function update() {
   echo "Updating installed skills..."
   cd "${mycroft_skill_folder}"
   
-  send_start_update & 
-  pids=("$!")
+  send_start_update
+  pids=()
 
   # Loop through all of the current Skill folders
   for d in $(find "${mycroft_skill_folder}" -mindepth 1 -maxdepth 1 -type d |grep -v '.git'$ ); do
@@ -543,7 +538,9 @@ function update() {
       pids+=("$!")
     fi
   done
-  wait $pids
+  for pid in "${pids[@]}"; do
+    wait $pid
+  done
 
   # TODO: Remove this for 18.02
   # HACK: Only do the re-PIP once per boot
@@ -740,7 +737,7 @@ case ${OPT} in
       fi
 
       # Create .msm file to provide timestamp for last msm default
-      rm ${mycroft_skill_folder}/.msm
+      rm -f ${mycroft_skill_folder}/.msm
       printf "" > ${mycroft_skill_folder}/.msm.tmp
       # These skills are automatically installed on all mycroft-core
       # installations.


### PR DESCRIPTION
## Description
Sometimes the `send_end_update` would happen before the `send_start_update` and due to the `install_started` being `false`, `msm.updated` would never get sent

## How to test
Start the Mycroft services a few times. You will notice, without this change, once every few bootups skils never load. With this change, they consistently load.