### PR TITLE
Try upgrading testing from PEP8 to flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ install:
  - VIRTUALENV_ROOT=${VIRTUAL_ENV} ./dev_setup.sh
  - pip install -r requirements.txt
  - pip install -r test-requirements.txt
+before_script:
+ - pip install flake8  # pytest  # add another testing frameworks later
+ # stop the build if there are Python syntax errors or undefined names
+ - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+ # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+ - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 # command to run tests
 script:
  - pep8 mycroft test


### PR DESCRIPTION
Flake8 is a superset of PEP8 (PyCodeStyle) to add PyFlakes and McCabe complexity tests some syntax error tests of its own.  The _undefined names_ capability is useful for finding missing imports and Python 2 only identifiers like __unicode__ and __xrange__.

Output: https://travis-ci.org/MycroftAI/mycroft-core/jobs/397703237#L1464-L1472
* These issues were fixed in #1665

## Description
(Description of what the PR does, such as fixes # {issue number})

## How to test
(Description of how to validate or test this PR)

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
