### PR TITLE
Python 3 fixes for xrange() and unicode

### DIFF
--- a/mycroft/audio/services/mopidy/mopidypost.py
+++ b/mycroft/audio/services/mopidy/mopidypost.py
@@ -90,7 +90,7 @@ class Mopidy(object):
     def add_list(self, uri):
         d = copy(_base_dict)
         d['method'] = 'core.tracklist.add'
-        if type(uri) in basestring:
+        if isinstance(uri, basestring):
             d['params'] = {'uri': uri}
         elif type(uri) == list:
             d['params'] = {'uris': uri}

--- a/mycroft/audio/services/mopidy/mopidypost.py
+++ b/mycroft/audio/services/mopidy/mopidypost.py
@@ -17,6 +17,10 @@ from copy import copy
 
 import requests
 
+try:
+    basestring            # Python 2
+except NameError:
+    basestring = (str, )  # Python 3
 
 MOPIDY_API = '/mopidy/rpc'
 
@@ -86,7 +90,7 @@ class Mopidy(object):
     def add_list(self, uri):
         d = copy(_base_dict)
         d['method'] = 'core.tracklist.add'
-        if type(uri) == str or type(uri) == unicode:
+        if type(uri) in basestring:
             d['params'] = {'uri': uri}
         elif type(uri) == list:
             d['params'] = {'uris': uri}

--- a/mycroft/audio/services/mopidy/mopidypost.py
+++ b/mycroft/audio/services/mopidy/mopidypost.py
@@ -17,11 +17,6 @@ from copy import copy
 
 import requests
 
-try:
-    basestring            # Python 2
-except NameError:
-    basestring = (str, )  # Python 3
-
 MOPIDY_API = '/mopidy/rpc'
 
 _base_dict = {'jsonrpc': '2.0', 'id': 1, 'params': {}}
@@ -90,7 +85,7 @@ class Mopidy(object):
     def add_list(self, uri):
         d = copy(_base_dict)
         d['method'] = 'core.tracklist.add'
-        if isinstance(uri, basestring):
+        if isinstance(uri, str):
             d['params'] = {'uri': uri}
         elif type(uri) == list:
             d['params'] = {'uris': uri}

--- a/test/unittests/client/test_dynamic_energy_test.py
+++ b/test/unittests/client/test_dynamic_energy_test.py
@@ -59,7 +59,7 @@ class DynamicEnergytest(unittest.TestCase):
 
         source = MockSource()
 
-        for i in xrange(100):
+        for i in range(100):
             source.stream.inject(low_base)
 
         source.stream.inject(higher_base)


### PR DESCRIPTION
* __xrange()__ was removed from Python 3 in favor of __range()__.
* __unicode__ and __basestring__ were removed in Python 3 because all __str__ are Unicode.

Found via #1664  See https://travis-ci.org/MycroftAI/mycroft-core/jobs/397703237#L1464-L1472