### PR TITLE
Use time.monotonic instead of monotonic module

### DIFF
--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -17,7 +17,6 @@ import time
 from multiprocessing.pool import ThreadPool
 from threading import Event
 
-import monotonic
 from pyee import EventEmitter
 from websocket import (WebSocketApp, WebSocketConnectionClosedException,
                        WebSocketException)
@@ -135,10 +134,10 @@ class WebsocketClient(object):
         # Send request
         self.emit(message)
         # Wait for response
-        start_time = monotonic.monotonic()
+        start_time = time.monotonic()
         while len(response) == 0:
             time.sleep(0.2)
-            if monotonic.monotonic() - start_time > (timeout or 3.0):
+            if time.monotonic() - start_time > (timeout or 3.0):
                 try:
                     self.remove(reply_type, handler)
                 except (ValueError, KeyError):

--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -19,7 +19,6 @@ import time
 from glob import glob
 from itertools import chain
 
-import monotonic
 from os.path import exists, join, basename, dirname, expanduser, isfile
 from threading import Timer, Thread, Event
 
@@ -47,7 +46,7 @@ event_scheduler = None
 skill_manager = None
 
 # Remember "now" at startup.  Used to detect clock changes.
-start_ticks = monotonic.monotonic()
+start_ticks = time.monotonic()
 start_clock = time.time()
 
 DEBUG = Configuration.get().get("debug", False)
@@ -117,7 +116,7 @@ def check_connection():
             time.sleep(15)  # TODO: Generate/listen for a message response...
 
         # Check if the time skewed significantly.  If so, reboot
-        skew = abs((monotonic.monotonic() - start_ticks) -
+        skew = abs((time.monotonic() - start_ticks) -
                    (time.time() - start_clock))
         if skew > 60 * 60:
             # Time moved by over an hour in the NTP sync. Force a reboot to

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,6 @@ pychromecast==0.7.7
 python-vlc==1.1.2
 pulsectl==17.7.4
 google-api-python-client==1.6.4
-monotonic
 
 msm==0.5.14
 msk==0.3.9


### PR DESCRIPTION
## Description
Replace the monotonic time from the monotonic module with the built in time.monotonic


## How to test
Easiest part to test is the usage in the cli when running :skills This calls `wait_for_response` which uses monotonic for timing. Stop the skills process and assert that the timeout occurs.

## Contributor license agreement signed?
CLA [Yes]