### PR TITLE
Fix changed default socket timeout

### DIFF
--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -177,13 +177,15 @@ def connected_dns(host="8.8.8.8", port=53, timeout=3):
     # OpenPort: 53/tcp
     # Service: domain (DNS/TCP)
     try:
-        socket.setdefaulttimeout(timeout)
-        socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect((host, port))
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.settimeout(timeout)
+        s.connect((host, port))
         return True
     except IOError:
         try:
-            socket.socket(socket.AF_INET, socket.SOCK_STREAM).connect(
-                ("8.8.4.4", port))
+            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            s.settimeout(timeout)
+            s.connect(("8.8.4.4", port))
             return True
         except IOError:
             return False


### PR DESCRIPTION
## Description
The default socket timeout was changed when checking the connectivity through connecting to a remote server (8.8.8.8). This has now been updated to only change the timeout for the socket used for the connection.

## How to test
Verify that the skills start up as intended and Internet connectivity is found.

## Contributor license agreement signed?
CLA [Yes]