### PR TITLE
Make skill ids use skill folder

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -37,7 +37,7 @@ from mycroft.filesystem import FileSystemAccess
 from mycroft.messagebus.message import Message
 from mycroft.metrics import report_metric, report_timing, Stopwatch
 from mycroft.skills.settings import SkillSettings
-from mycroft.skills.skill_data import (load_vocabulary, load_regex, to_letters,
+from mycroft.skills.skill_data import (load_vocabulary, load_regex, to_alnum,
                                        munge_regex, munge_intent_parser)
 from mycroft.util import resolve_resource_file
 from mycroft.util.log import LOG
@@ -63,13 +63,13 @@ def unmunge_message(message, skill_id):
 
     Args:
         message (Message): Intent result message
-        skill_id (int): skill identifier
+        skill_id (str): skill identifier
 
     Returns:
         Message without clear keywords
     """
     if isinstance(message, Message) and isinstance(message.data, dict):
-        skill_id = to_letters(skill_id)
+        skill_id = to_alnum(skill_id)
         for key in message.data:
             if key[:len(skill_id)] == skill_id:
                 new_key = key[len(skill_id):]
@@ -807,7 +807,7 @@ class MycroftSkill(object):
             raise ValueError('context should be a string')
         if not isinstance(word, str):
             raise ValueError('word should be a string')
-        context = to_letters(self.skill_id) + context
+        context = to_alnum(self.skill_id) + context
         self.emitter.emit(Message('add_context',
                                   {'context': context, 'word': word}))
 
@@ -827,7 +827,7 @@ class MycroftSkill(object):
                 entity_type:    Intent handler entity to tie the word to
         """
         self.emitter.emit(Message('register_vocab', {
-            'start': entity, 'end': to_letters(self.skill_id) + entity_type
+            'start': entity, 'end': to_alnum(self.skill_id) + entity_type
         }))
 
     def register_regex(self, regex_str):

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -172,7 +172,7 @@ class IntentService(object):
         Returns:
             (str) Skill name or the skill id if the skill wasn't found
         """
-        return self.skill_names.get(int(skill_id), skill_id)
+        return self.skill_names.get(skill_id, skill_id)
 
     def reset_converse(self, message):
         """Let skills know there was a problem with speech recognition"""
@@ -357,7 +357,7 @@ class IntentService(object):
         if best_intent and best_intent.get('confidence', 0.0) > 0.0:
             self.update_context(best_intent)
             # update active skills
-            skill_id = int(best_intent['intent_type'].split(":")[0])
+            skill_id = best_intent['intent_type'].split(":")[0]
             self.add_active_skill(skill_id)
             return best_intent
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -311,7 +311,7 @@ class SkillManager(Thread):
         skill_path = skill_path.rstrip('/')
         skill = self.loaded_skills.setdefault(skill_path, {})
         skill.update({
-            "id": hash(skill_path),
+            "id": basename(skill_path),
             "path": skill_path
         })
 
@@ -452,7 +452,7 @@ class SkillManager(Thread):
         If supported, the conversation is invoked.
         """
 
-        skill_id = int(message.data["skill_id"])
+        skill_id = message.data["skill_id"]
         utterances = message.data["utterances"]
         lang = message.data["lang"]
 

--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -80,7 +80,7 @@ def load_vocabulary(basedir, emitter, skill_id):
     """
     for vocab_file in listdir(basedir):
         if vocab_file.endswith(".voc"):
-            vocab_type = to_letters(skill_id) + splitext(vocab_file)[0]
+            vocab_type = to_alnum(skill_id) + splitext(vocab_file)[0]
             load_vocab_from_file(
                 join(basedir, vocab_file), vocab_type, emitter)
 
@@ -92,28 +92,24 @@ def load_regex(basedir, emitter, skill_id):
         basedir (str): path of directory to load from
         emitter (messagebus emitter): websocket used to send the vocab to
                                       the intent service
-        skill_id (int): skill identifier
+        skill_id (str): skill identifier
     """
     for regex_type in listdir(basedir):
         if regex_type.endswith(".rx"):
-            load_regex_from_file(
-                join(basedir, regex_type), emitter, skill_id)
+            load_regex_from_file(join(basedir, regex_type), emitter, skill_id)
 
 
-def to_letters(number):
-    """Convert number to string of letters.
+def to_alnum(skill_id):
+    """Convert a skill id to only alphanumeric characters
 
-    0 -> A, 1 -> B, etc.
+     Non alpha-numeric characters are converted to "_"
 
     Args:
-        number (int): number to be converted
+        skill_id (str): identifier to be converted
     Returns:
         (str) String of letters
     """
-    ret = ''
-    for n in str(number).strip('-'):
-        ret += chr(65 + int(n))
-    return ret
+    return ''.join(c if c.isalnum() else '_' for c in str(skill_id))
 
 
 def munge_regex(regex, skill_id):
@@ -121,11 +117,11 @@ def munge_regex(regex, skill_id):
 
     Args:
         regex (str): regex string
-        skill_id (int): skill identifier
+        skill_id (str): skill identifier
     Returns:
         (str) munged regex
     """
-    base = '(?P<' + to_letters(skill_id)
+    base = '(?P<' + to_alnum(skill_id)
     return base.join(regex.split('(?P<'))
 
 
@@ -150,7 +146,7 @@ def munge_intent_parser(intent_parser, name, skill_id):
         intent_parser.name = name
 
     # Munge keywords
-    skill_id = to_letters(skill_id)
+    skill_id = to_alnum(skill_id)
     # Munge required keyword
     reqs = []
     for i in intent_parser.requires:

--- a/test/unittests/skills/core.py
+++ b/test/unittests/skills/core.py
@@ -73,17 +73,18 @@ class MycroftSkillTest(unittest.TestCase):
 
     def check_regex_from_file(self, filename, result_list=None):
         result_list = result_list or []
-        load_regex_from_file(join(self.regex_path, filename), self.emitter, 0)
+        regex_file = join(self.regex_path, filename)
+        load_regex_from_file(regex_file, self.emitter, 'A')
         self.check_emitter(result_list)
 
     def check_vocab(self, path, result_list=None):
         result_list = result_list or []
-        load_vocabulary(path, self.emitter, 0)
+        load_vocabulary(path, self.emitter, 'A')
         self.check_emitter(result_list)
 
     def check_regex(self, path, result_list=None):
         result_list = result_list or []
-        load_regex(path, self.emitter, 0)
+        load_regex(path, self.emitter, 'A')
         self.check_emitter(result_list)
 
     def check_emitter(self, result_list):
@@ -231,7 +232,7 @@ class MycroftSkillTest(unittest.TestCase):
         s.bind(self.emitter)
         s.initialize()
         expected = [{'at_least_one': [],
-                     'name': '0:a',
+                     'name': 'A:a',
                      'optional': [],
                      'requires': [('AKeyword', 'AKeyword')]}]
         self.check_register_intent(expected)
@@ -241,7 +242,7 @@ class MycroftSkillTest(unittest.TestCase):
         s.bind(self.emitter)
         s.initialize()
         expected = [{'at_least_one': [],
-                     'name': '0:a',
+                     'name': 'A:a',
                      'optional': [],
                      'requires': [('AKeyword', 'AKeyword')]}]
 
@@ -260,7 +261,7 @@ class MycroftSkillTest(unittest.TestCase):
         s.bind(self.emitter)
         s.initialize()
         expected = [{'at_least_one': [],
-                     'name': '0:a',
+                     'name': 'A:a',
                      'optional': [],
                      'requires': [('AKeyword', 'AKeyword')]}]
         self.check_register_intent(expected)
@@ -334,12 +335,13 @@ class MycroftSkillTest(unittest.TestCase):
         sys.path.append(abspath(dirname(__file__)))
         SimpleSkill5 = __import__('decorator_test_skill').TestSkill
         s = SimpleSkill5()
+        s.skill_id = 'A'
         s.vocab_dir = join(dirname(__file__), 'intent_file')
         s.bind(self.emitter)
         s.initialize()
         s._register_decorated()
         expected = [{'at_least_one': [],
-                     'name': '0:a',
+                     'name': 'A:a',
                      'optional': [],
                      'requires': [('AKeyword', 'AKeyword')]},
                     {
@@ -447,8 +449,8 @@ class MycroftSkillTest(unittest.TestCase):
         s.bind(emitter)
         s.schedule_event(s.handler, datetime.now(), name='sched_handler1')
         # Check that the handler was registered with the emitter
-        self.assertEqual(emitter.once.call_args[0][0], '0:sched_handler1')
-        self.assertTrue('0:sched_handler1' in [e[0] for e in s.events])
+        self.assertEqual(emitter.once.call_args[0][0], 'A:sched_handler1')
+        self.assertTrue('A:sched_handler1' in [e[0] for e in s.events])
 
     @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_remove_scheduled_event(self):
@@ -457,11 +459,11 @@ class MycroftSkillTest(unittest.TestCase):
         s.bind(emitter)
         s.schedule_event(s.handler, datetime.now(), name='sched_handler1')
         # Check that the handler was registered with the emitter
-        self.assertTrue('0:sched_handler1' in [e[0] for e in s.events])
+        self.assertTrue('A:sched_handler1' in [e[0] for e in s.events])
         s.cancel_scheduled_event('sched_handler1')
         # Check that the handler was removed
-        self.assertEqual(emitter.remove.call_args[0][0], '0:sched_handler1')
-        self.assertTrue('0:sched_handler1' not in [e[0] for e in s.events])
+        self.assertEqual(emitter.remove.call_args[0][0], 'A:sched_handler1')
+        self.assertTrue('A:sched_handler1' not in [e[0] for e in s.events])
 
     @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_run_scheduled_event(self):
@@ -477,10 +479,16 @@ class MycroftSkillTest(unittest.TestCase):
             self.assertTrue(s.handler_run)
             # Check that the handler was removed from the list of registred
             # handler
-            self.assertTrue('0:sched_handler1' not in [e[0] for e in s.events])
+            self.assertTrue('A:sched_handler1' not in [e[0] for e in s.events])
 
 
-class SimpleSkill1(MycroftSkill):
+class _TestSkill(MycroftSkill):
+    def __init__(self):
+        super().__init__()
+        self.skill_id = 'A'
+
+
+class SimpleSkill1(_TestSkill):
     def __init__(self):
         super(SimpleSkill1, self).__init__()
         self.handler_run = False
@@ -497,8 +505,10 @@ class SimpleSkill1(MycroftSkill):
         pass
 
 
-class SimpleSkill2(MycroftSkill):
+class SimpleSkill2(_TestSkill):
     """ Test skill for intent builder without .build() """
+    skill_id = 'A'
+
     def initialize(self):
         i = IntentBuilder('a').require('Keyword')
         self.register_intent(i, self.handler)
@@ -510,8 +520,10 @@ class SimpleSkill2(MycroftSkill):
         pass
 
 
-class SimpleSkill3(MycroftSkill):
+class SimpleSkill3(_TestSkill):
     """ Test skill for invalid Intent for register_intent """
+    skill_id = 'A'
+
     def initialize(self):
         self.register_intent('string', self.handler)
 
@@ -522,8 +534,10 @@ class SimpleSkill3(MycroftSkill):
         pass
 
 
-class SimpleSkill4(MycroftSkill):
+class SimpleSkill4(_TestSkill):
     """ Test skill for padatious intent """
+    skill_id = 'A'
+
     def initialize(self):
         self.register_intent_file('test.intent', self.handler)
         self.register_entity_file('test_ent.entity')


### PR DESCRIPTION
## Description
This is necessary because in Python 3, hash(x) changes every single start of the application. Using the skill folder makes it consistent. In addition, the skill folder makes it easier to debug parts of the application in comparison to using something like an md5sum

## How to test
 - Make sure all intents register properly
 - Test skills that use both Adapt and Padatious