### PR TITLE
Fix msm not updating skills causing it to never finish booting up

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -746,17 +746,10 @@ case ${OPT} in
 
       # Grab any platform-specific skills
       if [[ ${mycroft_platform} != 'null' ]] ; then
-        if [[ ${exit_code} -eq 0 || ${exit_code} -eq 20 ]] ; then
-            install_from_url_list "https://raw.githubusercontent.com/MycroftAI/mycroft-skills/master/DEFAULT-SKILLS.${mycroft_platform}"
-            exit_code=$?
-        fi
+         install_from_url_list "https://raw.githubusercontent.com/MycroftAI/mycroft-skills/master/DEFAULT-SKILLS.${mycroft_platform}" || exit_code=$?
       fi
 
-      # exit code 20 == skills already installed, which is OK here
-      if [[ ${exit_code} -eq 0 || ${exit_code} -eq 20 ]] ; then
-         update
-         exit_code=$?
-      fi
+      update || exit_code=$?
       mv ${mycroft_skill_folder}/.msm.tmp ${mycroft_skill_folder}/.msm
    ;;
   "search")
@@ -810,3 +803,4 @@ if [[ ${exit_code} -gt 0 ]] ; then
    echo "${script}: error ${exit_code}"
 fi
 exit ${exit_code}
+


### PR DESCRIPTION
## Description
Previously, when resetting the device, when reinstalling skills they would not update unless all skill installations succeeded. This doesn't make much sense because a single skill installation failure shouldn't prevent the rest of them from updating.

## How to test
 - Reset device
 - Reboot (should happen automatically)
 - Reconnect to the internet
 - Device shouldn't freeze like it would before
