### PR TITLE
Fix issues in skill tester

### DIFF
--- a/test/integrationtests/skills/discover_tests.py
+++ b/test/integrationtests/skills/discover_tests.py
@@ -38,7 +38,7 @@ def discover_tests(skills_dir):
     tests = {}
     skills = [
         skill for skill
-        in glob.glob(skills_dir + '/*')
+        in sorted(glob.glob(skills_dir + '/*'))
         if os.path.isdir(skill)
     ]
 
@@ -54,7 +54,8 @@ def discover_tests(skills_dir):
         # Find all intent test files
         test_intent_files = [
             (f, test_env) for f
-            in glob.glob(os.path.join(skill, 'test/intent/*.intent.json'))
+            in sorted(
+                glob.glob(os.path.join(skill, 'test/intent/*.intent.json')))
         ]
         if len(test_intent_files) > 0:
             tests[skill] = test_intent_files

--- a/test/integrationtests/skills/discover_tests.py
+++ b/test/integrationtests/skills/discover_tests.py
@@ -16,7 +16,7 @@ import pytest
 
 import glob
 import os
-from os.path import exists
+from os.path import exists, join, expanduser
 import sys
 import imp
 
@@ -64,8 +64,10 @@ def discover_tests(skills_dir):
 
 def get_skills_dir():
     if len(sys.argv) > 1:
-        return sys.argv[1]
-    return Configuration.get()['skills']['msm']['directory']
+        return expanduser(sys.argv[-1])
+
+    return expanduser(join(Configuration.get()['data_dir'],
+                      Configuration.get()['skills']['msm']['directory']))
 
 
 skills_dir = get_skills_dir()

--- a/test/integrationtests/skills/single_test.py
+++ b/test/integrationtests/skills/single_test.py
@@ -51,7 +51,8 @@ def discover_tests():
         # Find intent tests
         test_intent_files = [
             f for f
-            in glob.glob(os.path.join(skill, 'test/intent/*.intent.json'))
+            in sorted(
+                glob.glob(os.path.join(skill, 'test/intent/*.intent.json')))
         ]
         if len(test_intent_files) > 0:
             tests[skill] = test_intent_files

--- a/test/integrationtests/skills/skill_developers_testrunner.py
+++ b/test/integrationtests/skills/skill_developers_testrunner.py
@@ -48,7 +48,8 @@ def discover_tests():
     for skill in skills:
         test_intent_files = [
             f for f
-            in glob.glob(os.path.join(skill, 'test/intent/*.intent.json'))
+            in sorted(
+                glob.glob(os.path.join(skill, 'test/intent/*.intent.json')))
         ]
         if len(test_intent_files) > 0:
             tests[skill] = test_intent_files

--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -331,7 +331,7 @@ class EvaluationRule(object):
         if test_case.get('expected_data'):
             _d = ['and']
             for item in test_case['expected_data'].items():
-                _d.append(['equal', str(item[0]), str(item[1])])
+                _d.append(['equal', item[0], item[1]])
             self.rule.append(_d)
 
         if _x != ['and']:


### PR DESCRIPTION
## Description
- The discover_test didn't handle configurable data path correctly.
- Running the test in an enforced order (sorted)
- Don't force expected_data values to string.

## How to test
Make sure pytest test/integration-tests/skills/discover_test.py detects tests to run

## Contributor license agreement signed?
CLA [Yes]