### PR TITLE
Load the volume skill before updates

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -95,7 +95,7 @@
     // blacklisted skills to not load
     "blacklisted_skills": ["skill-media", "send_sms", "skill-wolfram-alpha", "spotify-skill"],
     // priority skills to be loaded first
-    "priority_skills": ["skill-pairing"],
+    "priority_skills": ["skill-pairing", "skill-volume"],
     // Minimum time since last skill updata to force an update on startup
     "startup_update_required_time": 12
   },


### PR DESCRIPTION
## Description
Allows the user to adjust the volume during pairing

## How to test
Start up mycroft and assert that the volume skill is loaded before the msm updates start.

## Contributor license agreement signed?
CLA [Yes]