### PR TITLE
Update msm version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pulsectl==17.7.4
 google-api-python-client==1.6.4
 monotonic
 
-msm==0.5.4
+msm==0.5.5
 adapt-parser==0.3.0
 
 # dev setup tools


### PR DESCRIPTION
## Description
This upgrades msm to include some bug fixes including:
 - chmod being run on requirements.sh
 - Non-msm exception halting all other tasks in `msm.apply` and raising an exception

## How to test
 - Re-run `./dev_setup.sh`
 - Try updating and installing skills

