### PR TITLE
Feature/fix skill tester launch

### DIFF
--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -175,11 +175,11 @@ case ${_opt} in
     ;;
   "unittest")
     source ${VIRTUALENV_ROOT}/bin/activate
-    pytest test/unittests/ --cov=mycroft
+    pytest test/unittests/ --cov=mycroft "$@"
     ;;
   "skillstest")
     source ${VIRTUALENV_ROOT}/bin/activate
-    pytest test/integrationtests/skills/discover_tests.py
+    pytest test/integrationtests/skills/discover_tests.py "$@"
     ;;
   "audiotest")
     launch-process ${_opt}

--- a/test/integrationtests/skills/discover_tests.py
+++ b/test/integrationtests/skills/discover_tests.py
@@ -17,7 +17,6 @@ import pytest
 import glob
 import os
 from os.path import exists, join, expanduser
-import sys
 import imp
 
 from mycroft.configuration import Configuration
@@ -64,11 +63,13 @@ def discover_tests(skills_dir):
 
 
 def get_skills_dir():
-    if len(sys.argv) > 1:
-        return expanduser(sys.argv[-1])
-
-    return expanduser(join(Configuration.get()['data_dir'],
-                      Configuration.get()['skills']['msm']['directory']))
+    return (
+        expanduser(os.environ.get('SKILLS_DIR', '')) or
+        expanduser(join(
+            Configuration.get()['data_dir'],
+            Configuration.get()['skills']['msm']['directory']
+        ))
+    )
 
 
 skills_dir = get_skills_dir()

--- a/test/integrationtests/skills/discover_tests.py
+++ b/test/integrationtests/skills/discover_tests.py
@@ -16,7 +16,7 @@ import pytest
 
 import glob
 import os
-from os.path import exists, join, expanduser
+from os.path import exists, join, expanduser, abspath
 import imp
 
 from mycroft.configuration import Configuration
@@ -76,12 +76,14 @@ skills_dir = get_skills_dir()
 tests = discover_tests(skills_dir)
 loader = MockSkillsLoader(skills_dir)
 emitter = loader.load_skills()
+skill_dir = os.environ.get('SKILL_DIR', '')
 
 
 class TestCase(object):
     @pytest.mark.parametrize("skill,test", sum([
         [(skill, test) for test in tests[skill]]
         for skill in tests.keys()
+        if not skill_dir or abspath(skill).startswith(abspath(skill_dir))
         ], []))
     def test_skill(self, skill, test):
         example, test_env = test


### PR DESCRIPTION
## Description
This fixes launching `./start-mycroft skillstest` and makes it more usable by adding a `SKILL_DIR` environment variable so that rather than executing `source ...; python x/y/z/single_test.py` it can be executed through pytest via start-mycroft.

## How to test
 - Make sure `./start-mycroft.sh skillstest` works as intended
 - Make sure something like `SKILL_DIR=/opt/mycroft/skills/mycroft-speak.MycroftAI ./start-mycroft.sh skillstest` works
