### PR TITLE
Fix chromecast quitting app on mycroft shutdown.

### DIFF
--- a/mycroft/audio/services/chromecast/__init__.py
+++ b/mycroft/audio/services/chromecast/__init__.py
@@ -139,6 +139,10 @@ class ChromecastService(AudioBackend):
             ret['album'] = ''
         return ret
 
+    def shutdown(self):
+        """ Disconnect from the device. """
+        self.cast.disconnect()
+
 
 def autodetect(config, emitter):
     """


### PR DESCRIPTION
## Description
The default method for the audio services call stop, in the chromecast case this isn't desirable since any playing application would be shutdown (even if mycroft didn't initiate it).

This overrides default behaviour and will merely disconnect from the device at shutdown.

## How to test
Start youtube on a chromecast device on the network and  start mycroft. stop the audio service and check that the youtube app is still running.

## Contributor license agreement signed?
CLA [Yes]