### PR TITLE
Fix missing attribute in error

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -606,7 +606,7 @@ class MycroftSkill(object):
                 self.speak(msg)
                 LOG.exception(msg)
                 # append exception information in message
-                skill_data['exception'] = e.message
+                skill_data['exception'] = repr(e)
             finally:
                 if once:
                     self.remove_event(name)


### PR DESCRIPTION
## Description
Fixes an attribute error when a plain exception is raised that doesn't have the message attribtute

## How to test
Make sure the code can't except in the catch clause