### PR TITLE
Add AdaptIntent alias

### DIFF
--- a/mycroft/__init__.py
+++ b/mycroft/__init__.py
@@ -19,5 +19,6 @@ from mycroft.messagebus.message import Message
 from mycroft.skills.context import adds_context, removes_context
 from mycroft.skills.core import MycroftSkill, FallbackSkill, \
     intent_handler, intent_file_handler
+from mycroft.skills.intent_service import AdaptIntent
 
 MYCROFT_ROOT_PATH = abspath(join(dirname(__file__), '..'))

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -662,9 +662,9 @@ class MycroftSkill(object):
                                utterance for the handler.
                 handler:       function to register with intent
         """
-        if type(intent_parser) == IntentBuilder:
+        if isinstance(intent_parser, IntentBuilder):
             intent_parser = intent_parser.build()
-        elif type(intent_parser) != Intent:
+        elif not isinstance(intent_parser, Intent):
             raise ValueError('intent_parser is not an Intent')
 
         # Default to the handler's function name if none given

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -15,6 +15,7 @@
 import time
 from adapt.context import ContextManagerFrame
 from adapt.engine import IntentDeterminationEngine
+from adapt.intent import IntentBuilder
 
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
@@ -22,6 +23,11 @@ from mycroft.skills.core import open_intent_envelope
 from mycroft.util.log import LOG
 from mycroft.util.parse import normalize
 from mycroft.metrics import report_timing, Stopwatch
+
+
+class AdaptIntent(IntentBuilder):
+    def __init__(self, name=''):
+        super().__init__(name)
 
 
 class ContextManager(object):


### PR DESCRIPTION
## Description
It is used so that the init argument isn't required and so that it is imported from within the mycroft module

## How to test
Make sure a skill can use `AdaptIntent` via `from mycroft import AdaptIntent` instead of the `IntentBuilder`.