### PR TITLE
Enhance the behavior of the Mark 1 button

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -21,6 +21,7 @@ from mycroft.metrics import report_timing, Stopwatch
 from mycroft.tts import TTSFactory
 from mycroft.util import create_signal, check_for_signal
 from mycroft.util.log import LOG
+from mycroft.messagebus.message import Message
 
 ws = None  # TODO:18.02 - Rename to "messagebus"
 config = None
@@ -129,11 +130,12 @@ def handle_stop(event):
         _last_stop_signal = time.time()
         tts.playback.clear_queue()
         tts.playback.clear_visimes()
+        ws.emit(Message("mycroft.stop.handled", {"by": "TTS"}))
 
 
 def init(websocket):
     """
-        Start speach related handlers
+        Start speech related handlers
     """
 
     global ws

--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -32,7 +32,7 @@ from mycroft.configuration import Configuration, LocalConf, USER_CONFIG
 from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.util import play_wav, create_signal, connected, \
-    wait_while_speaking
+    wait_while_speaking, check_for_signal
 from mycroft.util.audio_test import record
 from mycroft.util.log import LOG
 from queue import Queue
@@ -62,6 +62,9 @@ class EnclosureReader(Thread):
         self.lang = lang or 'en-us'
         self.start()
 
+        # Notifications from mycroft-core
+        self.ws.on("mycroft.stop.handled", self.on_stop_handled)
+
     def read(self):
         while self.alive:
             try:
@@ -70,6 +73,10 @@ class EnclosureReader(Thread):
                     self.process(data.decode())
             except Exception as e:
                 LOG.error("Reading error: {0}".format(e))
+
+    def on_stop_handled(self, event):
+        # A skill performed a stop
+        check_for_signal('buttonPress')
 
     def process(self, data):
         # TODO: Look into removing this emit altogether.

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -901,14 +901,15 @@ class MycroftSkill(object):
         def __stop_timeout():
             # The self.stop() call took more than 100ms, assume it handled Stop
             self.emitter.emit(
-                Message("mycroft.stop.handled", {"skill_id": str(self.skill_id) + ":"}))
-            pass
+                Message("mycroft.stop.handled",
+                        {"skill_id": str(self.skill_id) + ":"}))
 
         timer = Timer(0.1, __stop_timeout)  # set timer for 100ms
         try:
             if self.stop():
                 self.emitter.emit(
-                    Message("mycroft.stop.handled", {"by": "skill:"+str(self.skill_id)}))
+                    Message("mycroft.stop.handled",
+                            {"by": "skill:"+str(self.skill_id)}))
             timer.cancel()
         except:
             timer.cancel()

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -107,6 +107,7 @@ class PlaybackThread(Thread):
                 if self.queue.empty():
                     self.tts.end_audio()
                     self._processing_queue = False
+                    self._clear_visimes = False
                 self.blink(0.2)
             except Empty:
                 pass


### PR DESCRIPTION
## Description
The Mark 1 button press can now be "consumed" when a skill handles
the Stop command.  When this happens, the button press will not
trigger listening mode.  An additional press would be needed to
trigger listening.

This introduces the "mycroft.stop.handled" messagebus message.  It
carries a data field called "by" which identifies who handled it.
Currently the values are "TTS" for when speaking ends or the name
of a skill which implements Stop and returns True from the call.

Also fixed a potential bug when the flag to clear queued visemes
was left set after a button press.

## How to test
Use the Mark 1 button to stop speaking, timers, etc.  The skill must return
True to consume it, so some skills might need altering to not accidentally
trigger listening.

## Contributor license agreement signed?
CLA [X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
