### PR TITLE
Feature/mycroft deepspeech stt

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -297,8 +297,8 @@ class DeviceApi(Api):
 class STTApi(Api):
     """ Web API wrapper for performing Speech to Text (STT) """
 
-    def __init__(self):
-        super(STTApi, self).__init__("stt")
+    def __init__(self, path="stt"):
+        super(STTApi, self).__init__(path)
 
     def stt(self, audio, language, limit):
         """ Web API wrapper for performing Speech to Text (STT)

--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -297,7 +297,7 @@ class DeviceApi(Api):
 class STTApi(Api):
     """ Web API wrapper for performing Speech to Text (STT) """
 
-    def __init__(self, path="stt"):
+    def __init__(self, path):
         super(STTApi, self).__init__(path)
 
     def stt(self, audio, language, limit):

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -14,8 +14,9 @@
 #
 import re
 import json
+import requests
 from abc import ABCMeta, abstractmethod
-from requests import post
+from requests import post, exceptions
 from speech_recognition import Recognizer
 
 from mycroft.api import STTApi
@@ -147,7 +148,8 @@ class MycroftDeepSpeechSTT(STT):
         try:
             response = self.api.stt(audio.get_wav_data(), self.lang, 1)
             return response
-        except:
+        except exceptions.RequestException as e:
+            LOG.error(e)
             LOG.error("error with Mycroft DeepSpeech STT request")
 
 

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -123,7 +123,7 @@ class IBMSTT(BasicSTT):
 class MycroftSTT(STT):
     def __init__(self):
         super(MycroftSTT, self).__init__()
-        self.api = STTApi()
+        self.api = STTApi("stt")
 
     def execute(self, audio, language=None):
         self.lang = language or self.lang
@@ -146,7 +146,6 @@ class MycroftDeepSpeechSTT(STT):
             raise ValueError("Deepspeech is currently english only")
         try:
             response = self.api.stt(audio.get_wav_data(), self.lang, 1)
-            LOG.info(response)
             return response
         except:
             LOG.error("error with Mycroft DeepSpeech STT request")

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -145,12 +145,7 @@ class MycroftDeepSpeechSTT(STT):
         language = language or self.lang
         if not language.startswith("en"):
             raise ValueError("Deepspeech is currently english only")
-        try:
-            response = self.api.stt(audio.get_wav_data(), self.lang, 1)
-            return response
-        except exceptions.RequestException as e:
-            LOG.error(e)
-            LOG.error("error with Mycroft DeepSpeech STT request")
+        return self.api.stt(audio.get_wav_data(), self.lang, 1)
 
 
 class DeepSpeechServerSTT(STT):

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -134,10 +134,29 @@ class MycroftSTT(STT):
             return self.api.stt(audio.get_flac_data(), self.lang, 1)[0]
 
 
+class MycroftDeepSpeechSTT(STT):
+    """Mycroft Hosted DeepSpeech"""
+    def __init__(self):
+        super(MycroftDeepSpeechSTT, self).__init__()
+        self.api = STTApi("deepspeech")
+
+    def execute(self, audio, language=None):
+        language = language or self.lang
+        if not language.startswith("en"):
+            raise ValueError("Deepspeech is currently english only")
+        try:
+            response = self.api.stt(audio.get_wav_data(), self.lang, 1)
+            LOG.info(response)
+            return response
+        except:
+            LOG.error("error with Mycroft DeepSpeech STT request")
+
+
 class DeepSpeechServerSTT(STT):
     """
         STT interface for the deepspeech-server:
         https://github.com/MainRo/deepspeech-server
+        use this if you want to host DeepSpeech yourself
     """
     def __init__(self):
         super(DeepSpeechServerSTT, self).__init__()
@@ -196,7 +215,8 @@ class STTFactory(object):
         "kaldi": KaldiSTT,
         "bing": BingSTT,
         "houndify": HoundifySTT,
-        "deepspeech_server": DeepSpeechServerSTT
+        "deepspeech_server": DeepSpeechServerSTT,
+        "mycroft_deepspeech": MycroftDeepSpeechSTT
     }
 
     @staticmethod

--- a/test/unittests/api/test_api.py
+++ b/test/unittests/api/test_api.py
@@ -268,7 +268,7 @@ class TestApi(unittest.TestCase):
         mock_identity = mock.MagicMock()
         mock_identity.uuid = '1234'
         mock_identity_get.return_value = mock_identity
-        stt = mycroft.api.STTApi()
+        stt = mycroft.api.STTApi('stt')
         self.assertEquals(stt.path, 'stt')
 
     @mock.patch('mycroft.api.IdentityManager.get')
@@ -278,7 +278,7 @@ class TestApi(unittest.TestCase):
         mock_identity = mock.MagicMock()
         mock_identity.uuid = '1234'
         mock_identity_get.return_value = mock_identity
-        stt = mycroft.api.STTApi()
+        stt = mycroft.api.STTApi('stt')
         stt.stt('La la la', 'en-US', 1)
         url = mock_request.call_args[0][1]
         self.assertEquals(url, 'https://api-test.mycroft.ai/v1/stt')


### PR DESCRIPTION
## Description
Added a class to the STT factory to allow switching to deepspeech.

## How to test
deepspeech is currenty running on the test cluster so you would need to switch to api-test and change stt module to mycroft_deepspeech until the next tartarus release - 3/27/2018

```json
{  
   "stt":{  
      "module":"mycroft_deepspeech"
   },
   "server":{  
      "url":"https://api-test.mycroft.ai",
      "version":"v1",
      "update":true,
      "metrics":false
   }
}
```

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
