### PR TITLE
Upgrade msk to 0.3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ google-api-python-client==1.6.4
 monotonic
 
 msm==0.5.14
-msk==0.3.4
+msk==0.3.9
 adapt-parser==0.3.0
 
 # dev setup tools


### PR DESCRIPTION
## Description
This upgrades mycroft skill manager to version 0.3.9 which includes bug fixes and support for vocab entities.

## How to test
Make sure `dev_setup.sh` runs fine
