### PR TITLE
Default skill config to empty dict

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -210,7 +210,7 @@ class MycroftSkill(object):
 
         self.bind(emitter)
         self.config_core = Configuration.get()
-        self.config = self.config_core.get(self.name)
+        self.config = self.config_core.get(self.name) or {}
         self.dialog_renderer = None
         self.vocab_dir = None
         self.root_dir = None


### PR DESCRIPTION
This defaults skill's configs to an empty dict instead of None,
which simplifies getting specific values in the config for skills.
It removes the check for None config.

==== Fixed Issues ====
#1044 

====  Documentation Notes ====
Skill writers no longer need to check for None configs.
So, instead of checking
```python
if not self.config:
    val = self.config.get('key')
```
you can now just write:
```python
val = self.config.get('key')
```
and if config is empty, your val will be None, without the `if` check.

## Description
fixes #1044 

## How to test
Test that your existing skills still work with no config values. Or confirm that
```python
#Old
config = None
if not config:
    print "Used to print here"
#New
config = {}
if not config:
    print "This still works"
```

## Contributor license agreement signed?
CLA [yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
