### PR TITLE
Clean up the core method tests

### DIFF
--- a/test/unittests/skills/core.py
+++ b/test/unittests/skills/core.py
@@ -231,7 +231,7 @@ class MycroftSkillTest(unittest.TestCase):
 
     def test_register_intent(self):
         # Test register Intent object
-        s = TestSkill1()
+        s = SimpleSkill1()
         s.bind(self.emitter)
         s.initialize()
         expected = [{'at_least_one': [],
@@ -241,7 +241,7 @@ class MycroftSkillTest(unittest.TestCase):
         self.check_register_intent(expected)
 
         # Test register IntentBuilder object
-        s = TestSkill2()
+        s = SimpleSkill2()
         s.bind(self.emitter)
         s.initialize()
         expected = [{'at_least_one': [],
@@ -253,14 +253,14 @@ class MycroftSkillTest(unittest.TestCase):
 
         # Test register IntentBuilder object
         with self.assertRaises(ValueError):
-            s = TestSkill3()
+            s = SimpleSkill3()
             s.bind(self.emitter)
             s.initialize()
 
     def test_enable_disable_intent(self):
         """Test disable/enable intent."""
         # Setup basic test
-        s = TestSkill1()
+        s = SimpleSkill1()
         s.bind(self.emitter)
         s.initialize()
         expected = [{'at_least_one': [],
@@ -278,7 +278,7 @@ class MycroftSkillTest(unittest.TestCase):
     def test_register_vocab(self):
         """Test disable/enable intent."""
         # Setup basic test
-        s = TestSkill1()
+        s = SimpleSkill1()
         s.bind(self.emitter)
         s.initialize()
 
@@ -300,7 +300,7 @@ class MycroftSkillTest(unittest.TestCase):
         self.emitter.reset()
 
     def test_register_intent_file(self):
-        s = TestSkill4()
+        s = SimpleSkill4()
         s.bind(self.emitter)
         s.vocab_dir = join(dirname(__file__), 'intent_file')
         s.initialize()
@@ -334,8 +334,8 @@ class MycroftSkillTest(unittest.TestCase):
         """ Test decorated intents """
         path_orig = sys.path
         sys.path.append(abspath(dirname(__file__)))
-        TestSkill5 = __import__('decorator_test_skill').TestSkill
-        s = TestSkill5()
+        SimpleSkill5 = __import__('decorator_test_skill').TestSkill
+        s = SimpleSkill5()
         s.vocab_dir = join(dirname(__file__), 'intent_file')
         s.bind(self.emitter)
         s.initialize()
@@ -352,7 +352,7 @@ class MycroftSkillTest(unittest.TestCase):
         self.check_register_decorators(expected)
 
     def test_failing_set_context(self):
-        s = TestSkill1()
+        s = SimpleSkill1()
         s.bind(self.emitter)
         with self.assertRaises(ValueError):
             s.set_context(1)
@@ -369,7 +369,7 @@ class MycroftSkillTest(unittest.TestCase):
                               sorted(result_list))
             self.emitter.reset()
 
-        s = TestSkill1()
+        s = SimpleSkill1()
         s.bind(self.emitter)
         # No context content
         s.set_context('TurtlePower')
@@ -389,7 +389,7 @@ class MycroftSkillTest(unittest.TestCase):
         self.emitter.reset()
 
     def test_failing_remove_context(self):
-        s = TestSkill1()
+        s = SimpleSkill1()
         s.bind(self.emitter)
         with self.assertRaises(ValueError):
             s.remove_context(1)
@@ -402,7 +402,7 @@ class MycroftSkillTest(unittest.TestCase):
                               sorted(result_list))
             self.emitter.reset()
 
-        s = TestSkill1()
+        s = SimpleSkill1()
         s.bind(self.emitter)
         s.remove_context('Donatello')
         expected = [{'context': 'Donatello'}]
@@ -410,7 +410,7 @@ class MycroftSkillTest(unittest.TestCase):
 
     @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_skill_location(self):
-        s = TestSkill1()
+        s = SimpleSkill1()
         self.assertEqual(s.location, BASE_CONF.get('location'))
         self.assertEqual(s.location_pretty,
                          BASE_CONF['location']['city']['name'])
@@ -420,7 +420,7 @@ class MycroftSkillTest(unittest.TestCase):
     @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_add_event(self):
         emitter = mock.MagicMock()
-        s = TestSkill1()
+        s = SimpleSkill1()
         s.bind(emitter)
         s.add_event('handler1', s.handler)
         # Check that the handler was registered with the emitter
@@ -431,7 +431,7 @@ class MycroftSkillTest(unittest.TestCase):
     @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_remove_event(self):
         emitter = mock.MagicMock()
-        s = TestSkill1()
+        s = SimpleSkill1()
         s.bind(emitter)
         s.add_event('handler1', s.handler)
         self.assertTrue('handler1' in zip(*s.events)[0])
@@ -445,7 +445,7 @@ class MycroftSkillTest(unittest.TestCase):
     @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_add_scheduled_event(self):
         emitter = mock.MagicMock()
-        s = TestSkill1()
+        s = SimpleSkill1()
         s.bind(emitter)
         s.schedule_event(s.handler, datetime.now(), name='sched_handler1')
         # Check that the handler was registered with the emitter
@@ -455,7 +455,7 @@ class MycroftSkillTest(unittest.TestCase):
     @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_remove_scheduled_event(self):
         emitter = mock.MagicMock()
-        s = TestSkill1()
+        s = SimpleSkill1()
         s.bind(emitter)
         s.schedule_event(s.handler, datetime.now(), name='sched_handler1')
         # Check that the handler was registered with the emitter
@@ -468,7 +468,7 @@ class MycroftSkillTest(unittest.TestCase):
     @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_run_scheduled_event(self):
         emitter = mock.MagicMock()
-        s = TestSkill1()
+        s = SimpleSkill1()
         with mock.patch.object(s, '_settings',
                                create=True, value=mock.MagicMock()):
             s.bind(emitter)
@@ -482,9 +482,9 @@ class MycroftSkillTest(unittest.TestCase):
             self.assertTrue('0:sched_handler1' not in zip(*s.events)[0])
 
 
-class TestSkill1(MycroftSkill):
+class SimpleSkill1(MycroftSkill):
     def __init__(self):
-        super(TestSkill1, self).__init__()
+        super(SimpleSkill1, self).__init__()
         self.handler_run = False
 
     """ Test skill for normal intent builder syntax """
@@ -499,7 +499,7 @@ class TestSkill1(MycroftSkill):
         pass
 
 
-class TestSkill2(MycroftSkill):
+class SimpleSkill2(MycroftSkill):
     """ Test skill for intent builder without .build() """
     def initialize(self):
         i = IntentBuilder('a').require('Keyword')
@@ -512,7 +512,7 @@ class TestSkill2(MycroftSkill):
         pass
 
 
-class TestSkill3(MycroftSkill):
+class SimpleSkill3(MycroftSkill):
     """ Test skill for invalid Intent for register_intent """
     def initialize(self):
         self.register_intent('string', self.handler)
@@ -524,7 +524,7 @@ class TestSkill3(MycroftSkill):
         pass
 
 
-class TestSkill4(MycroftSkill):
+class SimpleSkill4(MycroftSkill):
     """ Test skill for padatious intent """
     def initialize(self):
         self.register_intent_file('test.intent', self.handler)


### PR DESCRIPTION
## Description
Use a single complete config file as config mock and mock.patch.dict to mock it. Also cleans up a couple of warnings when using pytest to run the tests.

Tested to resolve testing issues in #1528

## How to test
Make sure travis tests still work.

## Contributor license agreement signed?
CLA [Yes]