### PR TITLE
Skill control

### DIFF
--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -753,7 +753,12 @@ def show_skills(skills):
     column = 0
     col_width = 0
     for skill in sorted(skills.keys()):
-        scr.addstr(row, column,  "  {}".format(skill))
+        if skills[skill]['active']:
+            color = curses.color_pair(4)
+        else:
+            color = curses.color_pair(2)
+
+        scr.addstr(row, column,  "  {}".format(skill), color)
         row += 1
         col_width = max(col_width, len(skill))
         if row == 21:
@@ -864,6 +869,15 @@ def handle_cmd(cmd):
             c = scr.getch()  # blocks
             screen_mode = 0  # back to main screen
             draw_screen()
+    elif "deactivate" in cmd:
+        skills = cmd.split()[1:]
+        for s in skills:
+            ws.emit(Message("skillmanager.deactivate", data={'skill': s}))
+    elif "activate" in cmd:
+        skills = cmd.split()[1:]
+        for s in skills:
+            ws.emit(Message("skillmanager.activate", data={'skill': s}))
+
     # TODO: More commands
     return 0  # do nothing upon return
 

--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -873,6 +873,10 @@ def handle_cmd(cmd):
         skills = cmd.split()[1:]
         for s in skills:
             ws.emit(Message("skillmanager.deactivate", data={'skill': s}))
+    elif "keep" in cmd:
+        s = cmd.split()[1]
+        ws.emit(Message("skillmanager.keep", data={'skill': s}))
+
     elif "activate" in cmd:
         skills = cmd.split()[1:]
         for s in skills:

--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -752,7 +752,7 @@ def show_skills(skills):
     row = 2
     column = 0
     col_width = 0
-    for skill in sorted(skills):
+    for skill in sorted(skills.keys()):
         scr.addstr(row, column,  "  {}".format(skill))
         row += 1
         col_width = max(col_width, len(skill))
@@ -859,8 +859,8 @@ def handle_cmd(cmd):
         message = ws.wait_for_response(
             Message('skillmanager.list'), reply_type='mycroft.skills.list')
 
-        if message and 'skills' in message.data:
-            show_skills(message.data['skills'])
+        if message:
+            show_skills(message.data)
             c = scr.getch()  # blocks
             screen_mode = 0  # back to main screen
             draw_screen()

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -934,8 +934,9 @@ class MycroftSkill(object):
             LOG.error('Skill specific shutdown function encountered '
                       'an error: {}'.format(repr(e)))
         # Store settings
-        self.settings.store()
-        self.settings.stop_polling()
+        if exists(self._dir):
+            self.settings.store()
+            self.settings.stop_polling()
         # removing events
         self.cancel_all_repeating_events()
         for e, f in self.events:

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -453,9 +453,13 @@ class SkillManager(Thread):
             Send list of loaded skills.
         """
         try:
-            self.ws.emit(Message('mycroft.skills.list', data={'skills': [
-                basename(skill_path) for skill_path in self.loaded_skills
-            ]}))
+            info = {}
+            for s in self.loaded_skills:
+                info[basename(s)] = {
+                    'active': self.loaded_skills[s].get('active', True),
+                    'id': self.loaded_skills[s]['id']
+                }
+            self.ws.emit(Message('mycroft.skills.list', data=info))
         except Exception as e:
             LOG.exception(e)
 

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -469,6 +469,10 @@ class SkillManager(Thread):
 
     def __deactivate_skill(self, skill):
         """ Deactivate a skill. """
+        for s in self.loaded_skills:
+            if skill in s:
+                skill = s
+                break
         try:
             self.loaded_skills[skill]['active'] = False
             self.loaded_skills[skill]['instance']._shutdown()
@@ -479,7 +483,7 @@ class SkillManager(Thread):
         """ Deactivate a skill. """
         try:
             skill = message.data['skill']
-            if skill in self.loaded_skills:
+            if skill in [basename(s) for s in self.loaded_skills]:
                 self.__deactivate_skill(skill)
         except Exception as e:
             LOG.error('Couldn\'t deactivate skill, {}'.format(repr(e)))
@@ -488,21 +492,28 @@ class SkillManager(Thread):
         """ Deactivate all skills except the provided. """
         try:
             skill_to_keep = message.data['skill']
-            if skill_to_keep in self.loaded_skills:
+            LOG.info('DEACTIVATING ALL SKILLS EXCEPT {}'.format(skill_to_keep))
+            if skill_to_keep in [basename(i) for i in self.loaded_skills]:
                 for skill in self.loaded_skills:
-                    if skill != skill_to_keep:
+                    if basename(skill) != skill_to_keep:
                         self.__deactivate_skill(skill)
+            else:
+                LOG.info('Couldn\'t find skill')
         except Exception as e:
-            LOG.error('Couldn\'t deactivate skill, {}'.format(repr(e)))
+            LOG.error('Error during skill removal, {}'.format(repr(e)))
 
     def activate_skill(self, message):
         """ Activate a deactivated skill. """
         try:
             skill = message.data['skill']
+            for s in self.loaded_skills:
+                if skill in s:
+                    skill = s
+                    break
             if not self.loaded_skills[skill].get('active', True):
                 self.loaded_skills[skill]['loaded'] = False
                 self.loaded_skills[skill]['active'] = True
-        except:
+        except Exception as e:
             LOG.error('Couldn\'t activate skill, {}'.format(repr(e)))
 
     def stop(self):

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -223,6 +223,8 @@ class SkillManager(Thread):
         # Update upon request
         ws.on('skillmanager.update', self.schedule_now)
         ws.on('skillmanager.list', self.send_skill_list)
+        ws.on('skillmanager.deactivate', self.deactivate_skill)
+        ws.on('skillmanager.activate', self.activate_skill)
 
     @staticmethod
     def create_msm():
@@ -462,6 +464,24 @@ class SkillManager(Thread):
             self.ws.emit(Message('mycroft.skills.list', data=info))
         except Exception as e:
             LOG.exception(e)
+
+    def deactivate_skill(self, message):
+        try:
+            skill = message.data['skill']
+            if skill in self.loaded_skills:
+                self.loaded_skills[skill]['active'] = False
+                self.loaded_skills[skill]['instance']._shutdown()
+        except Exception as e:
+            LOG.error('Couldn\'t deactivate skill, {}'.format(repr(e)))
+
+    def activate_skill(self, message):
+        try:
+            skill = message.data['skill']
+            if not self.loaded_skills[skill].get('active', True):
+                self.loaded_skills[skill]['loaded'] = False
+                self.loaded_skills[skill]['active'] = True
+        except:
+            LOG.error('Couldn\'t activate skill, {}'.format(repr(e)))
 
     def stop(self):
         """ Tell the manager to shutdown """


### PR DESCRIPTION
## Description
- Add messagebus handlers to activate and deactivate skills
- Unload skills when they are removed on disk
- Add the `:activate`, `:deactivate` and `:keep commands`

## How to test
- Delete a skill and check that it gets unloaded
- try the `:deactivate` / `:activate` commands and assert that they function as intended

## Contributor license agreement signed?
CLA [Yes]