### PR TITLE
keep message context

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -589,7 +589,7 @@ class MycroftSkill(object):
                 if handler_info:
                     # Indicate that the skill handler is starting if requested
                     msg_type = handler_info + '.start'
-                    self.emitter.emit(Message(msg_type, skill_data))
+                    self.emitter.emit(message.reply(msg_type, skill_data))
 
                 with stopwatch:
                     if len(signature(handler).parameters) == 0:
@@ -614,7 +614,7 @@ class MycroftSkill(object):
                 # Indicate that the skill handler has completed
                 if handler_info:
                     msg_type = handler_info + '.complete'
-                    self.emitter.emit(Message(msg_type, skill_data))
+                    self.emitter.emit(message.reply(msg_type, skill_data))
 
                 # Send timing metrics
                 context = message.context
@@ -1118,8 +1118,8 @@ class FallbackSkill(MycroftSkill):
 
         def handler(message):
             # indicate fallback handling start
-            ws.emit(Message("mycroft.skill.handler.start",
-                            data={'handler': "fallback"}))
+            ws.emit(message.reply("mycroft.skill.handler.start",
+                                  data={'handler': "fallback"}))
 
             stopwatch = Stopwatch()
             handler_name = None
@@ -1130,7 +1130,7 @@ class FallbackSkill(MycroftSkill):
                         if handler(message):
                             #  indicate completion
                             handler_name = get_handler_name(handler)
-                            ws.emit(Message(
+                            ws.emit(message.reply(
                                 'mycroft.skill.handler.complete',
                                 data={'handler': "fallback",
                                       "fallback_handler": handler_name}))
@@ -1138,13 +1138,13 @@ class FallbackSkill(MycroftSkill):
                     except Exception:
                         LOG.exception('Exception in fallback.')
                 else:  # No fallback could handle the utterance
-                    ws.emit(Message('complete_intent_failure'))
+                    ws.emit(message.reply('complete_intent_failure'))
                     warning = "No fallback could handle intent."
                     LOG.warning(warning)
                     #  indicate completion with exception
-                    ws.emit(Message('mycroft.skill.handler.complete',
-                                    data={'handler': "fallback",
-                                          'exception': warning}))
+                    ws.emit(message.reply('mycroft.skill.handler.complete',
+                                          data={'handler': "fallback",
+                                                'exception': warning}))
 
             # Send timing metric
             if message.context and message.context['ident']:

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -217,7 +217,7 @@ class EventScheduler(Thread):
         if event_name in self.events:
             event = self.events[event_name]
         emitter_name = 'mycroft.event_status.callback.{}'.format(event_name)
-        self.emitter.emit(Message(emitter_name, data=event))
+        self.emitter.emit(message.reply(emitter_name, data=event))
 
     def store(self):
         """

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -487,19 +487,19 @@ class SkillManager(Thread):
                     instance = self.loaded_skills[skill]["instance"]
                 except BaseException:
                     LOG.error("converse requested but skill not loaded")
-                    self.ws.emit(Message("skill.converse.response", {
+                    self.ws.emit(message.reply("skill.converse.response", {
                         "skill_id": 0, "result": False}))
                     return
                 try:
                     result = instance.converse(utterances, lang)
-                    self.ws.emit(Message("skill.converse.response", {
+                    self.ws.emit(message.reply("skill.converse.response", {
                         "skill_id": skill_id, "result": result}))
                     return
                 except BaseException:
                     LOG.exception(
                         "Error in converse method for skill " + str(skill_id))
-        self.ws.emit(Message("skill.converse.response",
-                             {"skill_id": 0, "result": False}))
+        self.ws.emit(message.reply("skill.converse.response",
+                                   {"skill_id": 0, "result": False}))
 
 
 def main():

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -122,5 +122,5 @@ class PadatiousService(FallbackSkill):
 
         self.service.add_active_skill(data.name.split(':')[0])
 
-        self.emitter.emit(Message(data.name, data=data.matches))
+        self.emitter.emit(message.reply(data.name, data=data.matches))
         return True


### PR DESCRIPTION
## Description
This uses the message.reply method in all places it was missing to propagate message context information

I make heavy use of this in https://chat.mycroft.ai/community/pl/azu61hg1dpygjxy8cdnst9sqne

## How to test
Check nothing breaks, notice that complete_intent_failure and other messages includes message context

## Contributor license agreement signed?
CLA [yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
