### PR TITLE
Make data optional in Message.reply()

### DIFF
--- a/mycroft/messagebus/message.py
+++ b/mycroft/messagebus/message.py
@@ -74,7 +74,7 @@ class Message(object):
         obj = json.loads(value)
         return Message(obj.get('type'), obj.get('data'), obj.get('context'))
 
-    def reply(self, type, data, context=None):
+    def reply(self, type, data=None, context=None):
         """Construct a reply message for a given message
 
         This will take the same parameters as a message object but use
@@ -94,6 +94,7 @@ class Message(object):
         Returns:
             Message: Message object to be used on the reply to the message
         """
+        data = data or {}
         context = context or {}
 
         new_context = self.context if self.context else {}


### PR DESCRIPTION
## Description
To make reply work in the same manner as a newly created message data
shall be optional. This allows mistakes like L1141 of
mycroft/skills/core.py, where the data field isn't set. (And causes an
exception when the line is hit.)

## Contributor license agreement signed?
CLA [Yes]