### PR TITLE
Remove numbers before skill names when listing

### DIFF
--- a/msm/msm
+++ b/msm/msm
@@ -116,7 +116,7 @@ function fetch_skill_info() {
 
 # Return newline separated names of skills
 function get_skill_names() {
-  echo "${LIST_CACHE}" | grep -n 'submodule' | sed 's/[[:space:]]//g' | sed 's/\[submodule"//g' | sed 's/"\]//g'
+  echo "${LIST_CACHE}" | grep 'submodule' | sed 's/[[:space:]]//g' | sed 's/\[submodule"//g' | sed 's/"\]//g'
 }
 
 function get_skill_repo() {


### PR DESCRIPTION
## Description
This commit removes extra numbers prepended by "msm list"

Example of previous output:
`64:mycroft-release-test`

This prevents skill-installer from installing skills

## How to test
Make sure msm list produces a normal output.

## Contributor license agreement signed?
CLA [Yes]