### PR TITLE
Fix crash during initial skill download

### DIFF
--- a/mycroft/skills/main.py
+++ b/mycroft/skills/main.py
@@ -282,9 +282,12 @@ class SkillManager(Thread):
 
         installed_skills = self.load_installed_skills()
         default_groups = dict(self.msm.repo.get_default_skill_names())
-        default_names = set(chain(default_groups['default'],
-                                  default_groups[self.msm.platform]))
-
+        if self.msm.platform in default_groups:
+            platform_groups = default_groups[self.msm.platform]
+        else:
+            LOG.info('Platform defaults not found, using DEFAULT skills only')
+            platform_groups = []
+        default_names = set(chain(default_groups['default'], platform_groups))
         default_skill_errored = False
 
         def install_or_update(skill):


### PR DESCRIPTION
When running on a platform for which there was not a DEFAULT.platform
file in the mycroft-skills repo, the downloading of skills would
crash.  Now an informational message is shown and the DEFAULT
skills alone are loaded.

## Description
When running on a platform such as Ubuntu, the default skills weren't being downloaded.

## How to test
Edit the /etc/mycroft/mycroft.conf so that enclosure.platform is a value other than 'kde',
'mycroft_mark_1', or 'picroft'.

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
