### PR TITLE
Add SSML support for TTS

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -114,7 +114,7 @@ def mute_and_speak(utterance, ident):
 
     LOG.info("Speak: " + utterance)
     try:
-        tts.validate_and_execute(utterance, ident)
+        tts.execute(utterance, ident)
     finally:
         lock.release()
 

--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -113,7 +113,10 @@ def mute_and_speak(utterance, ident):
         tts_hash = hash(str(config.get('tts', '')))
 
     LOG.info("Speak: " + utterance)
-    tts.execute(utterance, ident)
+    try:
+        tts.validate_and_execute(utterance, ident)
+    finally:
+        lock.release()
 
 
 def handle_stop(event):

--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import time
 import re
-
+import time
 from threading import Lock
+
 from mycroft.configuration import Configuration
+from mycroft.metrics import report_timing, Stopwatch
 from mycroft.tts import TTSFactory
 from mycroft.util import create_signal, check_for_signal
 from mycroft.util.log import LOG
-from mycroft.metrics import report_timing, Stopwatch
 
 ws = None  # TODO:18.02 - Rename to "messagebus"
 config = None
@@ -69,7 +69,8 @@ def handle_speak(event):
         #
         # TODO: Remove or make an option?  This is really a hack, anyway,
         # so we likely will want to get rid of this when not running on Mimic
-        if not config.get('enclosure', {}).get('platform') == "picroft":
+        if (config.get('enclosure', {}).get('platform') != "picroft" and
+                len(re.findall('<[^>]*>', utterance)) == 0):
             start = time.time()
             chunks = re.split(r'(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?)\s',
                               utterance)

--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -16,6 +16,8 @@ from __future__ import print_function
 import sys
 import io
 
+from mycroft.tts import TTS
+
 
 def custom_except_hook(exctype, value, traceback):           # noqa
     print(sys.stdout.getvalue(), file=sys.__stdout__)        # noqa
@@ -351,6 +353,7 @@ def rebuild_filtered_log():
 def handle_speak(event):
     global chat
     utterance = event.data.get('utterance')
+    utterance = TTS.remove_ssml(utterance)
     if bSimple:
         print(">> " + utterance)
     else:

--- a/mycroft/tts/bing_tts.py
+++ b/mycroft/tts/bing_tts.py
@@ -18,8 +18,8 @@ from mycroft.configuration import Configuration
 
 
 class BingTTS(TTS):
-    def __init__(self, lang, voice):
-        super(BingTTS, self).__init__(lang, voice, BingTTSValidator(self))
+    def __init__(self, lang, config):
+        super(BingTTS, self).__init__(lang, config, BingTTSValidator(self))
         self.type = 'wav'
         from bingtts import Translator
         self.config = Configuration.get().get("tts", {}).get("bing", {})

--- a/mycroft/tts/espeak_tts.py
+++ b/mycroft/tts/espeak_tts.py
@@ -18,8 +18,8 @@ from mycroft.tts import TTS, TTSValidator
 
 
 class ESpeak(TTS):
-    def __init__(self, lang, voice):
-        super(ESpeak, self).__init__(lang, voice, ESpeakValidator(self))
+    def __init__(self, lang, config):
+        super(ESpeak, self).__init__(lang, config, ESpeakValidator(self))
 
     def execute(self, sentence, ident=None):
         self.begin_audio()

--- a/mycroft/tts/fa_tts.py
+++ b/mycroft/tts/fa_tts.py
@@ -28,8 +28,8 @@ class FATTS(RemoteTTS):
         'output[type]': 'AUDIO'
     }
 
-    def __init__(self, lang, voice, url):
-        super(FATTS, self).__init__(lang, voice, url, '/say',
+    def __init__(self, lang, config):
+        super(FATTS, self).__init__(lang, config, '/say',
                                     FATTSValidator(self))
 
     def build_request_params(self, sentence):

--- a/mycroft/tts/google_tts.py
+++ b/mycroft/tts/google_tts.py
@@ -18,8 +18,9 @@ from mycroft.tts import TTS, TTSValidator
 
 
 class GoogleTTS(TTS):
-    def __init__(self, lang, voice):
-        super(GoogleTTS, self).__init__(lang, voice, GoogleTTSValidator(self))
+    def __init__(self, lang, config):
+        super(GoogleTTS, self).__init__(lang, config, GoogleTTSValidator(
+            self))
         self.type = 'mp3'
 
     def get_tts(self, sentence, wav_file):

--- a/mycroft/tts/ibm_tts.py
+++ b/mycroft/tts/ibm_tts.py
@@ -27,7 +27,6 @@ class WatsonTTS(RemoteTTS):
         super(WatsonTTS, self).__init__(lang, config, url, '/v1/synthesize',
                                         WatsonTTSValidator(self))
         self.type = "wav"
-        self.config = Configuration.get().get("tts", {}).get("watson", {})
         user = self.config.get("user") or self.config.get("username")
         password = self.config.get("password")
         self.auth = HTTPBasicAuth(user, password)

--- a/mycroft/tts/ibm_tts.py
+++ b/mycroft/tts/ibm_tts.py
@@ -22,9 +22,9 @@ from requests.auth import HTTPBasicAuth
 class WatsonTTS(RemoteTTS):
     PARAMS = {'accept': 'audio/wav'}
 
-    def __init__(self, lang, voice="en-US_AllisonVoice",
+    def __init__(self, lang, config,
                  url="https://stream.watsonplatform.net/text-to-speech/api"):
-        super(WatsonTTS, self).__init__(lang, voice, url, '/v1/synthesize',
+        super(WatsonTTS, self).__init__(lang, config, url, '/v1/synthesize',
                                         WatsonTTSValidator(self))
         self.type = "wav"
         self.config = Configuration.get().get("tts", {}).get("watson", {})

--- a/mycroft/tts/mary_tts.py
+++ b/mycroft/tts/mary_tts.py
@@ -28,8 +28,8 @@ class MaryTTS(RemoteTTS):
         'OUTPUT_TYPE': 'AUDIO'
     }
 
-    def __init__(self, lang, voice, url):
-        super(MaryTTS, self).__init__(lang, voice, url, '/process',
+    def __init__(self, lang, config):
+        super(MaryTTS, self).__init__(lang, config, '/process',
                                       MaryTTSValidator(self))
 
     def build_request_params(self, sentence):

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -85,11 +85,13 @@ def download_subscriber_voices(selected_voice):
 
 
 class Mimic(TTS):
-    def __init__(self, lang, voice):
-        super(Mimic, self).__init__(lang, voice, MimicValidator(self))
+    def __init__(self, lang, config):
+        super(Mimic, self).__init__(lang, config, MimicValidator(self))
         self.dl = None
         self.clear_cache()
         self.type = 'wav'
+        self.extra_tags = ["voice", "emphasis", "audio", "sub", "ssml"]
+
         # Download subscriber voices if needed
         self.is_subscriber = DeviceApi().is_subscriber
         if self.is_subscriber:
@@ -115,6 +117,10 @@ class Mimic(TTS):
             voice = self.voice
 
         args = [mimic_bin, '-voice', voice, '-psdur']
+
+        if self.ssml_support:
+            args += ['-ssml']
+
         stretch = config.get('duration_stretch', None)
         if stretch:
             args += ['--setf', 'duration_stretch=' + stretch]

--- a/mycroft/tts/remote_tts.py
+++ b/mycroft/tts/remote_tts.py
@@ -29,8 +29,8 @@ class RemoteTTS(TTS):
     whole sentence into small ones.
     """
 
-    def __init__(self, lang, voice, url, api_path, validator):
-        super(RemoteTTS, self).__init__(lang, voice, validator)
+    def __init__(self, lang, config, url, api_path, validator):
+        super(RemoteTTS, self).__init__(lang, config, validator)
         self.api_path = api_path
         self.auth = None
         self.url = remove_last_slash(url)

--- a/mycroft/tts/spdsay_tts.py
+++ b/mycroft/tts/spdsay_tts.py
@@ -18,8 +18,8 @@ from mycroft.tts import TTS, TTSValidator
 
 
 class SpdSay(TTS):
-    def __init__(self, lang, voice):
-        super(SpdSay, self).__init__(lang, voice, SpdSayValidator(self))
+    def __init__(self, lang, config):
+        super(SpdSay, self).__init__(lang, config, SpdSayValidator(self))
 
     def execute(self, sentence, ident=None):
         self.begin_audio()

--- a/test/unittests/tts/test_stt.py
+++ b/test/unittests/tts/test_stt.py
@@ -1,0 +1,68 @@
+import unittest
+import mycroft.tts
+
+
+class TestSTT(unittest.TestCase):
+    def test_ssml_support(self):
+        class TestTTS(mycroft.tts.TTS):
+            def execute(self, audio, language=None):
+                pass
+
+        class TestTTSValidator(mycroft.tts.TTSValidator):
+            def validate(self):
+                pass
+
+        sentence = "<speak>Prosody can be used to change the way words " \
+                   "sound. The following words are " \
+                   "<prosody volume='x-loud'> " \
+                   "quite a bit louder than the rest of this passage. " \
+                   "</prosody> Each morning when I wake up, " \
+                   "<prosody rate='x-slow'>I speak quite slowly and " \
+                   "deliberately until I have my coffee.</prosody> I can " \
+                   "also change the pitch of my voice using prosody. " \
+                   "Do you like <prosody pitch='+5%'> speech with a pitch " \
+                   "that is higher, </prosody> or <prosody pitch='-10%'> " \
+                   "is a lower pitch preferable?</prosody></speak>"
+        sentence_no_ssml = "Prosody can be used to change the way " \
+                           "words sound. The following words are quite " \
+                           "a bit louder than the rest of this passage. " \
+                           "Each morning when I wake up, I speak quite " \
+                           "slowly and deliberately until I have my " \
+                           "coffee. I can also change the pitch of my " \
+                           "voice using prosody. Do you like speech " \
+                           "with a pitch that is higher, or is " \
+                           "a lower pitch preferable?"
+        sentence_bad_ssml = "<foo_invalid>" + sentence + \
+                            "</foo_invalid end=whatever>"
+        sentence_extra_ssml = "<whispered>whisper tts<\whispered>"
+
+        # test valid ssml
+        test_config = {'voice': 'test_voice', 'ssml': True}
+        tts = TestTTS("en-US", test_config, TestTTSValidator(None))
+        self.assertEqual(tts.validate_ssml(sentence), sentence)
+
+        # test extra ssml
+        test_config = {'voice': 'test_voice', 'ssml': True,
+                       "extra_tags": ["whispered"]}
+        tts = TestTTS("en-US", test_config, TestTTSValidator(None))
+        self.assertEqual(tts.validate_ssml(sentence_extra_ssml),
+                         sentence_extra_ssml)
+
+        # test unsupported extra ssml
+        test_config = {'voice': 'test_voice', 'ssml': True}
+        tts = TestTTS("en-US", test_config, TestTTSValidator(None))
+        self.assertEqual(tts.validate_ssml(sentence_extra_ssml), "whisper "
+                                                                 "tts")
+
+        # test mixed valid / invalid ssml
+        test_config = {'voice': 'test_voice', 'ssml': True}
+        tts = TestTTS("en-US", test_config, TestTTSValidator(None))
+        self.assertEqual(tts.validate_ssml(sentence_bad_ssml), sentence)
+
+        # test unsupported ssml
+        test_config = {'voice': 'test_voice', 'ssml': False}
+        tts = TestTTS("en-US", test_config, TestTTSValidator(None))
+        self.assertEqual(tts.validate_ssml(sentence), sentence_no_ssml)
+
+        self.assertEqual(tts.validate_ssml(sentence_bad_ssml),
+                         sentence_no_ssml)

--- a/test/unittests/tts/test_tts.py
+++ b/test/unittests/tts/test_tts.py
@@ -1,16 +1,26 @@
 import unittest
+
 import mycroft.tts
 
 
-class TestSTT(unittest.TestCase):
+class TestTTS(unittest.TestCase):
     def test_ssml_support(self):
         class TestTTS(mycroft.tts.TTS):
-            def execute(self, audio, language=None):
+            def execute(self, sentence, ident=None):
                 pass
 
         class TestTTSValidator(mycroft.tts.TTSValidator):
             def validate(self):
                 pass
+
+            def validate_lang(self):
+                pass
+
+            def validate_connection(self):
+                pass
+
+            def get_tts_class(self):
+                return TestTTS
 
         sentence = "<speak>Prosody can be used to change the way words " \
                    "sound. The following words are " \
@@ -37,32 +47,33 @@ class TestSTT(unittest.TestCase):
         sentence_extra_ssml = "<whispered>whisper tts<\whispered>"
 
         # test valid ssml
-        test_config = {'voice': 'test_voice', 'ssml': True}
-        tts = TestTTS("en-US", test_config, TestTTSValidator(None))
+        tts = TestTTS("en-US", {}, TestTTSValidator(None),
+                      ssml_tags=['speak', 'prosody'])
         self.assertEqual(tts.validate_ssml(sentence), sentence)
 
         # test extra ssml
-        test_config = {'voice': 'test_voice', 'ssml': True,
-                       "extra_tags": ["whispered"]}
-        tts = TestTTS("en-US", test_config, TestTTSValidator(None))
+        tts = TestTTS("en-US", {}, TestTTSValidator(None),
+                      ssml_tags=['whispered'])
         self.assertEqual(tts.validate_ssml(sentence_extra_ssml),
                          sentence_extra_ssml)
 
         # test unsupported extra ssml
-        test_config = {'voice': 'test_voice', 'ssml': True}
-        tts = TestTTS("en-US", test_config, TestTTSValidator(None))
-        self.assertEqual(tts.validate_ssml(sentence_extra_ssml), "whisper "
-                                                                 "tts")
+        tts = TestTTS("en-US", {}, TestTTSValidator(None),
+                      ssml_tags=['speak', 'prosody'])
+        self.assertEqual(tts.validate_ssml(sentence_extra_ssml),
+                         "whisper tts")
 
         # test mixed valid / invalid ssml
-        test_config = {'voice': 'test_voice', 'ssml': True}
-        tts = TestTTS("en-US", test_config, TestTTSValidator(None))
+        tts = TestTTS("en-US", {}, TestTTSValidator(None),
+                      ssml_tags=['speak', 'prosody'])
         self.assertEqual(tts.validate_ssml(sentence_bad_ssml), sentence)
 
         # test unsupported ssml
-        test_config = {'voice': 'test_voice', 'ssml': False}
-        tts = TestTTS("en-US", test_config, TestTTSValidator(None))
+        tts = TestTTS("en-US", {}, TestTTSValidator(None))
         self.assertEqual(tts.validate_ssml(sentence), sentence_no_ssml)
 
         self.assertEqual(tts.validate_ssml(sentence_bad_ssml),
+                         sentence_no_ssml)
+
+        self.assertEqual(mycroft.tts.TTS.remove_ssml(sentence),
                          sentence_no_ssml)


### PR DESCRIPTION
## Description
This brings in @JarbasAI's SSML support PR. Here's the original description:
> some TTS engines support SSML to modulate speech
> - make TTS Factory pass config to Engine
> - add method validate_ssml to TTS, checks for SSML, if current TTS does not support SSML remove all ssml tags (regex)
> - if current TTS supports SSML, check if it supports all tags, remove invalid ones
> - validate ssml in audio service before calling execute()

Additional changes are:
 - Parameter to TTS class used to specify supported SSML tags

## How to test
Add a `self.speak` to something like the hello world skill and make sure the following works:
```xml
<speak>Each morning when I wake up, <prosody rate='x-slow'>I speak quite slowly and deliberately until I have my coffee.</prosody></speak>
```
Also, make sure other TTS engines still work due to the constructor changes.
