### PR TITLE
add try catch for failed remote fetch location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ scripts/*.screen
 doc/_build/
 .installed
 .mypy_cache
+.vscode
 
 # Created by unit tests
 test/unittests/skills/test_skill/settings.json

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -164,7 +164,14 @@ class RemoteConf(LocalConf):
             from mycroft.api import DeviceApi
             api = DeviceApi()
             setting = api.get_settings()
-            location = api.get_location()
+
+            try:
+                location = api.get_location()
+            except HTTPError as e:
+                LOG.error("RequestException fetching remote location: %s" %
+                          e.response.status_code)
+                location = load_commented_json(cache).get('location')
+
             if location:
                 setting["location"] = location
             # Remove server specific entries

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -18,7 +18,7 @@ import re
 import json
 import inflection
 from os.path import exists, isfile, join, dirname, expanduser
-from requests import HTTPError
+from requests import RequestException
 
 from mycroft.util.json_helper import load_commented_json
 from mycroft.util.log import LOG
@@ -167,7 +167,7 @@ class RemoteConf(LocalConf):
 
             try:
                 location = api.get_location()
-            except HTTPError as e:
+            except RequestException as e:
                 LOG.error("RequestException fetching remote location: %s" %
                           e.response.status_code)
                 location = load_commented_json(cache).get('location')
@@ -181,7 +181,7 @@ class RemoteConf(LocalConf):
                 self.__setitem__(key, config[key])
             self.store(cache)
 
-        except HTTPError as e:
+        except RequestException as e:
             LOG.error("RequestException fetching remote configuration: %s" %
                       e.response.status_code)
             self.load_local(cache)

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -164,7 +164,7 @@ class RemoteConf(LocalConf):
             from mycroft.api import DeviceApi
             api = DeviceApi()
             setting = api.get_settings()
-            LOG.info("tsttinnng")
+
             try:
                 location = api.get_location()
             except RequestException as e:

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -164,12 +164,12 @@ class RemoteConf(LocalConf):
             from mycroft.api import DeviceApi
             api = DeviceApi()
             setting = api.get_settings()
-
+            LOG.info("tsttinnng")
             try:
                 location = api.get_location()
             except RequestException as e:
-                LOG.error("RequestException fetching remote location: %s" %
-                          e.response.status_code)
+                LOG.error("RequestException fetching remote location: {}"
+                          .format(str(e)))
                 location = load_commented_json(cache).get('location')
 
             if location:
@@ -182,8 +182,8 @@ class RemoteConf(LocalConf):
             self.store(cache)
 
         except RequestException as e:
-            LOG.error("RequestException fetching remote configuration: %s" %
-                      e.response.status_code)
+            LOG.error("RequestException fetching remote configuration: {}"
+                      .format(str(e)))
             self.load_local(cache)
 
         except Exception as e:


### PR DESCRIPTION
## Description
Fixes issue where failed API call to location services will default to load all cache settings only. Now configuration will still be updated with new settings if location service is failing. 

## How to test
pull down the branch and start Mycroft. Force a HTTPError raise in the try catch block and cached location should load. 

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
