### PR TITLE
Fix google tts playing audio

### DIFF
--- a/mycroft/tts/google_tts.py
+++ b/mycroft/tts/google_tts.py
@@ -20,8 +20,7 @@ from mycroft.tts import TTS, TTSValidator
 class GoogleTTS(TTS):
     def __init__(self, lang, config):
         super(GoogleTTS, self).__init__(lang, config, GoogleTTSValidator(
-            self))
-        self.type = 'mp3'
+            self), 'mp3')
 
     def get_tts(self, sentence, wav_file):
         tts = gTTS(sentence, self.lang)


### PR DESCRIPTION
## Description
The file extention of the audio was not set properly in the google_tts causing it to fail to playback the synthezised audio.

Big thanks to @livey0u for helping to identify the problem!

## How to test
Add the following block to the mycroft.conf
```json

  "tts": {
    "module": "google"
  }
```
and restart the audio process. Verify that the TTS is not mimic and is working as expected

## Contributor license agreement signed?
CLA [Yes]