### PR TITLE
skiller.sh addition: settingsmeta.json.example creation

### DIFF
--- a/skiller.sh
+++ b/skiller.sh
@@ -139,9 +139,9 @@ echo '{
 	"name": "'${capital_desc}'",
 	"skillMetadata": {
 		"sections": [
-		{
-		 "name": "Section Friendly Display Name for Home.Mycroft.AI",
-		 "fields": [
+			{
+				"name": "Section Friendly Display Name for Home.Mycroft.AI",
+				"fields": [
 					{
 						"name": "internal_python_variable_name",
 						"type": "text",
@@ -155,9 +155,9 @@ echo '{
 				"name": "Login --Another Section But This One Has Two Values--",
 				"fields": [
 					{
-			"type": "label",
-			"label": "Just a little bit of extra info for the user to understand following settings"
-			},
+						"type": "label",
+						"label": "Just a little bit of extra info for the user to understand following settings"
+					},
 					{
 						"name": "username",
 						"type": "text",

--- a/skiller.sh
+++ b/skiller.sh
@@ -135,49 +135,49 @@ def create_skill():
     return $class_name()
 """ > "$skill_dir/__init__.py"
 
-echo """{
-	\"name\": \"${capital_desc}\",
-	\"skillMetadata\": {
-		\"sections\": [
+echo '{
+	"name": "'${capital_desc}'",
+	"skillMetadata": {
+		"sections": [
 		{
-		 \"name\": \"Section Friendly Display Name for Home.Mycroft.AI\",
-		 \"fields\": [
+		 "name": "Section Friendly Display Name for Home.Mycroft.AI",
+		 "fields": [
 					{
-						\"name\": \"internal_python_variable_name\",
-						\"type\": \"text\",
-						\"label\": \"Setting Friendly Display Name\",
-						\"value\": \"\",
-						\"placeholder\": \"demo prompt in the input box\"
+						"name": "internal_python_variable_name",
+						"type": "text",
+						"label": "Setting Friendly Display Name",
+						"value": "",
+						"placeholder": "demo prompt in the input box"
 					}
 				]
 			},
 			{
-				\"name\": \"Login --Another Section But This One Has Two Values--\",
-				\"fields\": [
+				"name": "Login --Another Section But This One Has Two Values--",
+				"fields": [
 					{
-			\"type\": \"label\",
-			\"label\": \"Just a little bit of extra info for the user to understand following settings\"
+			"type": "label",
+			"label": "Just a little bit of extra info for the user to understand following settings"
 			},
 					{
-						\"name\": \"username\",
-						\"type\": \"text\",
-						\"label\": \"Username\",
-						\"value\": \"\"
+						"name": "username",
+						"type": "text",
+						"label": "Username",
+						"value": ""
 					},
 					{
-						\"name\": \"password\",
-						\"type\": \"password\",
-						\"label\": \"Password\",
-						\"value\": \"\"
+						"name": "password",
+						"type": "password",
+						"label": "Password",
+						"value": ""
 					}
 				]
 			}
 		]
 	}
 }
-""" > "$skill_dir/settingsmeta.json.example"
+' > "$skill_dir/settingsmeta.json.example"
 
-echo -e "*.pyc\nsettings.json\n" > $skill_dir/.gitignore
+echo -e "*.pyc\nsettings.json\nsettingsmeta.json.example\n" > $skill_dir/.gitignore
 for i in "dialog" "vocab"; do mkdir -p "$skill_dir/$i/$lang"; done
 echo "$skill_desc" > "$skill_dir/vocab/$lang/$keyword.voc"
 echo "$skill_desc" > "$skill_dir/dialog/$lang/$dialog_name.dialog"

--- a/skiller.sh
+++ b/skiller.sh
@@ -135,6 +135,48 @@ def create_skill():
     return $class_name()
 """ > "$skill_dir/__init__.py"
 
+echo """{
+	\"name\": \"${capital_desc}\",
+	\"skillMetadata\": {
+		\"sections\": [
+		{
+		 \"name\": \"Section Friendly Display Name for Home.Mycroft.AI\",
+		 \"fields\": [
+					{
+						\"name\": \"internal_python_variable_name\",
+						\"type\": \"text\",
+						\"label\": \"Setting Friendly Display Name\",
+						\"value\": \"\",
+						\"placeholder\": \"demo prompt in the input box\"
+					}
+				]
+			},
+			{
+				\"name\": \"Login --Another Section But This One Has Two Values--\",
+				\"fields\": [
+					{
+			\"type\": \"label\",
+			\"label\": \"Just a little bit of extra info for the user to understand following settings\"
+			},
+					{
+						\"name\": \"username\",
+						\"type\": \"text\",
+						\"label\": \"Username\",
+						\"value\": \"\"
+					},
+					{
+						\"name\": \"password\",
+						\"type\": \"password\",
+						\"label\": \"Password\",
+						\"value\": \"\"
+					}
+				]
+			}
+		]
+	}
+}
+""" > "$skill_dir/settingsmeta.json.example"
+
 echo -e "*.pyc\nsettings.json\n" > $skill_dir/.gitignore
 for i in "dialog" "vocab"; do mkdir -p "$skill_dir/$i/$lang"; done
 echo "$skill_desc" > "$skill_dir/vocab/$lang/$keyword.voc"


### PR DESCRIPTION
## Description
Minor addition to skiller.sh to generate an annotated settingsmeta.json.exmample file.

## How to test
Simply execute skiller.sh and observe a valid (but generic) settingsmeta.json.example also exists.

## Contributor license agreement signed?
CLA [Y] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
