### PR TITLE
Restore python-gobject-2-dev

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -94,7 +94,7 @@ install_deps() {
 	$SUDO zypper install -y git python glibc-devel linux-glibc-devel python-devel python2-virtualenv python2-gobject-devel python-virtualenvwrapper libtool libffi-devel libopenssl-devel autoconf automake bison swig glib2-devel portaudio-devel mpg123 flac curl libicu-devel pkg-config pkg-config libjpeg-devel libfann-devel python-curses
 	$SUDO zypper install -y -t pattern devel_C_C++
     elif found_exe apt-get; then
-        $SUDO apt-get install -y git python python-dev python-setuptools python-gobject-dev libtool libffi-dev libssl-dev autoconf automake bison swig libglib2.0-dev portaudio19-dev mpg123 screen flac curl libicu-dev pkg-config automake libjpeg-dev libfann-dev build-essential jq
+        $SUDO apt-get install -y git python python-dev python-setuptools python-gobject-2-dev libtool libffi-dev libssl-dev autoconf automake bison swig libglib2.0-dev portaudio19-dev mpg123 screen flac curl libicu-dev pkg-config automake libjpeg-dev libfann-dev build-essential jq
     elif found_exe pacman; then
         $SUDO pacman -S --needed --noconfirm git python2 python2-pip python2-setuptools python2-virtualenv python2-gobject python-virtualenvwrapper libtool libffi openssl autoconf bison swig glib2 portaudio mpg123 screen flac curl pkg-config icu automake libjpeg-turbo base-devel jq
         pacman -Qs "^fann$" &> /dev/null || (


### PR DESCRIPTION
## Description
In #1544 python-gobject-dev was replaced by python-gobject-2-dev, but this was lost somehow when merging the python 3 branch.

Thanks to @brobostigon for reporting this in #1576.

## How to test
Make sure travis still can install the package

## Contributor license agreement signed?
CLA [Yes]
