### PR TITLE
Skill settings improvements

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -395,8 +395,8 @@ class SkillSettings(dict):
 
         # this is used in core so do not delete!
         if self.is_alive:
-            # continues to poll settings every 5 minutes
-            t = Timer(300, self._poll_skill_settings)
+            # continues to poll settings every minute
+            t = Timer(60, self._poll_skill_settings)
             t.daemon = True
             t.start()
 


### PR DESCRIPTION
## Description
 - Support triggering skill settings update via a message
 - Decrease polling to 60 seconds now the etag support reduced the load on the servers

## How to test
 - Check if the initial skill settings download
 - Manually trigger skill settings update via `workon mycroft; python mycroft/messagebus/send.py "mycroft.skills.settings.update"`
 - Ensure after 1 minute each skill still only updates once