### PR TITLE
Fix install script for renamed module

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -176,7 +176,7 @@ if [ ! -f "$VENV_PATH_FILE" ] ; then
     echo "import sys; new=sys.path[sys.__plen:]; del sys.path[sys.__plen:]; p=getattr(sys,'__egginsert',0); sys.path[p:p]=new; sys.__egginsert = p+len(new)" >> "$VENV_PATH_FILE" || return 1
 fi
 
-if ! grep -q "mycroft-core" $VENV_PATH_FILE; then
+if ! grep -q "$TOP" $VENV_PATH_FILE; then
    echo "Adding mycroft-core to virtualenv path"
    sed -i.tmp '1 a\
 '"$TOP"'


### PR DESCRIPTION
This fixes a problem where if "mycroft-core" was already in the
virtualenv path file, but the actual name of the module wasn't,
then the dev_setup.sh would succeed but start-mycroft.sh would
fail with "No module named mycroft.version". Now dev_setup.sh
actually checks for the $TOP variable in the virtualenv path,
instead of hardcoded "mycroft-core".

==== Fixed Issues ====
Might fix issue #1419 for some rare cases.

====  Documentation Notes ====
Slightly improves the durability of the install script.

## Description
Makes install script more robust to renamed mycroft-core folders.

## How to test
Make a clean install but clone into a different folder:
`git clone git@github.com:cowang4/mycroft-core.git my-mycroft`
. Then add "mycroft-core" to the virtualenv path, then run dev_setup.sh. The setup should work, but running `start-mycroft.sh debug` you'll get "No module named mycroft.version" because it didn't add "my-mycroft to the path, since it already found "mycroft-core". A more realistic reproduction is with a clone of MycroftAI/mycroft-core, install and run it, then fork it, cloned the fork as my-mycroft, then delete the original mycroft-core, run `my-mycroft/dev_setup.sh` then try to run `my-mycroft/start-mycroft.sh debug`

## Contributor license agreement signed?
CLA [requested] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
