### PR TITLE
AudioService - no old style class

### DIFF
--- a/mycroft/skills/audioservice.py
+++ b/mycroft/skills/audioservice.py
@@ -36,7 +36,7 @@ def ensure_uri(s):
         return s
 
 
-class AudioService():
+class AudioService(object):
     """
         AudioService object for interacting with the audio subsystem
 


### PR DESCRIPTION
## Description

Audio service does not inherit from "object" , this was causing me some random troubles when sub-classing it and using super

use-case (fixed to not use super anymore) -
 https://github.com/JarbasAl/mycroft_jarbas_utils/blob/master/mycroft_jarbas_utils/skills/audio.py#L10

## How to test

check everything works the same

## Contributor license agreement signed?
CLA [yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
