### PR TITLE
Feature add query mic status

### DIFF
--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -103,7 +103,7 @@ def handle_mic_is_muted(event):
     """
         Query microphone mute status.
     """
-    data = {'mic_state':loop.is_muted()}
+    data = {'mic_state': loop.is_muted()}
     ws.emit(Message('mycroft.mic.muted', data))
 
 

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -99,6 +99,14 @@ def handle_mic_unmute(event):
     loop.unmute()
 
 
+def handle_mic_is_muted(event):
+    """
+        Query microphone mute status.
+    """
+    data = {'mic_state':loop.is_muted()}
+    ws.emit(Message('mycroft.mic.muted', data))
+
+
 def handle_paired(event):
     IdentityManager.update(event.data)
 
@@ -153,6 +161,7 @@ def main():
     ws.on('recognizer_loop:wake_up', handle_wake_up)
     ws.on('mycroft.mic.mute', handle_mic_mute)
     ws.on('mycroft.mic.unmute', handle_mic_unmute)
+    ws.on('mycroft.mic.is_muted', handle_mic_is_muted)
     ws.on("mycroft.paired", handle_paired)
     ws.on('recognizer_loop:audio_output_start', handle_audio_start)
     ws.on('recognizer_loop:audio_output_end', handle_audio_end)

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -104,7 +104,7 @@ def handle_mic_is_muted(event):
         Query microphone mute status.
     """
     data = {'mic_state': loop.is_muted()}
-    ws.emit(Message('mycroft.mic.muted', data))
+    ws.emit(event.response(data))
 
 
 def handle_paired(event):

--- a/mycroft/client/speech/main.py
+++ b/mycroft/client/speech/main.py
@@ -99,11 +99,11 @@ def handle_mic_unmute(event):
     loop.unmute()
 
 
-def handle_mic_is_muted(event):
+def handle_mic_get_status(event):
     """
         Query microphone mute status.
     """
-    data = {'mic_state': loop.is_muted()}
+    data = {'muted': loop.is_muted()}
     ws.emit(event.response(data))
 
 
@@ -161,7 +161,7 @@ def main():
     ws.on('recognizer_loop:wake_up', handle_wake_up)
     ws.on('mycroft.mic.mute', handle_mic_mute)
     ws.on('mycroft.mic.unmute', handle_mic_unmute)
-    ws.on('mycroft.mic.is_muted', handle_mic_is_muted)
+    ws.on('mycroft.mic.get_status', handle_mic_get_status)
     ws.on("mycroft.paired", handle_paired)
     ws.on('recognizer_loop:audio_output_start', handle_audio_start)
     ws.on('recognizer_loop:audio_output_end', handle_audio_end)


### PR DESCRIPTION
## Description
Adds ability for enclosures to query mycroft over the messagebus about the status of the microphone weather the state is muted or unmuted.

## How to test
Send message type:"mycroft.mic.is_muted" from an enclosure to mycroft core, return bool value should be in mycroft.mic.muted data {mic_state:true/false} 

## Contributor license agreement signed?
CLA [Yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
