### PR TITLE
Add configuration values for msm

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -86,6 +86,15 @@
   
   // General skill values
   "skills": {
+    "msm": {
+      "directory": "/opt/mycroft/skills",
+      "versioned": true,
+      "repo": {
+        "cache": "/opt/mycroft/.skills-repo",
+        "url": "https://github.com/MycroftAI/mycroft-skills",
+        "branch": "18.02"
+      }
+    },
     // Directory to look for user skills
     "directory": "~/.mycroft/skills",
     // TODO: Old unused kludge, remove from code

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -22,7 +22,7 @@ from threading import Timer, Thread, Event
 import monotonic
 from glob import glob
 from os.path import exists, join, basename, dirname, expanduser, isfile
-from msm import MycroftSkillsManager
+from msm import MycroftSkillsManager, SkillRepo
 
 import mycroft.lock
 from mycroft import dialog
@@ -220,8 +220,19 @@ class SkillManager(Thread):
         ws.on('skillmanager.update', self.schedule_now)
         ws.on('skillmanager.list', self.send_skill_list)
 
-        self.msm = MycroftSkillsManager(
-            Configuration.get()['enclosure'].get('platform', 'default')
+        self.msm = self.create_msm()
+
+    @staticmethod
+    def create_msm():
+        config = Configuration.get()
+        msm_config = config['skills']['msm']
+        repo_config = msm_config['repo']
+        platform = config['enclosure'].get('platform', 'default')
+        return MycroftSkillsManager(
+            platform=platform, skills_dir=msm_config['directory'],
+            repo=SkillRepo(
+                repo_config['cache'], repo_config['url'], repo_config['branch']
+            ), versioned=msm_config['versioned']
         )
 
     def schedule_now(self, message=None):


### PR DESCRIPTION
## Description
This fixes part of #1380 by letting the msm repo, branch, and options be changed via the configuration.

## How to test
Try deleting default skills and make sure skills update correctly. Note: To test the update feature, delete `/opt/mycroft/.msm` to trigger the update (or wait an hour).