### PR TITLE
Add proper messages when the backend replies incorrectly

### DIFF
--- a/mycroft/identity/__init__.py
+++ b/mycroft/identity/__init__.py
@@ -37,7 +37,7 @@ class IdentityManager(object):
         try:
             with FileSystemAccess('identity').open('identity2.json', 'r') as f:
                 IdentityManager.__identity = DeviceIdentity(**json.load(f))
-        except:
+        except Exception:
             IdentityManager.__identity = DeviceIdentity()
         return IdentityManager.__identity
 

--- a/mycroft/res/text/en-us/backend.down.dialog
+++ b/mycroft/res/text/en-us/backend.down.dialog
@@ -1,0 +1,4 @@
+I'm having trouble communicating with the Mycroft servers. Please give me a few minutes before trying to speak to me.
+I'm having trouble communicating with the Mycroft servers. Please wait few minutes before trying to speak to me.
+It seems I cannot connect to the Mycroft servers. Please give me a few minutes before trying to speak to me.
+It seems I cannot connect to the Mycroft servers. Please wait few minutes before trying to speak to me.

--- a/mycroft/res/text/en-us/not connected to the internet.dialog
+++ b/mycroft/res/text/en-us/not connected to the internet.dialog
@@ -1,4 +1,5 @@
-It seems I'm not connected to the Internet
-I don't seem to be connected to the internet
-I can't reach the internet right now
-I'm unable to reach the internet
+It seems I'm not connected to the Internet, please check your network connection.
+I don't seem to be connected to the internet, please check your network connection.
+I can't reach the internet right now, please check your network connection.
+I'm unable to reach the internet, please check your network connection.
+I'm having trouble reaching the internet right now, please check your network connection.


### PR DESCRIPTION
## Description
This PR notifies the user whether either the backend is down or there is no internet connection on both bootup and when speech to text fails.

## How to test
 - Check if it replies something sensible when either the network is down or the server url is wrong.