### PR TITLE
Shutdown improvements

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -151,7 +151,6 @@ def init(websocket):
 
 
 def shutdown():
-    global tts
     if tts:
         tts.playback.stop()
         tts.playback.join()

--- a/mycroft/lock/__init__.py
+++ b/mycroft/lock/__init__.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from signal import getsignal, signal, SIGKILL, SIGINT, SIGTERM  # signals
+from signal import getsignal, signal, SIGKILL, SIGINT, SIGTERM, \
+    SIG_DFL, default_int_handler, SIG_IGN  # signals
 
 import os  # Operating System functions
 
@@ -20,16 +21,19 @@ import os  # Operating System functions
 #
 # Wrapper around chain of handler functions for a specific system level signal.
 # Often used to trap Ctrl-C for specific application purposes.
+from mycroft.util import LOG
+
+
 class Signal(object):  # python 3+ class Signal
 
-    '''
+    """
     Capture and replace a signal handler with a user supplied function.
     The user supplied function is always called first then the previous
     handler, if it exists, will be called.  It is possible to chain several
     signal handlers together by creating multiply instances of objects of
     this class, providing a  different user functions for each instance.  All
     provided user functions will be called in LIFO order.
-    '''
+    """
 
     #
     # Constructor
@@ -37,38 +41,40 @@ class Signal(object):  # python 3+ class Signal
     # as the new handler function for this signal
 
     def __init__(self, sig_value, func):
-        '''
+        """
         Create an instance of the signal handler class.
 
         sig_value:  The ID value of the signal to be captured.
         func:  User supplied function that will act as the new signal handler.
-        '''
+        """
         super(Signal, self).__init__()  # python 3+ 'super().__init__()
         self.__sig_value = sig_value
         self.__user_func = func  # store user passed function
-        self.__previous_func = getsignal(sig_value)  # get current handler
-        signal(sig_value, self)
+        self.__previous_func = signal(sig_value, self)
+        self.__previous_func = {  # Convert signal codes to functions
+            SIG_DFL: default_int_handler,
+            SIG_IGN: lambda a, b: None
+        }.get(self.__previous_func, self.__previous_func)
 
     #
     # Called to handle the passed signal
     def __call__(self, signame, sf):
-        '''
+        """
         Allows the instance of this class to be called as a function.
         When called it runs the user supplied signal handler than
         checks to see if there is a previously defined handler.  If
         there is a previously defined handler call it.
-        '''
-        self.__user_func()  # call user function
-        if self.__previous_func:
-            self.__previous_func(signame, sf)
+        """
+        self.__user_func()
+        self.__previous_func(signame, sf)
 
     #
     # reset the signal handler
     def __del__(self):
-        '''
+        """
         Class destructor.  Called during garbage collection.
         Resets the signal handler to the previous function.
-        '''
+        """
         signal(self.__sig_value, self.__previous_func)
 
     # End class Signal
@@ -83,12 +89,12 @@ class Signal(object):  # python 3+ class Signal
 # ------------------------------------------------------------------------------
 class Lock(object):  # python 3+ 'class Lock'
 
-    '''
+    """
     Create and maintains the PID lock file for this application process.
     The PID lock file is located in /tmp/mycroft/*.pid.  If another process
     of the same type is started, this class will 'attempt' to stop the
     previously running process and then change the process ID in the lock file.
-    '''
+    """
 
     #
     # Class constants
@@ -98,13 +104,13 @@ class Lock(object):  # python 3+ 'class Lock'
     #
     # Constructor
     def __init__(self, service):
-        '''
+        """
         Builds the instance of this object.  Holds the lock until the
         object is garbage collected.
 
         service: Text string.  The name of the service application
         to be locked (ie: skills, voice)
-        '''
+        """
         super(Lock, self).__init__()  # python 3+ 'super().__init__()'
         self.__pid = os.getpid()  # PID of this application
         self.path = Lock.DIRECTORY + Lock.FILE.format(service)
@@ -114,11 +120,11 @@ class Lock(object):  # python 3+ 'class Lock'
     #
     # Reset the signal handlers to the 'delete' function
     def set_handlers(self):
-        '''
+        """
         Trap both SIGINT and SIGTERM to gracefully clean up PID files
-        '''
-        self.__handlers = {SIGINT: Signal(SIGINT, self.delete)}
-        self.__handlers = {SIGTERM: Signal(SIGTERM, self.delete)}
+        """
+        self.__handlers = {SIGINT: Signal(SIGINT, self.delete),
+                           SIGTERM: Signal(SIGTERM, self.delete)}
 
     #
     # Check to see if the PID already exists
@@ -126,12 +132,12 @@ class Lock(object):  # python 3+ 'class Lock'
     #    Stop the current process
     #    Delete the exiting file
     def exists(self):
-        '''
+        """
         Check to see if the PID lock file currently exists.  If it does
         than send a SIGTERM signal to the process defined by the value
         in the lock file.  Catch the keyboard interrupt exception to
         prevent propagation if stopped by use of Ctrl-C.
-        '''
+        """
         if not os.path.isfile(self.path):
             return
         with open(self.path, 'r') as L:
@@ -143,11 +149,11 @@ class Lock(object):  # python 3+ 'class Lock'
     #
     # Create a lock file for this server process
     def touch(self):
-        '''
+        """
         If needed, create the '/tmp/mycroft' directory than open the
         lock file for writting and store the current process ID (PID)
         as text.
-        '''
+        """
         if not os.path.exists(Lock.DIRECTORY):
             os.makedirs(Lock.DIRECTORY)
         with open(self.path, 'w') as L:
@@ -156,12 +162,12 @@ class Lock(object):  # python 3+ 'class Lock'
     #
     # Create the PID file
     def create(self):
-        '''
+        """
         Checks to see if a lock file for this service already exists,
         if so have it killed.  In either case write the process ID of
         the current service process to to the existing or newly created
         lock file in /tmp/mycroft/
-        '''
+        """
         self.exists()  # check for current running process
         self.touch()
 
@@ -169,12 +175,12 @@ class Lock(object):  # python 3+ 'class Lock'
     # Delete the PID file - but only if it has not been overwritten
     # by a duplicate service application
     def delete(self, *args):
-        '''
+        """
         If the PID lock file contains the PID of this process delete it.
 
         *args: Ignored.  Required as this fuction is called as a signel
         handler.
-        '''
+        """
         try:
             with open(self.path, 'r') as L:
                 pid = int(L.read())

--- a/mycroft/messagebus/service/main.py
+++ b/mycroft/messagebus/service/main.py
@@ -17,8 +17,8 @@ from tornado import autoreload, web, ioloop
 from mycroft.configuration import Configuration
 from mycroft.lock import Lock  # creates/supports PID locking file
 from mycroft.messagebus.service.ws import WebsocketEventHandler
-from mycroft.util import validate_param
-
+from mycroft.util import validate_param, reset_sigint_handler, create_daemon, \
+    wait_for_exit_signal
 
 settings = {
     'debug': True
@@ -27,6 +27,7 @@ settings = {
 
 def main():
     import tornado.options
+    reset_sigint_handler()
     lock = Lock("service")
     tornado.options.parse_command_line()
 
@@ -50,7 +51,9 @@ def main():
     ]
     application = web.Application(routes, **settings)
     application.listen(port, host)
-    ioloop.IOLoop.instance().start()
+    create_daemon(ioloop.IOLoop.instance().start)
+
+    wait_for_exit_signal()
 
 
 if __name__ == "__main__":

--- a/mycroft/skills/container.py
+++ b/mycroft/skills/container.py
@@ -88,7 +88,7 @@ class SkillContainer(object):
 
     def stop(self):
         if self.skill:
-            self.skill.shutdown()
+            self.skill._shutdown()
 
 
 def main():

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -882,6 +882,11 @@ class MycroftSkill(object):
         process termination. The skill implementation must
         shutdown all processes and operations in execution.
         """
+        pass
+
+    def _shutdown(self):
+        """Parent function called internally to shut down everything"""
+        self.shutdown()
         # Store settings
         self.settings.store()
         self.settings.is_alive = False
@@ -1154,9 +1159,9 @@ class FallbackSkill(MycroftSkill):
             handler = self.instance_fallback_handlers.pop()
             self.remove_fallback(handler)
 
-    def shutdown(self):
+    def _shutdown(self):
         """
             Remove all registered handlers and perform skill shutdown.
         """
         self.remove_instance_handlers()
-        super(FallbackSkill, self).shutdown()
+        super(FallbackSkill, self)._shutdown()

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -910,7 +910,7 @@ class MycroftSkill(object):
             Returns:
                 str: name unique to this skill
         """
-        return str(self.skill_id) + ':' + name
+        return str(self.skill_id) + ':' + (name or '')
 
     def _schedule_event(self, handler, when, data=None, name=None,
                         repeat=None):

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -886,7 +886,11 @@ class MycroftSkill(object):
 
     def _shutdown(self):
         """Parent function called internally to shut down everything"""
-        self.shutdown()
+        try:
+            self.shutdown()
+        except exception as e:
+            LOG.error('Skill specific shutdown function encountered '
+                      'an error: {}'.format(repr(e)))
         # Store settings
         self.settings.store()
         self.settings.is_alive = False

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -378,7 +378,7 @@ class SkillManager(Thread):
             LOG.debug("Reloading Skill: " + skill_folder)
             # removing listeners and stopping threads
             try:
-                skill["instance"].shutdown()
+                skill["instance"]._shutdown()
             except Exception:
                 LOG.exception("An error occured while shutting down {}"
                               .format(skill["instance"].name))
@@ -503,7 +503,7 @@ class SkillManager(Thread):
             instance = skill_info.get('instance')
             if instance:
                 try:
-                    instance.shutdown()
+                    instance._shutdown()
                 except Exception:
                     LOG.exception('Shutting down skill: ' + name)
 

--- a/stop-mycroft.sh
+++ b/stop-mycroft.sh
@@ -53,7 +53,7 @@ function end-process() {
 
     if process-running $1 ; then
         pid=$( ps aux | grep "[p]ython .*${1}/main.py" | awk '{print $2}' )
-        kill ${pid}
+        kill -SIGINT ${pid}
 
         c=1
         while [ $c -le 20 ]
@@ -67,6 +67,7 @@ function end-process() {
         done
 
         if process-running $1 ; then
+            echo "Killing $1..."
             kill -9 ${pid}
         fi
     fi

--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -61,7 +61,7 @@ def load_skills(emitter, skills_root):
 
 def unload_skills(skills):
     for s in skills:
-        s.shutdown()
+        s._shutdown()
 
 
 class RegistrationOnlyEmitter(object):


### PR DESCRIPTION
## Description
This cleans up the shutdown process so that skill shutdown methods are called properly. It is now no longer necessary to call `MycroftSkill.shutdown` from within skill shutdown methods. Other notable changes include:
 - `create_daemon` method used to clean up create daemon threads
 - `create_echo_function` used to reduce code duplication with messagebus
 echo functions
 - `wait_for_exit_signal` used to wait for ctrl+c (SIGINT)
 - `reset_sigint_handler` used to ensure SIGINT will raise `KeyboardInterrupt`

## How to test
Start and stop all services. Make sure each process both shuts down properly and doesn't consistently have to kill the services (there is a new message to show when this happens)