### PR TITLE
Don't fail in dev_setup.sh if mimic fails to check version

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -141,13 +141,13 @@ else
   # first, look for a build of mimic in the folder
   has_mimic=""
   if [[ -f ${TOP}/mimic/bin/mimic ]] ; then
-      has_mimic=$( ${TOP}/mimic/bin/mimic -lv | grep Voice )
+      has_mimic=$( ${TOP}/mimic/bin/mimic -lv | grep Voice ) || true
   fi
 
   # in not, check the system path
   if [ "$has_mimic" = "" ] ; then
     if [ -x "$(command -v mimic)" ]; then
-      has_mimic="$( mimic -lv | grep Voice )"
+      has_mimic="$( mimic -lv | grep Voice )" || true
     fi
   fi
 


### PR DESCRIPTION
## Description
This prevents a messed up mimic install from stopping `dev_setup.sh`

## How to test
 - **Only on a desktop:** `echo #!error | sudo tee /usr/bin/mimic`
 - Make sure `dev_setup.sh` still runs properly
 - **Only if ran first command:** `sudo rm /usr/bin/mimic`
