### PR TITLE
Re-add checking of dependencies when running start-mycroft.sh

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -225,4 +225,4 @@ chmod +x start-mycroft.sh
 chmod +x stop-mycroft.sh
 
 #Store a fingerprint of setup
-md5sum requirements.txt dev_setup.sh > .installed
+md5sum requirements.txt test-requirements.txt dev_setup.sh > .installed

--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -118,9 +118,20 @@ function launch-background() {
     python ${_script} $_params >> ${scripts_dir}/logs/mycroft-${1}.log 2>&1 &
 }
 
+function check-dependencies() {
+  if [ ! -f .installed ] || ! md5sum -c &> /dev/null < .installed; then
+    echo "Please update dependencies by running ./dev_setup.sh again."
+    if command -v notify-send >/dev/null; then
+      notify-send "Mycroft Dependencies Outdated" "Run ./dev_setup.sh again"
+    fi
+  fi
+}
+
 _opt=$1
 shift
 _params=$@
+
+check-dependencies
 
 case ${_opt} in
   "all")


### PR DESCRIPTION
## Description
This re-introduces the dependency check (#1058) when running `dev_setuo.sh`. If you haven't run `dev_setup.sh` with the current version of `requirements.txt`, `test-requirements.txt`, and `dev_setup.sh`, it will notify you to run the setup script again.

## How to test
 - Run `./start-mycroft.sh all`
 - Make sure you see a notification to update
 - Run `./dev_setup.sh`
 - Run `./start-mycroft.sh all`
 - Make sure you don't see a notification to update