### PR TITLE
honor skill update flag

### DIFF
--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -67,19 +67,23 @@ def direct_update_needed():
     dot_msm = join(SKILLS_DIR, '.msm')
     hours = skills_config.get('startup_update_required_time', 12)
     LOG.info('TIME LIMIT {}'.format(hours))
-    # if .msm file is missing or older than 1 hour update skills
-    if (not exists(dot_msm) or
-            os.path.getmtime(dot_msm) < time.time() - 60 * MINUTES * hours):
-        return True
-    else:  # verify that all default skills are installed
-        with open(dot_msm) as f:
-            default_skills = [line.strip() for line in f if line != '']
-        skills = os.listdir(SKILLS_DIR)
-        LOG.info(default_skills)
-        for d in default_skills:
-            if d not in skills:
-                LOG.info('{} has been removed, direct update needed'.format(d))
-                return True
+    # check if skill updates are enabled
+    update = Configuration.get().get("skills", {}).get("auto_update",
+                                                       True)
+    if update:
+        # if .msm file is missing or older than 1 hour update skills
+        if (not exists(dot_msm) or
+                os.path.getmtime(dot_msm) < time.time() - 60 * MINUTES * hours):
+            return True
+        else:  # verify that all default skills are installed
+            with open(dot_msm) as f:
+                default_skills = [line.strip() for line in f if line != '']
+            skills = os.listdir(SKILLS_DIR)
+            LOG.info(default_skills)
+            for d in default_skills:
+                if d not in skills:
+                    LOG.info('{} has been removed, direct update needed'.format(d))
+                    return True
     return False
 
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -72,8 +72,8 @@ def direct_update_needed():
                                                        True)
     if update:
         # if .msm file is missing or older than 1 hour update skills
-        if (not exists(dot_msm) or
-                os.path.getmtime(dot_msm) < time.time() - 60 * MINUTES * hours):
+        if (not exists(dot_msm) or os.path.getmtime(dot_msm) <
+                time.time() - 60 * MINUTES * hours):
             return True
         else:  # verify that all default skills are installed
             with open(dot_msm) as f:
@@ -82,7 +82,8 @@ def direct_update_needed():
             LOG.info(default_skills)
             for d in default_skills:
                 if d not in skills:
-                    LOG.info('{} has been removed, direct update needed'.format(d))
+                    LOG.info('{} has been removed, direct update needed'
+                             .format(d))
                     return True
     return False
 


### PR DESCRIPTION
## Description

#1342 is ignored in direct update needed, this keeps messing up my dev environment by downloading skills on boot

## How to test
disable auto skills update, check that on boot skills are not auto downloaded (in fresh install, else delete .msm file and some default skill)

## Contributor license agreement signed?
CLA [ x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
