### PR TITLE
Fixes for Python3 migration

### DIFF
--- a/test/integrationtests/skills/message_tester.py
+++ b/test/integrationtests/skills/message_tester.py
@@ -23,8 +23,8 @@
     must be installed (on Ubuntu: apt-get install python-tk)
 """
 
-from Tkinter import Label, Button, Tk, NORMAL, END, DISABLED
-import ScrolledText
+from tkinter import Label, Button, Tk, NORMAL, END, DISABLED
+from tkinter.scrolledtext import ScrolledText
 import skill_tester
 import ast
 
@@ -47,19 +47,16 @@ class MessageTester:
     def __init__(self, root):
         root.title("Message tester")
         Label(root, text="Enter message event below", bg="light green").pack()
-        self.event_field = ScrolledText.ScrolledText(root,
-                                                     width=180, height=10)
+        self.event_field = ScrolledText(root, width=180, height=10)
         self.event_field.pack()
 
         Label(root, text="Enter test case below", bg="light green").pack()
-        self.test_case_field = ScrolledText.ScrolledText(root,
-                                                         width=180, height=20)
+        self.test_case_field = ScrolledText(root, width=180, height=20)
         self.test_case_field.pack()
 
         Label(root, text="Test result:", bg="light green").pack()
 
-        self.result_field = ScrolledText.ScrolledText(root,
-                                                      width=180, height=10)
+        self.result_field = ScrolledText(root, width=180, height=10)
         self.result_field.pack()
         self.result_field.config(state=DISABLED)
         self.button = Button(root, text="Evaluate", fg="red",

--- a/test/integrationtests/skills/skill_developers_testrunner.py
+++ b/test/integrationtests/skills/skill_developers_testrunner.py
@@ -77,10 +77,9 @@ class IntentTestSequenceMeta(type):
         return type.__new__(mcs, name, bases, d)
 
 
-class IntentTestSequence(unittest.TestCase):
+class IntentTestSequence(unittest.TestCase, metaclass=IntentTestSequenceMeta):
     """This is the TestCase class that pythons unit tester can execute.
     """
-    __metaclass__ = IntentTestSequenceMeta
     loader = None
 
     @classmethod

--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -243,7 +243,7 @@ class SkillTest(object):
 
         cxt = test_case.get('set_context', None)
         if cxt:
-            for key, value in cxt.iteritems():
+            for key, value in cxt.items():
                 MycroftSkill.set_context(s, key, value)
 
         # Emit an utterance, just like the STT engine does.  This sends the


### PR DESCRIPTION
## Description
Fix message_tester.py, skill_developers_testrunner.py and skill_tester.py to run Python 3.

## How to test
The problem solved in skill_tester.py does not happen on any skill, it did happen on the cows lists:
source <mycroft-core-dir>/.venv/bin/activate 
python3 single_test.py /opt/mycroft/skills/carstena-the-cows-lists
will now execute without errors

skill_developers_testrunner:
Copy skill_developers_testrunner.py to a skills directory.
source <mycroft-core-dir>/.venv/bin/activate 
Python3 skill_developers_testrunner.py

message_tester:
On Ubuntu: sudo apt-get install python3-tk
source <mycroft-core-dir>/.venv/bin/activate 
Python3 message_tester.py

## Contributor license agreement signed?
CLA [X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
