### PR TITLE
Pulseaudio update

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -416,6 +416,7 @@ class AudioService(object):
                        self._restore_volume)
         self.ws.remove('recognizer_loop:record_end', self._restore_volume)
         self.ws.remove('mycroft.stop', self._stop)
+        self._restore_volume()
 
 
 def main():
@@ -444,7 +445,6 @@ def main():
         LOG.exception(e)
     finally:
         speech.shutdown()
-        audio._restore_volume()
         audio.shutdown()
         sys.exit()
 

--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -270,7 +270,6 @@ class AudioService(object):
                 self.current.lower_volume()
             try:
                 if self.pulse_ducking:
-                    LOG.info('!!!!!!!!!!!!! DUCKING!')
                     self.pulse_duck()
             except Exception as exc:
                 LOG.error(exc)

--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -322,15 +322,19 @@ class AudioService(object):
         self.modified_sinks = []
 
     def pulse_duck(self):
-        LOG.info('DUCKING!')
-        self.duck_proc = subprocess.Popen(['paplay',
-                                           '--property=media.role=phone',
-                                           '/dev/zero', '--raw'])
+        """ Trigger pulse audio ducking. """
+        # Create a dummy stream to lower volume
+        if not self.duck_proc:
+            self.duck_proc = subprocess.Popen(['paplay',
+                                               '--property=media.role=phone',
+                                               '/dev/zero', '--raw'])
 
     def pulse_unduck(self):
-        LOG.info('UNDUCKING!')
+        """ Release ducking. """
+        # remove the dummy stream to restore volume
         if self.duck_proc:
             self.duck_proc.kill()
+            self.duck_proc.communicate()
             self.duck_proc = None
 
     def _restore_volume(self, message=None):

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -302,7 +302,8 @@
         "duck": true
       }
     },
-    "default-backend": "local"
+    "default-backend": "local",
+    "pulseaudio": false
   },
   "debug": false
 }

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -92,7 +92,7 @@ def play_wav(uri):
     config = mycroft.configuration.Configuration.get()
     play_cmd = config.get("play_wav_cmdline")
     env = os.environ.copy()
-    if config.get('Audio', {}).get('pulseaudio') == 'duck':
+    if config.get('Audio', {}).get('pulseaudio', False):
         env['PULSE_PROP'] = 'media.role=phone'
 
     play_wav_cmd = str(play_cmd).split(" ")
@@ -105,7 +105,7 @@ def play_wav(uri):
 def play_mp3(uri):
     config = mycroft.configuration.Configuration.get()
     env = os.environ.copy()
-    if config.get('Audio', {}).get('pulseaudio') == 'duck':
+    if config.get('Audio', {}).get('pulseaudio', False):
         env['PULSE_PROP'] = 'media.role=music'
 
     play_cmd = config.get("play_mp3_cmdline")

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -22,7 +22,7 @@ from threading import Thread
 from time import sleep
 
 import json
-import os.path
+import os, os.path
 import psutil
 from stat import S_ISREG, ST_MTIME, ST_MODE, ST_SIZE
 import requests
@@ -91,31 +91,37 @@ def resolve_resource_file(res_name):
 def play_wav(uri):
     config = mycroft.configuration.Configuration.get()
     play_cmd = config.get("play_wav_cmdline")
+    env = os.environ.copy()
+    env['PULSE_PROP'] = 'media.role=phone'
     play_wav_cmd = str(play_cmd).split(" ")
     for index, cmd in enumerate(play_wav_cmd):
         if cmd == "%1":
             play_wav_cmd[index] = (get_http(uri))
-    return subprocess.Popen(play_wav_cmd)
+    return subprocess.Popen(play_wav_cmd, env=env)
 
 
 def play_mp3(uri):
     config = mycroft.configuration.Configuration.get()
+    env = os.environ.copy()
+    env['PULSE_PROP'] = 'media.role=music'
     play_cmd = config.get("play_mp3_cmdline")
     play_mp3_cmd = str(play_cmd).split(" ")
     for index, cmd in enumerate(play_mp3_cmd):
         if cmd == "%1":
             play_mp3_cmd[index] = (get_http(uri))
-    return subprocess.Popen(play_mp3_cmd)
+    return subprocess.Popen(play_mp3_cmd, env=env)
 
 
 def play_ogg(uri):
     config = mycroft.configuration.Configuration.get()
+    env = os.environ.copy()
+    env['PULSE_PROP'] = 'media.role=music'
     play_cmd = config.get("play_ogg_cmdline")
     play_ogg_cmd = str(play_cmd).split(" ")
     for index, cmd in enumerate(play_ogg_cmd):
         if cmd == "%1":
             play_ogg_cmd[index] = (get_http(uri))
-    return subprocess.Popen(play_ogg_cmd)
+    return subprocess.Popen(play_ogg_cmd, env=env)
 
 
 def record(file_path, duration, rate, channels):

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -92,7 +92,9 @@ def play_wav(uri):
     config = mycroft.configuration.Configuration.get()
     play_cmd = config.get("play_wav_cmdline")
     env = os.environ.copy()
-    env['PULSE_PROP'] = 'media.role=phone'
+    if config.get('Audio', {}).get('pulseaudio') == 'duck':
+        env['PULSE_PROP'] = 'media.role=phone'
+
     play_wav_cmd = str(play_cmd).split(" ")
     for index, cmd in enumerate(play_wav_cmd):
         if cmd == "%1":
@@ -103,7 +105,9 @@ def play_wav(uri):
 def play_mp3(uri):
     config = mycroft.configuration.Configuration.get()
     env = os.environ.copy()
-    env['PULSE_PROP'] = 'media.role=music'
+    if config.get('Audio', {}).get('pulseaudio') == 'duck':
+        env['PULSE_PROP'] = 'media.role=music'
+
     play_cmd = config.get("play_mp3_cmdline")
     play_mp3_cmd = str(play_cmd).split(" ")
     for index, cmd in enumerate(play_mp3_cmd):

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -22,7 +22,8 @@ from threading import Thread
 from time import sleep
 
 import json
-import os, os.path
+import os
+import os.path
 import psutil
 from stat import S_ISREG, ST_MTIME, ST_MODE, ST_SIZE
 import requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,6 @@ pillow==4.1.1
 python-dateutil==2.6.0
 pychromecast==0.7.7
 python-vlc==1.1.2
-pulsectl==17.7.4
 google-api-python-client==1.6.4
 fasteners==0.14.1
 


### PR DESCRIPTION
## Description
Replaces the current approach of modifying streams on the go with an approach using pulse audio's built in support for audio ducking. This will mute or lower the volume of streams with certain media roles (music and video by default).

To trigger the ducking/corking when mycroft is listening the audioservice launches `paplay` with a dummy input.

## How to test
Load the module-role-ducking:
`pactl load-module module-role-ducking`
Enter the following into your mycroft.conf:
```json
  "Audio": {
    "pulseaudio": true
  }
```

Start up Mycroft and start the npr-news. Why playing say "Hey Mycroft", the news volume should be reduced while mycroft listens. The volume should also be lowered when Mycroft starts speaking.

## Contributor license agreement signed?
CLA [Yes]