### PR TITLE
Fix deadlock

### DIFF
--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -59,10 +59,10 @@ class WebsocketClient(object):
 
     def on_open(self, ws):
         LOG.info("Connected")
+        self.connected_event.set()
         self.emitter.emit("open")
         # Restore reconnect timer to 5 seconds on sucessful connect
         self.retry = 5
-        self.connected_event.set()
 
     def on_close(self, ws):
         self.emitter.emit("close")


### PR DESCRIPTION
## Description
The emitted event "open" will in many cases call ws.emit, and this will
lock if the connected_event isn't set. This makes sure that the
connected_event is set before emitting the open event.

## How to test
(Description of how to validate or test this PR)

## Contributor license agreement signed?
CLA [Yes]