### PR TITLE
Fix error code 20 when doing msm default

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -749,6 +749,12 @@ case ${OPT} in
          install_from_url_list "https://raw.githubusercontent.com/MycroftAI/mycroft-skills/master/DEFAULT-SKILLS.${mycroft_platform}" || exit_code=$?
       fi
 
+      # Suppress error 20 (skill exists) since this is an expected error
+      # when doing `msm default`
+      if [ ${exit_code} == 20 ]; then
+         exit_code=0
+      fi
+
       update || exit_code=$?
       mv ${mycroft_skill_folder}/.msm.tmp ${mycroft_skill_folder}/.msm
    ;;


### PR DESCRIPTION
## Description
When running `msm default` the expected error code 20 (skill is already
installed) is always reported (unless the skills directory is empty).
This commit supressess that error to not confuse any users.

Thanks to merspieler for reporting the issue.

## How to test
run `./msm/msm default` and verify that the script doesn't return `Error 20`

## Contributor license agreement signed?
CLA [Yes]