### PR TITLE
Handle stop correctly in the audio service.

### DIFF
--- a/mycroft/audio/services/__init__.py
+++ b/mycroft/audio/services/__init__.py
@@ -63,6 +63,8 @@ class AudioBackend():
     def stop(self):
         """
             Stop playback.
+
+            Returns: (bool) True if playback was stopped, otherwise False
         """
         pass
 

--- a/mycroft/audio/services/chromecast/__init__.py
+++ b/mycroft/audio/services/chromecast/__init__.py
@@ -98,8 +98,12 @@ class ChromecastService(AudioBackend):
 
     def stop(self):
         """ Stop playback and quit app. """
-        self.cast.media_controller.stop()
-        self.cast.quit_app()
+        if self.cast.media_controller.is_playing:
+            self.cast.media_controller.stop()
+            self.cast.quit_app()
+            return True
+        else:
+            return False
 
     def pause(self):
         """ Pause current playback. """

--- a/mycroft/audio/services/mopidy/__init__.py
+++ b/mycroft/audio/services/mopidy/__init__.py
@@ -78,8 +78,12 @@ class MopidyService(AudioBackend):
         self.mopidy.play()
 
     def stop(self):
-        self.mopidy.clear_list()
-        self.mopidy.stop()
+        if self.mopidy.is_playing():
+            self.mopidy.clear_list()
+            self.mopidy.stop()
+            return True
+        else:
+            return False
 
     def pause(self):
         self.mopidy.pause()

--- a/mycroft/audio/services/mpg123/__init__.py
+++ b/mycroft/audio/services/mpg123/__init__.py
@@ -87,10 +87,14 @@ class Mpg123Service(AudioBackend):
 
     def stop(self):
         LOG.info('Mpg123ServiceStop')
-        self._stop_signal = True
-        while self._is_playing:
-            sleep(0.1)
-        self._stop_signal = False
+        if self._is_playing:
+            self._stop_signal = True
+            while self._is_playing:
+                sleep(0.01)
+            self._stop_signal = False
+            return True
+        else:
+            return False
 
     def pause(self):
         pass

--- a/mycroft/audio/services/mplayer/__init__.py
+++ b/mycroft/audio/services/mplayer/__init__.py
@@ -58,6 +58,7 @@ class MPlayerService(AudioBackend):
 
     def stop(self):
         self.mpc.stop()
+        return True  # TODO: Return False if not playing
 
     def pause(self):
         if not self.mpc.paused:

--- a/mycroft/audio/services/vlc/__init__.py
+++ b/mycroft/audio/services/vlc/__init__.py
@@ -58,8 +58,12 @@ class VlcService(AudioBackend):
 
     def stop(self):
         LOG.info('VLCService Stop')
-        self.clear_list()
-        self.list_player.stop()
+        if self.player.is_playing():
+            self.clear_list()
+            self.list_player.stop()
+            return True
+        else:
+            return False
 
     def pause(self):
         self.player.set_pause(1)


### PR DESCRIPTION
## Description
This allows for example the news skill playback to be stopped without
the listening being triggered.

## How to test
Install on a Mark-1 device, start the news skill and press the stop button. The device should stop playing the news but not start listening.

## Contributor license agreement signed?
CLA [Yes]