### PR TITLE
Feature: Allow comments in voc and regex files

### DIFF
--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -37,6 +37,8 @@ def load_vocab_from_file(path, vocab_type, emitter):
     if path.endswith('.voc'):
         with open(path, 'r') as voc_file:
             for line in voc_file.readlines():
+                if line.startswith("#"):
+                    continue
                 parts = line.strip().split("|")
                 entity = parts[0]
                 emitter.emit(Message("register_vocab", {
@@ -59,6 +61,8 @@ def load_regex_from_file(path, emitter, skill_id):
     if path.endswith('.rx'):
         with open(path, 'r') as reg_file:
             for line in reg_file.readlines():
+                if line.startswith("#"):
+                    continue
                 re.compile(munge_regex(line.strip(), skill_id))
                 emitter.emit(
                     Message("register_vocab",


### PR DESCRIPTION
When loading voc and regex files, lines starting with "#" are now
ignored, so developers and translators can use them to document their
decisions.

Fixes #1531 

## How to test
Use a comment (line starting with "#") in a voc file.

## Contributor license agreement signed?
CLA [x]
