### PR TITLE
Feature/api etags

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -79,6 +79,16 @@ class Api(object):
         IdentityManager.save(data)
 
     def send(self, params):
+        """ Send request to mycroft backend.
+        The method handles Etags and will return a cached response value
+        if nothing has changed on the remote.
+
+        Arguments:
+            params (dict): request parameters
+
+        Returns:
+            Requests response object.
+        """
         query_data = frozenset(params.get('query', {}).items())
         params_key = (params.get('path'), query_data)
         etag = self.params_to_etag.get(params_key)
@@ -90,6 +100,8 @@ class Api(object):
         query = self.build_query(params)
         url = self.build_url(params)
 
+        # For an introduction to the Etag feature check out:
+        # https://en.wikipedia.org/wiki/HTTP_ETag
         if etag:
             headers['If-None-Match'] = etag
 


### PR DESCRIPTION
## Description
This adds support for html ETags which decrease the bandwidth of requests by replying with an empty response when the request contains the same content as it did before.

## How to test
 - Make sure the config and skill settings still update properly on the production servers
 - Switch the `server.url` config value to `https://api-test.mycroft.ai` and test if settings and skill settings still works
 - Verify etags update the first time and the say the settings haven't changed subsequent times in the logs
Tip: Decrease polling seconds in `mycroft/skills/settings.py:399`