### PR TITLE
Fix startup of audio-test

### DIFF
--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -69,7 +69,6 @@ function name-to-script-path() {
     "cli")             _script=${DIR}/mycroft/client/text/main.py ;;
     "wifi")            _script=${DIR}/mycroft/client/wifisetup/main.py ;;
     "skill_container") _script=${DIR}/mycroft/skills/container.py ;;
-    "audiotest")       _script=${DIR}/mycroft/util/audio_test.py ;;
     "audioaccuracytest") _script=${DIR}/mycroft/audio-accuracy-test/audio_accuracy_test.py ;;
     "sdkdoc")          _script=${DIR}/doc/generate_sdk_docs.py ;;
     "enclosure")       _script=${DIR}/mycroft/client/enclosure/main.py ;;
@@ -189,7 +188,8 @@ case ${_opt} in
     pytest test/integrationtests/skills/discover_tests.py "$@"
     ;;
   "audiotest")
-    launch-process ${_opt}
+    source ${VIRTUALENV_ROOT}/bin/activate
+    python -m mycroft.util.audio_test "${@:1}"
     ;;
   "audioaccuracytest")
     launch-process ${_opt}


### PR DESCRIPTION
## Description
There seem to be some sort of name space collision running the
audio_test in the util folder. running it as a module like this keeps
backward compatibility and fixes the issue.

Resolves #1640 

## How to test
Run ./start-mycroft.sh audiotest and ensure that it works.

## Contributor license agreement signed?
CLA [Yes]