### PR TITLE
Remove all references to /opt/mycroft/skills

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -149,7 +149,7 @@ class RemoteConf(LocalConf):
     def __init__(self, cache=None):
         super(RemoteConf, self).__init__(None)
 
-        cache = cache or '/opt/mycroft/web_config_cache.json'
+        cache = cache or '/var/tmp/mycroft_web_cache.json'
         from mycroft.api import is_paired
         if not is_paired():
             self.load_local(cache)

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -83,14 +83,17 @@
       "offset": -21600000
     }
   },
+  "data_dir": "/opt/mycroft",
   
   // General skill values
   "skills": {
     "msm": {
-      "directory": "/opt/mycroft/skills",
+      // Relative to "data_dir"
+      "directory": "skills",
       "versioned": true,
       "repo": {
-        "cache": "/opt/mycroft/.skills-repo",
+        // Relative to "data_dir"
+        "cache": ".skills-repo",
         "url": "https://github.com/MycroftAI/mycroft-skills",
         "branch": "18.02"
       }

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -83,6 +83,8 @@
       "offset": -21600000
     }
   },
+
+  // Also change in scripts/prepare-msm.sh
   "data_dir": "/opt/mycroft",
   
   // General skill values

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -16,8 +16,9 @@ import json
 import time
 from threading import Thread
 
-from os.path import isfile
+from os.path import isfile, join
 
+from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
 from queue import Queue
@@ -41,7 +42,7 @@ def repeat_time(sched_time, repeat):
 
 
 class EventScheduler(Thread):
-    def __init__(self, emitter, schedule_file='/opt/mycroft/schedule.json'):
+    def __init__(self, emitter, schedule_file='schedule.json'):
         """
             Create an event scheduler thread. Will send messages at a
             predetermined time to the registered targets.
@@ -51,10 +52,12 @@ class EventScheduler(Thread):
                 schedule_file:  File to store pending events to on shutdown
         """
         super(EventScheduler, self).__init__()
+        data_dir = Configuration.get()['data_dir']
+
         self.events = {}
         self.emitter = emitter
         self.isRunning = True
-        self.schedule_file = schedule_file
+        self.schedule_file = join(data_dir, schedule_file)
         if self.schedule_file:
             self.load()
 
@@ -81,7 +84,7 @@ class EventScheduler(Thread):
                 try:
                     json_data = json.load(f)
                 except Exception as e:
-                    LOG.error(e.message)
+                    LOG.error(e)
             current_time = time.time()
             for key in json_data:
                 event_list = json_data[key]

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -16,7 +16,7 @@ import json
 import time
 from threading import Thread
 
-from os.path import isfile, join
+from os.path import isfile, join, expanduser
 
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
@@ -52,7 +52,7 @@ class EventScheduler(Thread):
                 schedule_file:  File to store pending events to on shutdown
         """
         super(EventScheduler, self).__init__()
-        data_dir = Configuration.get()['data_dir']
+        data_dir = expanduser(Configuration.get()['data_dir'])
 
         self.events = {}
         self.emitter = emitter

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -54,7 +54,6 @@ DEBUG = Configuration.get().get("debug", False)
 skills_config = Configuration.get().get("skills")
 BLACKLISTED_SKILLS = skills_config.get("blacklisted_skills", [])
 PRIORITY_SKILLS = skills_config.get("priority_skills", [])
-SKILLS_DIR = '/opt/mycroft/skills'
 
 installer_config = Configuration.get().get("SkillInstallerSkill")
 
@@ -202,9 +201,12 @@ class SkillManager(Thread):
         self.enclosure = EnclosureAPI(ws)
 
         # Schedule install/update of default skill
+        self.msm = self.create_msm()
+        self.num_install_retries = 0
+
         self.update_interval = Configuration.get()['skills']['update_interval']
         self.update_interval = int(self.update_interval * 60 * MINUTES)
-        self.dot_msm = join(SKILLS_DIR, '.msm')
+        self.dot_msm = join(self.msm.skills_dir, '.msm')
         if exists(self.dot_msm):
             self.next_download = os.path.getmtime(self.dot_msm) + \
                                  self.update_interval
@@ -221,9 +223,6 @@ class SkillManager(Thread):
         # Update upon request
         ws.on('skillmanager.update', self.schedule_now)
         ws.on('skillmanager.list', self.send_skill_list)
-
-        self.msm = self.create_msm()
-        self.num_install_retries = 0
 
     @staticmethod
     def create_msm():
@@ -432,7 +431,7 @@ class SkillManager(Thread):
 
             # Look for recently changed skill(s) needing a reload
             # checking skills dir and getting all skills there
-            skill_paths = glob(join(SKILLS_DIR, '*/'))
+            skill_paths = glob(join(self.msm.skills_dir, '*/'))
             still_loading = False
             for skill_path in skill_paths:
                 still_loading = (

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -229,11 +229,13 @@ class SkillManager(Thread):
         config = Configuration.get()
         msm_config = config['skills']['msm']
         repo_config = msm_config['repo']
+        skills_dir = join(config['data_dir'], msm_config['directory'])
+        repo_cache = join(config['data_dir'], repo_config['cache'])
         platform = config['enclosure'].get('platform', 'default')
         return MycroftSkillsManager(
-            platform=platform, skills_dir=msm_config['directory'],
+            platform=platform, skills_dir=skills_dir,
             repo=SkillRepo(
-                repo_config['cache'], repo_config['url'], repo_config['branch']
+                repo_cache, repo_config['url'], repo_config['branch']
             ), versioned=msm_config['versioned']
         )
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -229,8 +229,9 @@ class SkillManager(Thread):
         config = Configuration.get()
         msm_config = config['skills']['msm']
         repo_config = msm_config['repo']
-        skills_dir = join(config['data_dir'], msm_config['directory'])
-        repo_cache = join(config['data_dir'], repo_config['cache'])
+        data_dir = expanduser(config['data_dir'])
+        skills_dir = join(data_dir, msm_config['directory'])
+        repo_cache = join(data_dir, repo_config['cache'])
         platform = config['enclosure'].get('platform', 'default')
         return MycroftSkillsManager(
             platform=platform, skills_dir=skills_dir,

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -19,7 +19,7 @@ from threading import Thread
 from time import time, sleep
 
 import os.path
-from os.path import exists
+from os.path import exists, join
 
 from mycroft import MYCROFT_ROOT_PATH
 from mycroft.api import DeviceApi
@@ -29,6 +29,7 @@ from mycroft.util.download import download
 from mycroft.util.log import LOG
 
 config = Configuration.get().get("tts").get("mimic")
+data_dir = Configuration.get()['data_dir']
 
 BIN = config.get("path",
                  os.path.join(MYCROFT_ROOT_PATH, 'mimic', 'bin', 'mimic'))
@@ -39,7 +40,7 @@ if not os.path.isfile(BIN):
 
     BIN = distutils.spawn.find_executable("mimic")
 
-SUBSCRIBER_VOICES = {'trinity': '/opt/mycroft/voices/mimic_tn'}
+SUBSCRIBER_VOICES = {'trinity': join(data_dir, 'voices/mimic_tn')}
 
 
 def download_subscriber_voices(selected_voice):

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -19,7 +19,7 @@ from threading import Thread
 from time import time, sleep
 
 import os.path
-from os.path import exists, join
+from os.path import exists, join, expanduser
 
 from mycroft import MYCROFT_ROOT_PATH
 from mycroft.api import DeviceApi
@@ -29,7 +29,7 @@ from mycroft.util.download import download
 from mycroft.util.log import LOG
 
 config = Configuration.get().get("tts").get("mimic")
-data_dir = Configuration.get()['data_dir']
+data_dir = expanduser(Configuration.get()['data_dir'])
 
 BIN = config.get("path",
                  os.path.join(MYCROFT_ROOT_PATH, 'mimic', 'bin', 'mimic'))

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -15,6 +15,8 @@
 from __future__ import absolute_import
 import socket
 import subprocess
+from os.path import join
+
 from threading import Thread
 from time import sleep
 
@@ -59,6 +61,7 @@ def resolve_resource_file(res_name):
     Args:
         res_name (str): a resource path/name
     """
+    config = mycroft.configuration.Configuration.get()
 
     # First look for fully qualified file (e.g. a user setting)
     if os.path.isfile(res_name):
@@ -70,7 +73,7 @@ def resolve_resource_file(res_name):
         return filename
 
     # Next look for /opt/mycroft/res/res_name
-    filename = os.path.expanduser("/opt/mycroft/" + res_name)
+    filename = os.path.expanduser(join(config['data_dir'], res_name))
     if os.path.isfile(filename):
         return filename
 

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -15,7 +15,7 @@
 from __future__ import absolute_import
 import socket
 import subprocess
-from os.path import join
+from os.path import join, expanduser
 
 from threading import Thread
 from time import sleep
@@ -73,7 +73,8 @@ def resolve_resource_file(res_name):
         return filename
 
     # Next look for /opt/mycroft/res/res_name
-    filename = os.path.expanduser(join(config['data_dir'], res_name))
+    data_dir = expanduser(config['data_dir'])
+    filename = os.path.expanduser(join(data_dir, res_name))
     if os.path.isfile(filename):
         return filename
 

--- a/mycroft/version/__init__.py
+++ b/mycroft/version/__init__.py
@@ -15,7 +15,9 @@
 import json
 
 from genericpath import exists, isfile
+from os.path import join
 
+from mycroft.configuration import Configuration
 from mycroft.util.log import LOG
 
 
@@ -33,18 +35,15 @@ CORE_VERSION_STR = '.'.join(map(str, CORE_VERSION_TUPLE))
 
 
 class VersionManager(object):
-    __location = "/opt/mycroft/version.json"
-
     @staticmethod
     def get():
-        if (exists(VersionManager.__location) and
-                isfile(VersionManager.__location)):
+        version_file = join(Configuration.get()['data_dir'], 'version.json')
+        if exists(version_file) and isfile(version_file):
             try:
-                with open(VersionManager.__location) as f:
+                with open(version_file) as f:
                     return json.load(f)
-            except:
-                LOG.error("Failed to load version from '%s'"
-                          % VersionManager.__location)
+            except Exception:
+                LOG.error("Failed to load version from '%s'" % version_file)
         return {"coreVersion": None, "enclosureVersion": None}
 
 

--- a/mycroft/version/__init__.py
+++ b/mycroft/version/__init__.py
@@ -15,7 +15,7 @@
 import json
 
 from genericpath import exists, isfile
-from os.path import join
+from os.path import join, expanduser
 
 from mycroft.configuration import Configuration
 from mycroft.util.log import LOG
@@ -37,7 +37,8 @@ CORE_VERSION_STR = '.'.join(map(str, CORE_VERSION_TUPLE))
 class VersionManager(object):
     @staticmethod
     def get():
-        version_file = join(Configuration.get()['data_dir'], 'version.json')
+        data_dir = expanduser(Configuration.get()['data_dir'])
+        version_file = join(data_dir, 'version.json')
         if exists(version_file) and isfile(version_file):
             try:
                 with open(version_file) as f:

--- a/scripts/prepare-msm.sh
+++ b/scripts/prepare-msm.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-mycroft_root_dir='/opt/mycroft'
+mycroft_root_dir='/opt/mycroft'  # Also change in configuration
 skills_dir="${mycroft_root_dir}"/skills
 # exit on any error
 set -Ee

--- a/test/integrationtests/skills/discover_tests.py
+++ b/test/integrationtests/skills/discover_tests.py
@@ -20,13 +20,12 @@ from os.path import exists
 import sys
 import imp
 
+from mycroft.configuration import Configuration
 from test.integrationtests.skills.skill_tester import MockSkillsLoader
 from test.integrationtests.skills.skill_tester import SkillTest
 
-SKILL_PATH = '/opt/mycroft/skills/'
 
-
-def discover_tests():
+def discover_tests(skills_dir):
     """ Find all tests for the skills in the default skill path,
     or in the path provided as the LAST command line argument.
 
@@ -36,13 +35,10 @@ def discover_tests():
     Returns:
         Tests, lists of (intent example, test environment)
     """
-    global SKILL_PATH
-    if len(sys.argv) > 2:
-        SKILL_PATH = sys.argv.pop()
     tests = {}
     skills = [
         skill for skill
-        in glob.glob(SKILL_PATH + '/*')
+        in glob.glob(skills_dir + '/*')
         if os.path.isdir(skill)
     ]
 
@@ -66,8 +62,15 @@ def discover_tests():
     return tests
 
 
-tests = discover_tests()
-loader = MockSkillsLoader(SKILL_PATH)
+def get_skills_dir():
+    if len(sys.argv) > 1:
+        return sys.argv[1]
+    return Configuration.get()['skills']['msm']['directory']
+
+
+skills_dir = get_skills_dir()
+tests = discover_tests(skills_dir)
+loader = MockSkillsLoader(skills_dir)
 emitter = loader.load_skills()
 
 

--- a/test/unittests/api/test_api.py
+++ b/test/unittests/api/test_api.py
@@ -22,6 +22,7 @@ import mycroft.configuration
 from mycroft.util.log import LOG
 
 CONFIG = {
+    'data_dir': '/opt/mycroft',
     'server': {
         'url': 'https://api-test.mycroft.ai',
         'version': 'v1',


### PR DESCRIPTION
## Description
This get's rid of references to `/opt/mycroft/skills` so that it can properly be configured. The only thing that should reference it is the config. This fixes #1354 and closes #1255.

## How to test
 - Pull branch
 - Make sure skills load properly