### PR TITLE
Fix utterance_remainder for normalized keywords

### DIFF
--- a/mycroft/messagebus/message.py
+++ b/mycroft/messagebus/message.py
@@ -156,7 +156,7 @@ class Message(object):
         Returns:
             str: Leftover words or None if not an utterance.
         """
-        utt = self.data.get("utterance", None)
+        utt = normalize(self.data.get("utterance", ""))
         if utt and "__tags__" in self.data:
             for token in self.data["__tags__"]:
                 utt = utt.replace(token.get("key", ""), "")


### PR DESCRIPTION
## Description
If the sentence is normalized the utterance_remainder() method may fail if
the intent keyword expects normalization.

Example the joking skill has an intent "tell me joke" which is the
normalized equivalent of "tell me a joke". In this case the intent wouldn't be removed from the remainder and instead of an empty string the utterance remainder would contain "tell me joke"

## How to test

## Contributor license agreement signed?
CLA [Yes]