### PR TITLE
Wait for messagebus before emitting a message

### DIFF
--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -246,7 +246,6 @@ class Enclosure(object):
 
     def __init__(self):
         self.ws = WebsocketClient()
-        self.ws.on("open", self.on_ws_open)
 
         Configuration.init(self.ws)
 
@@ -258,13 +257,6 @@ class Enclosure(object):
         self.reader = EnclosureReader(self.serial, self.ws, self.lang)
         self.writer = EnclosureWriter(self.serial, self.ws)
 
-        # initiates the web sockets on display manager
-        # NOTE: this is a temporary place to initiate display manager sockets
-        initiate_display_manager_ws()
-
-    def on_ws_open(self, event=None):
-        # Mark 1 auto-detection:
-        #
         # Prepare to receive message when the Arduino responds to the
         # following "system.version"
         self.ws.on("enclosure.started", self.on_arduino_responded)
@@ -280,6 +272,10 @@ class Enclosure(object):
 
         # Notifications from mycroft-core
         self.ws.on("enclosure.notify.no_internet", self.on_no_internet)
+
+        # initiates the web sockets on display manager
+        # NOTE: this is a temporary place to initiate display manager sockets
+        initiate_display_manager_ws()
 
     def on_arduino_responded(self, event=None):
         self.eyes = EnclosureEyes(self.ws, self.writer)

--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -45,6 +45,7 @@ class WebsocketClient(object):
         self.pool = ThreadPool(10)
         self.retry = 5
         self.connected_event = Event()
+        self.started_running = False
 
     @staticmethod
     def build_url(host, port, route, ssl):
@@ -85,10 +86,12 @@ class WebsocketClient(object):
             self.emitter.emit, (parsed_message.type, parsed_message))
 
     def emit(self, message):
-        self.connected_event.wait(10)
-        if (not self.client or not self.client.sock or
-                not self.client.sock.connected):
-            return
+        if not self.connected_event.wait(10):
+            if not self.started_running:
+                raise ValueError('You must execute run_forever() '
+                                 'before emitting messages')
+            self.connected_event.wait()
+
         if hasattr(message, 'serialize'):
             self.client.send(message.serialize())
         else:
@@ -145,6 +148,7 @@ class WebsocketClient(object):
         self.emitter.remove_all_listeners(event_name)
 
     def run_forever(self):
+        self.started_running = True
         self.client.run_forever()
 
     def close(self):

--- a/test/integrationtests/messagebus/messagebus_test.py
+++ b/test/integrationtests/messagebus/messagebus_test.py
@@ -33,6 +33,7 @@ class TestMessagebusMethods(unittest.TestCase):
     It currently only tests send and receive.  The tests could include
     more.
     """
+
     def setUp(self):
         """
         This sets up for testing the message buss
@@ -43,8 +44,6 @@ class TestMessagebusMethods(unittest.TestCase):
         """
         # start the mycroft service. and get the pid of the script.
         self.pid = Popen(["python", "mycroft/messagebus/service/main.py"]).pid
-        # delay to allow the service to start up.
-        time.sleep(10)
         # Create the two web clients
         self.ws1 = WebsocketClient()
         self.ws2 = WebsocketClient()
@@ -54,8 +53,6 @@ class TestMessagebusMethods(unittest.TestCase):
         # Start threads to handle websockets
         Thread(target=self.ws1.run_forever).start()
         Thread(target=self.ws2.run_forever).start()
-        # Sleep to give the websockets to startup before adding handlers
-        time.sleep(10)
         # Setup handlers for each of the messages.
         self.ws1.on('ws1.message', self.onHandle1)
         self.ws2.on('ws2.message', self.onHandle2)
@@ -98,7 +95,7 @@ class TestMessagebusMethods(unittest.TestCase):
         self.ws2.emit(Message('ws1.message'))
         self.ws1.emit(Message('ws2.message'))
         # allow time for messages to be processed
-        time.sleep(10)
+        time.sleep(0.2)
         # Check that both of the handlers were called.
         self.assertTrue(self.handle1)
         self.assertTrue(self.handle2)


### PR DESCRIPTION
## Description
This PR waits for the messagebus connection to open before emitting messages. Previously the behavior was to silently return without sending the message.

## How to test
 - Make sure all functionality is normal
 - Try to send a message right after creating a websocket client and make sure it doesn't eat it up