### PR TITLE
Upgrade msm and padatious

### DIFF
--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -25,9 +25,6 @@ from mycroft.skills.core import FallbackSkill
 from mycroft.util.log import LOG
 
 
-PADATIOUS_VERSION = '0.3.7'  # Also update in requirements.txt
-
-
 class PadatiousService(FallbackSkill):
     def __init__(self, emitter, service):
         FallbackSkill.__init__(self)
@@ -45,10 +42,6 @@ class PadatiousService(FallbackSkill):
             except OSError:
                 pass
             return
-        ver = get_distribution('padatious').version
-        if ver != PADATIOUS_VERSION:
-            LOG.warning('Using Padatious v' + ver + '. Please re-run ' +
-                        'dev_setup.sh to install ' + PADATIOUS_VERSION)
 
         self.container = IntentContainer(intent_cache)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ pulsectl==17.7.4
 google-api-python-client==1.6.4
 monotonic
 
-msm==0.5.14
+msm==0.5.15
 msk==0.3.9
 adapt-parser==0.3.0
 
@@ -35,4 +35,4 @@ adapt-parser==0.3.0
 pep8==1.7.0
 fann2==1.0.7
 # Also update in mycroft/skills/padatious_service.py
-padatious==0.3.7
+padatious==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,4 @@ adapt-parser==0.3.0
 # dev setup tools
 pep8==1.7.0
 fann2==1.0.7
-# Also update in mycroft/skills/padatious_service.py
 padatious==0.4.1


### PR DESCRIPTION
## Description
This PR upgrades msm and padatious.
 - Padatious upgrade brings in nested parentheses support and slightly optimized network inputs
 - Msm upgrade brings in a bugfix for git repos with private or invalid remotes

## How to test
 - Make sure padatious intents still work
 - Make sure `msm update` and a skill install works
