### PR TITLE
extract number scientific notation support

### DIFF
--- a/mycroft/util/lang/format_en.py
+++ b/mycroft/util/lang/format_en.py
@@ -58,11 +58,11 @@ FRACTION_STRING_EN = {
     5: 'fifth',
     6: 'sixth',
     7: 'seventh',
-    8: 'eigth',
+    8: 'eighth',
     9: 'ninth',
     10: 'tenth',
     11: 'eleventh',
-    12: 'twelveth',
+    12: 'twelfth',
     13: 'thirteenth',
     14: 'fourteenth',
     15: 'fifteenth',
@@ -70,7 +70,17 @@ FRACTION_STRING_EN = {
     17: 'seventeenth',
     18: 'eighteenth',
     19: 'nineteenth',
-    20: 'twentyith'
+    20: 'twentieth',
+    30: 'thirtieth',
+    40: "fortieth",
+    50: "fiftieth",
+    60: "sixtieth",
+    70: "seventieth",
+    80: "eightieth",
+    90: "ninetieth",
+    10e-3: "hundredth",
+    1e-3: "thousandth",
+    1e-6: "millionth",
 }
 
 LONG_SCALE_EN = collections.OrderedDict([

--- a/mycroft/util/lang/format_en.py
+++ b/mycroft/util/lang/format_en.py
@@ -54,7 +54,7 @@ NUM_STRING_EN = {
 FRACTION_STRING_EN = {
     2: 'half',
     3: 'third',
-    4: 'forth',
+    4: 'fourth',
     5: 'fifth',
     6: 'sixth',
     7: 'seventh',

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -144,6 +144,8 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
             prev_word = words[idx - 1] if idx > 0 else ""
             if word == "power" and prev_word in cards:
                 words[idx - 1] = NUM_STRING_EN[cards.index(prev_word) + 1]
+            elif prev_word == "power" and word in cards:
+                words[idx] = word = NUM_STRING_EN[cards.index(word) + 1]
             if word in erases:
                 words[idx] = ""
             elif word in replaces.keys():

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -147,9 +147,15 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
         for idx, word in enumerate(words):
             prev_word = words[idx - 1] if idx > 0 else ""
             if word == "power" and prev_word in cards:
-                words[idx - 1] = NUM_STRING_EN[cards.index(prev_word) + 1]
+                i = cards.index(prev_word) + 1
+                # TODO > 20
+                if i <= 20:
+                    words[idx - 1] = NUM_STRING_EN[i]
             elif prev_word == "power" and word in cards:
-                words[idx] = word = NUM_STRING_EN[cards.index(word) + 1]
+                i = cards.index(word) + 1
+                # TODO > 20
+                if i <= 20:
+                    words[idx] = word = NUM_STRING_EN[i]
             if word in erases:
                 words[idx] = ""
             elif word in replaces.keys():

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -137,8 +137,12 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
         }
         check_duplicates = ["power"]
         # cardinals
-        cards = [CARDINAL_STRING_EN[c] for c in CARDINAL_STRING_EN.keys()]
-
+        if short_scale:
+            cards = [SHORT_ORDINAL_STRING_EN[c]
+                     for c in SHORT_ORDINAL_STRING_EN.keys()]
+        else:
+            cards = [LONG_ORDINAL_STRING_EN[c]
+                     for c in LONG_ORDINAL_STRING_EN.keys()]
         words = text.split(" ")
         for idx, word in enumerate(words):
             prev_word = words[idx - 1] if idx > 0 else ""

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -192,10 +192,7 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
 
     # decimal marker ( 1 point 5 = 1 + 0.5)
     decimal_marker = [" point ", " dot "]
-    decimal_point = False
-    for m in decimal_marker:
-        if m in text:
-            decimal_point = True
+
     if short_scale:
         for num in SHORT_SCALE_EN:
             num_string = SHORT_SCALE_EN[num]
@@ -232,7 +229,6 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
             if number is not False and decimal is not False:
                 number = extractnumber_en(components[0])
                 # TODO handle number dot number number number
-                decimal = extractnumber_en(components[1])
                 if "." not in str(decimal):
                     return number + float("0." + str(decimal))
 

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -126,6 +126,31 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
 
     """
 
+    def _normalize(text):
+        erases = ["the", "of", "a", "an", "to", "positive", "plus"]
+        replaces = {
+            "exponentiated": "power",
+            "raised": "power",
+            "elevated": "power",
+            "by": "times"  # scientific notation
+        }
+        check_duplicates = ["power"]
+        words = text.split(" ")
+        for idx, word in enumerate(words):
+            if word in erases:
+                words[idx] = ""
+            elif word in replaces.keys():
+                words[idx] = replaces[word]
+                if replaces[word] in check_duplicates and replaces[
+                    word] in " ".join(words[:idx]):
+                    words[idx] = ""
+            if word in check_duplicates and word in " ".join(words[:idx]):
+                words[idx] = ""
+
+        return " ".join(words).rstrip().lstrip()
+
+    text = _normalize(text)
+
     string_num_en = {
                      "half": 0.5,
                      "halves": 0.5,
@@ -167,7 +192,10 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
 
     # decimal marker ( 1 point 5 = 1 + 0.5)
     decimal_marker = [" point ", " dot "]
-
+    decimal_point = False
+    for m in decimal_marker:
+        if m in text:
+            decimal_point = True
     if short_scale:
         for num in SHORT_SCALE_EN:
             num_string = SHORT_SCALE_EN[num]
@@ -201,8 +229,10 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
         if len(components) == 2:
             number = extractnumber_en(components[0])
             decimal = extractnumber_en(components[1])
-            if number is not None and decimal is not None:
+            if number is not False and decimal is not False:
+                number = extractnumber_en(components[0])
                 # TODO handle number dot number number number
+                decimal = extractnumber_en(components[1])
                 if "." not in str(decimal):
                     return number + float("0." + str(decimal))
 
@@ -273,6 +303,23 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
                 to_sum.append(val)
                 val = 0
                 prev_val = 0
+            # scientific notation
+            elif prev_word == "times" and \
+                    word in ["ten", "10"] and next_word == "power":
+
+                power = int(extractnumber_en(" ".join(aWords[idx:])))
+                val = extractnumber_en(" ".join(aWords[:idx]))
+                if val:
+                    return float(str(val) + "e" + str(power))
+            elif prev_word == "times" and \
+                    word in ["ten", "10"] and \
+                    extractnumber_en(" ".join(aWords[idx:])) \
+                    and text.endswith("power"):
+
+                power = int(extractnumber_en(" ".join(aWords[idx:])))
+                val = extractnumber_en(" ".join(aWords[:idx]))
+                if val:
+                    return float(str(val) + "e" + str(power))
 
     if val is not None:
         for v in to_sum:

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -127,6 +127,7 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
     """
 
     def _normalize(text):
+        text = text.lower()
         erases = ["the", "of", "a", "an", "to", "positive", "plus"]
         replaces = {
             "exponentiated": "power",
@@ -135,8 +136,14 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
             "by": "times"  # scientific notation
         }
         check_duplicates = ["power"]
+        # cardinals
+        cards = [CARDINAL_STRING_EN[c] for c in CARDINAL_STRING_EN.keys()]
+
         words = text.split(" ")
         for idx, word in enumerate(words):
+            prev_word = words[idx - 1] if idx > 0 else ""
+            if word == "power" and prev_word in cards:
+                words[idx - 1] = NUM_STRING_EN[cards.index(prev_word) + 1]
             if word in erases:
                 words[idx] = ""
             elif word in replaces.keys():

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -141,8 +141,8 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
                 words[idx] = ""
             elif word in replaces.keys():
                 words[idx] = replaces[word]
-                if replaces[word] in check_duplicates and replaces[
-                    word] in " ".join(words[:idx]):
+                if replaces[word] in check_duplicates and \
+                        replaces[word] in " ".join(words[:idx]):
                     words[idx] = ""
             if word in check_duplicates and word in " ".join(words[:idx]):
                 words[idx] = ""

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -150,12 +150,12 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
                 i = cards.index(prev_word) + 1
                 # TODO > 20
                 if i <= 20:
-                    words[idx - 1] = NUM_STRING_EN[i]
+                    words[idx - 1] = NUM_STRING_EN[i - 1]
             elif prev_word == "power" and word in cards:
                 i = cards.index(word) + 1
                 # TODO > 20
                 if i <= 20:
-                    words[idx] = word = NUM_STRING_EN[i]
+                    words[idx] = word = NUM_STRING_EN[i - 1]
             if word in erases:
                 words[idx] = ""
             elif word in replaces.keys():
@@ -169,7 +169,6 @@ def extractnumber_en(text, short_scale=True, ordinals=False):
         return " ".join(words).rstrip().lstrip()
 
     text = _normalize(text)
-
     string_num_en = {
                      "half": 0.5,
                      "halves": 0.5,

--- a/test/unittests/util/test_format.py
+++ b/test/unittests/util/test_format.py
@@ -36,18 +36,18 @@ NUMBERS_FIXTURE_EN = {
     0.5: 'a half',
     1.333: '1 and a third',
     2.666: '2 and 2 thirds',
-    0.25: 'a forth',
-    1.25: '1 and a forth',
-    0.75: '3 forths',
-    1.75: '1 and 3 forths',
+    0.25: 'a fourth',
+    1.25: '1 and a fourth',
+    0.75: '3 fourths',
+    1.75: '1 and 3 fourths',
     3.4: '3 and 2 fifths',
     16.8333: '16 and 5 sixths',
     12.5714: '12 and 4 sevenths',
-    9.625: '9 and 5 eigths',
+    9.625: '9 and 5 eighths',
     6.777: '6 and 7 ninths',
     3.1: '3 and a tenth',
     2.272: '2 and 3 elevenths',
-    5.583: '5 and 7 twelveths',
+    5.583: '5 and 7 twelfths',
     8.384: '8 and 5 thirteenths',
     0.071: 'a fourteenth',
     6.466: '6 and 7 fifteenths',
@@ -55,7 +55,7 @@ NUMBERS_FIXTURE_EN = {
     2.176: '2 and 3 seventeenths',
     200.722: '200 and 13 eighteenths',
     7.421: '7 and 8 nineteenths',
-    0.05: 'a twentyith'
+    0.05: 'a twentieth'
 }
 
 

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -140,51 +140,47 @@ class TestNormalize(unittest.TestCase):
 
         self.assertTrue(extract_number("grobo 0") is not False)
         self.assertEqual(extract_number("grobo 0"), 0)
-        self.assertEqualFloat(extract_number("gravitational constant is 6.67408 "
-                                        "by 10 to the power of minus eleven"),
-                         6.67408e-11)
+        self.assertEqualFloat(extract_number("gravitational constant is "
+                                             "6.67408 by 10 to the power of "
+                                             "minus eleven"), 6.67408e-11)
         self.assertEqualFloat(extract_number("planck constant is 4.1356677 "
-                                        "by 10 to the power of minus 15 "
-                                        "electron volts"),
-                         4.1356677e-15)
+                                             "by 10 to the power of minus 15 "
+                                             "electron volts"), 4.1356677e-15)
         self.assertEqualFloat(extract_number("666 by 10 elevated to 9"), 666e9)
-        self.assertEqualFloat(extract_number("666 times 10 to the power of 9"),
-                         666e9)
-        self.assertEqualFloat(extract_number("666 times 10 to the power of minus "
-                                        "9"),
-                         666e-9)
+        self.assertEqualFloat(extract_number("666 times 10 to the power of "
+                                             "9"), 666e9)
+        self.assertEqualFloat(extract_number("666 times 10 to the power of "
+                                             "minus  9"), 666e-9)
         self.assertEqualFloat(extract_number("666 by 10 to the power of 9"),
-                         666e9)
-        self.assertEqualFloat(extract_number("666 times 10 exponentiated to 9"),
-                         666e9)
+                              666e9)
+        self.assertEqualFloat(extract_number("666 times 10 exponentiated "
+                                             "to 9"), 666e9)
         self.assertEqualFloat(extract_number("666 times 10 raised to 9"),
-                         666e9)
+                              666e9)
         self.assertEqualFloat(extract_number("666 times 10 elevated to 9"),
-                         666e9)
+                              666e9)
         self.assertEqualFloat(extract_number("negative 666 by 10 elevated to "
-                                        "power 9"), -666e9)
+                                             "power 9"), -666e9)
         self.assertEqualFloat(extract_number("sixty six times ten to the "
-                                        "power of nine"), 66e9)
+                                             "power of nine"), 66e9)
         self.assertEqualFloat(
             extract_number("six hundred sixty six times ten to the "
                            "power of nine"), 666e9)
         self.assertEqualFloat(extract_number("six hundred sixty six by ten "
-                                        "to the 9 power"), 666e9)
+                                             "to the 9 power"), 666e9)
         self.assertEqualFloat(
             extract_number("six hundred sixty six by ten to the minus 9 "
-                           "power"),
-            666e-9)
+                           "power"), 666e-9)
         self.assertEqualFloat(
-            extract_number("six dot sixty six times ten to the power of six"),
-            6.66e6)
+            extract_number("six dot sixty six times ten to the power of "
+                           "six"), 6.66e6)
         self.assertEqualFloat(
-            extract_number("six dot sixty six times ten to the ninth power"),
-            6.66e9)
+            extract_number("six dot sixty six times ten to the ninth "
+                           "power"), 6.66e9)
         self.assertEqualFloat(
-            extract_number("sixty six times ten to the sixth power"),
-            66e6)
-        self.assertEqualFloat(extract_number("666 times 10 raised to the ninth"),
-                         666e9)
+            extract_number("sixty six times ten to the sixth power"), 66e6)
+        self.assertEqualFloat(extract_number("666 times 10 raised to "
+                                             "the ninth"), 666e9)
 
     def test_extractdatetime_en(self):
         def extractWithFormat(text):

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -48,6 +48,14 @@ class TestFuzzyMatch(unittest.TestCase):
 
 
 class TestNormalize(unittest.TestCase):
+
+    def assertEqualFloat(self, test, expected, epsilon=None):
+        epsilon = epsilon or 0.0000001
+        if test > expected + epsilon or test < expected - epsilon:
+            self.fail(
+                "Value {} was not equal to {} within {}".format(test, expected,
+                                                                epsilon))
+
     def test_articles(self):
         self.assertEqual(normalize("this is a test", remove_articles=True),
                          "this is test")
@@ -132,50 +140,50 @@ class TestNormalize(unittest.TestCase):
 
         self.assertTrue(extract_number("grobo 0") is not False)
         self.assertEqual(extract_number("grobo 0"), 0)
-        self.assertEqual(extract_number("gravitational constant is 6.67408 "
+        self.assertEqualFloat(extract_number("gravitational constant is 6.67408 "
                                         "by 10 to the power of minus eleven"),
                          6.67408e-11)
-        self.assertEqual(extract_number("planck constant is 4.1356677 "
+        self.assertEqualFloat(extract_number("planck constant is 4.1356677 "
                                         "by 10 to the power of minus 15 "
                                         "electron volts"),
                          4.1356677e-15)
-        self.assertEqual(extract_number("666 by 10 elevated to 9"), 666e9)
-        self.assertEqual(extract_number("666 times 10 to the power of 9"),
+        self.assertEqualFloat(extract_number("666 by 10 elevated to 9"), 666e9)
+        self.assertEqualFloat(extract_number("666 times 10 to the power of 9"),
                          666e9)
-        self.assertEqual(extract_number("666 times 10 to the power of minus "
+        self.assertEqualFloat(extract_number("666 times 10 to the power of minus "
                                         "9"),
                          666e-9)
-        self.assertEqual(extract_number("666 by 10 to the power of 9"),
+        self.assertEqualFloat(extract_number("666 by 10 to the power of 9"),
                          666e9)
-        self.assertEqual(extract_number("666 times 10 exponentiated to 9"),
+        self.assertEqualFloat(extract_number("666 times 10 exponentiated to 9"),
                          666e9)
-        self.assertEqual(extract_number("666 times 10 raised to 9"),
+        self.assertEqualFloat(extract_number("666 times 10 raised to 9"),
                          666e9)
-        self.assertEqual(extract_number("666 times 10 elevated to 9"),
+        self.assertEqualFloat(extract_number("666 times 10 elevated to 9"),
                          666e9)
-        self.assertEqual(extract_number("negative 666 by 10 elevated to "
+        self.assertEqualFloat(extract_number("negative 666 by 10 elevated to "
                                         "power 9"), -666e9)
-        self.assertEqual(extract_number("sixty six times ten to the "
+        self.assertEqualFloat(extract_number("sixty six times ten to the "
                                         "power of nine"), 66e9)
-        self.assertEqual(
+        self.assertEqualFloat(
             extract_number("six hundred sixty six times ten to the "
                            "power of nine"), 666e9)
-        self.assertEqual(extract_number("six hundred sixty six by ten "
+        self.assertEqualFloat(extract_number("six hundred sixty six by ten "
                                         "to the 9 power"), 666e9)
-        self.assertEqual(
+        self.assertEqualFloat(
             extract_number("six hundred sixty six by ten to the minus 9 "
                            "power"),
             666e-9)
-        self.assertEqual(
+        self.assertEqualFloat(
             extract_number("six dot sixty six times ten to the power of six"),
             6.66e6)
-        self.assertEqual(
+        self.assertEqualFloat(
             extract_number("six dot sixty six times ten to the ninth power"),
             6.66e9)
-        self.assertEqual(
+        self.assertEqualFloat(
             extract_number("sixty six times ten to the sixth power"),
             66e6)
-        self.assertEqual(extract_number("666 times 10 raised to the ninth"),
+        self.assertEqualFloat(extract_number("666 times 10 raised to the ninth"),
                          666e9)
 
     def test_extractdatetime_en(self):

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -132,6 +132,42 @@ class TestNormalize(unittest.TestCase):
 
         self.assertTrue(extract_number("grobo 0") is not False)
         self.assertEqual(extract_number("grobo 0"), 0)
+        self.assertEqual(extract_number("gravitational constant is 6.67408 "
+                                       "by 10 to the power of minus eleven"),
+                         6.67408e-11)
+        self.assertEqual(extract_number("planck constant is 4.1356677 "
+                                       "by 10 to the power of minus 15 electron volts"),
+                         4.1356677e-15)
+        self.assertEqual(extract_number("666 by 10 elevated to 9"), 666e9)
+        self.assertEqual(extract_number("666 times 10 to the power of 9"),
+                         666e9)
+        self.assertEqual(extract_number("666 times 10 to the power of minus "
+                                        "9"),
+                         666e-9)
+        self.assertEqual(extract_number("666 by 10 to the power of 9"),
+                         666e9)
+        self.assertEqual(extract_number("666 times 10 exponentiated to 9"),
+                         666e9)
+        self.assertEqual(extract_number("666 times 10 raised to 9"),
+                         666e9)
+        self.assertEqual(extract_number("666 times 10 elevated to 9"),
+                         666e9)
+        self.assertEqual(extract_number("negative 666 by 10 elevated to "
+                                       "power 9"), -666e9)
+        self.assertEqual(extract_number("sixty six times ten to the "
+                                       "power of nine"), 66e9)
+        self.assertEqual(
+            extract_number("six hundred sixty six times ten to the "
+                          "power of nine"), 666e9)
+        self.assertEqual(extract_number("six hundred sixty six by ten "
+                                       "to the 9 power"), 666e9)
+        self.assertEqual(
+            extract_number("six hundred sixty six by ten to the minus 9 "
+                           "power"),
+            666e-9)
+        self.assertEqual(
+            extract_number("six dot sixty six times ten to the power of six"),
+            6.66e6)
 
     def test_extractdatetime_en(self):
         def extractWithFormat(text):

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -174,6 +174,8 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(
             extractnumber("sixty six times ten to the sixth power"),
             66e6)
+        self.assertEqual(extractnumber("666 times 10 raised to the ninth"),
+                         666e9)
         # TODO handle this case
         # self.assertEqual(
         #    extractnumber("6 dot six six six"),

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -176,12 +176,6 @@ class TestNormalize(unittest.TestCase):
             66e6)
         self.assertEqual(extractnumber("666 times 10 raised to the ninth"),
                          666e9)
-        self.assertEqual(extractnumber("sixth sixth"),
-                         1 / 6 / 6)
-        # TODO handle this case
-        # self.assertEqual(
-        #    extractnumber("6 dot six six six"),
-        #    6.666)
 
     def test_extractdatetime_en(self):
         def extractWithFormat(text):

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -133,10 +133,11 @@ class TestNormalize(unittest.TestCase):
         self.assertTrue(extract_number("grobo 0") is not False)
         self.assertEqual(extract_number("grobo 0"), 0)
         self.assertEqual(extract_number("gravitational constant is 6.67408 "
-                                       "by 10 to the power of minus eleven"),
+                                        "by 10 to the power of minus eleven"),
                          6.67408e-11)
         self.assertEqual(extract_number("planck constant is 4.1356677 "
-                                       "by 10 to the power of minus 15 electron volts"),
+                                        "by 10 to the power of minus 15 "
+                                        "electron volts"),
                          4.1356677e-15)
         self.assertEqual(extract_number("666 by 10 elevated to 9"), 666e9)
         self.assertEqual(extract_number("666 times 10 to the power of 9"),
@@ -153,14 +154,14 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(extract_number("666 times 10 elevated to 9"),
                          666e9)
         self.assertEqual(extract_number("negative 666 by 10 elevated to "
-                                       "power 9"), -666e9)
+                                        "power 9"), -666e9)
         self.assertEqual(extract_number("sixty six times ten to the "
-                                       "power of nine"), 66e9)
+                                        "power of nine"), 66e9)
         self.assertEqual(
             extract_number("six hundred sixty six times ten to the "
-                          "power of nine"), 666e9)
+                           "power of nine"), 666e9)
         self.assertEqual(extract_number("six hundred sixty six by ten "
-                                       "to the 9 power"), 666e9)
+                                        "to the 9 power"), 666e9)
         self.assertEqual(
             extract_number("six hundred sixty six by ten to the minus 9 "
                            "power"),
@@ -169,12 +170,12 @@ class TestNormalize(unittest.TestCase):
             extract_number("six dot sixty six times ten to the power of six"),
             6.66e6)
         self.assertEqual(
-            extractnumber("six dot sixty six times ten to the ninth power"),
+            extract_number("six dot sixty six times ten to the ninth power"),
             6.66e9)
         self.assertEqual(
-            extractnumber("sixty six times ten to the sixth power"),
+            extract_number("sixty six times ten to the sixth power"),
             66e6)
-        self.assertEqual(extractnumber("666 times 10 raised to the ninth"),
+        self.assertEqual(extract_number("666 times 10 raised to the ninth"),
                          666e9)
 
     def test_extractdatetime_en(self):
@@ -186,8 +187,8 @@ class TestNormalize(unittest.TestCase):
 
         def testExtract(text, expected_date, expected_leftover):
             res = extractWithFormat(normalize(text))
-            self.assertEqual(res[0], expected_date, "for="+text)
-            self.assertEqual(res[1], expected_leftover, "for="+text)
+            self.assertEqual(res[0], expected_date, "for=" + text)
+            self.assertEqual(res[1], expected_leftover, "for=" + text)
 
         testExtract("Set the ambush for 5 days from today",
                     "2017-07-02 00:00:00", "set ambush")
@@ -418,8 +419,8 @@ class TestNormalize(unittest.TestCase):
 
         def testExtract(text, expected_date, expected_leftover):
             res = extractWithFormat(normalize(text))
-            self.assertEqual(res[0], expected_date, "for="+text)
-            self.assertEqual(res[1], expected_leftover, "for="+text)
+            self.assertEqual(res[0], expected_date, "for=" + text)
+            self.assertEqual(res[1], expected_leftover, "for=" + text)
 
         testExtract("lets meet in 5 minutes",
                     "2017-06-27 10:06:02", "lets meet")

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -168,6 +168,16 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(
             extract_number("six dot sixty six times ten to the power of six"),
             6.66e6)
+        self.assertEqual(
+            extractnumber("six dot sixty six times ten to the ninth power"),
+            6.66e9)
+        self.assertEqual(
+            extractnumber("sixty six times ten to the sixth power"),
+            66e6)
+        # TODO handle this case
+        # self.assertEqual(
+        #    extractnumber("6 dot six six six"),
+        #    6.666)
 
     def test_extractdatetime_en(self):
         def extractWithFormat(text):

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -176,6 +176,8 @@ class TestNormalize(unittest.TestCase):
             66e6)
         self.assertEqual(extractnumber("666 times 10 raised to the ninth"),
                          666e9)
+        self.assertEqual(extractnumber("sixth sixth"),
+                         1 / 6 / 6)
         # TODO handle this case
         # self.assertEqual(
         #    extractnumber("6 dot six six six"),


### PR DESCRIPTION
## Description

extract_number_en now supports scientific notation

Partially solves #1647 

## How to test
check unittests

## Contributor license agreement signed?
CLA [yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
