### PR TITLE
bug: more robust utterance_remainder

### DIFF
--- a/mycroft/messagebus/message.py
+++ b/mycroft/messagebus/message.py
@@ -159,5 +159,5 @@ class Message(object):
         utt = self.data.get("utterance", None)
         if utt and "__tags__" in self.data:
             for token in self.data["__tags__"]:
-                utt = utt.replace(token["key"], "")
+                utt = utt.replace(token.get("key", ""), "")
         return normalize(utt)


### PR DESCRIPTION
## Description

This changes the utterance_remainder to method to be more robust, when manually calling an intent handler to re-utilize code it sometimes causes troubles


this snippet throws an error without this PR

```

 def handle_search_next_intent(self, message):
        message.data["index"] = self.band_index + 1
        message.data["MetalBandNameKeyword"] = self.last_band
        self.handle_search_intent(message)

 def handle_search_intent(self, message):
        band_name = message.data.get("MetalBandNameKeyword",
                                     message.utterance_remainder())
```



## How to test

skill that needs this - https://github.com/JarbasAl/skill-metal-archives/blob/master/__init__.py#L92

"search metal archives for black metal"
"next" <- throw error without PR

## Contributor license agreement signed?
CLA [ yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
