### PR TITLE
Add security notice running Mycroft from desktops

### DIFF
--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -114,6 +114,13 @@ function launch-background() {
         echo "Starting background service $1"
     fi
 
+    # Security warning/reminder for the user
+    if [[ "${1}" = "bus" ]] ; then
+        echo "CAUTION: The Mycroft bus is an open websocket with no built-in security"
+        echo "         measures.  You are responsible for protecting the local port"
+        echo "         8181 with a firewall as appropriate."
+    fi
+
     # Launch process in background, sending log to scripts/log/mycroft-*.log
     python ${_script} $_params >> ${scripts_dir}/logs/mycroft-${1}.log 2>&1 &
 }


### PR DESCRIPTION
Security researcher w00t pointed out a potential exploit if an user
starts the Mycroft messagebus service on a system with an exposed
network connection with no protection for port 8181.  For now the
start-mycroft.sh script will simply display a CAUTION to point out
this concern and remind them to protect themselves with a firewall.

Future versions of the websocket implementation will use encryption
and authentication.

## Description
(Description of what the PR does, such as fixes # {issue number})

## How to test
(Description of how to validate or test this PR)

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
