### PR TITLE
Upgrade Padatious

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ adapt-parser==0.3.0
 # dev setup tools
 pep8==1.7.0
 fann2==1.0.7
-padatious==0.4.2
+padatious==0.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,4 +34,4 @@ adapt-parser==0.3.0
 # dev setup tools
 pep8==1.7.0
 fann2==1.0.7
-padatious==0.4.1
+padatious==0.4.2


### PR DESCRIPTION
## Description
This upgrade adds a timeout to training and uses a rigid matcher on top of the neural networks to ensure consistency

## How to test
 - Check that a Padatious skill like `mycroft-timer` still works
 - Remove the `~/.mycroft/intent_cache` folder and restart
 - Ensure the same skill still works