### PR TITLE
Check that web cache exists before loading it

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -166,7 +166,8 @@ class RemoteConf(LocalConf):
             except RequestException as e:
                 LOG.error("RequestException fetching remote location: {}"
                           .format(str(e)))
-                location = load_commented_json(cache).get('location')
+                if exists(cache) and isfile(cache):
+                    location = load_commented_json(cache).get('location')
 
             if location:
                 setting["location"] = location


### PR DESCRIPTION
## Description
If an exception occurs and the remote config fails to download the cache would be loaded even if it doesn't exist when handling failed get location. This adds a check to ensure that the cache exist before trying to load it.

## How to test
Remove the /var/tmp/mycroft_web_cache.json, disconnect from the internet and load configurations. This should not raise an exception

## Contributor license agreement signed?
CLA [Yes]