### PR TITLE
Ogg123

### DIFF
--- a/mycroft/audio/services/ogg123/__init__.py
+++ b/mycroft/audio/services/ogg123/__init__.py
@@ -1,0 +1,123 @@
+# Copyright 2017 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import subprocess
+from time import sleep
+
+from mycroft.audio.services import AudioBackend
+from mycroft.messagebus.message import Message
+from mycroft.util.log import LOG
+
+
+class Ogg123Service(AudioBackend):
+    """
+        Audio backend for ogg123 player. This one is rather limited and
+        only implements basic usage.
+    """
+
+    def __init__(self, config, emitter, name='ogg123'):
+        super(Ogg123Service, self).__init__(config, emitter)
+        self.config = config
+        self.process = None
+        self.emitter = emitter
+        self.name = name
+        self._stop_signal = False
+        self._is_playing = False
+        self.index = 0
+        self.tracks = []
+
+        self.emitter.on('Ogg123ServicePlay', self._play)
+
+    def supported_uris(self):
+        return ['file', 'http']
+
+    def clear_list(self):
+        self.tracks = []
+
+    def add_list(self, tracks):
+        self.tracks += tracks
+        LOG.info("Track list is " + str(tracks))
+
+    def _play(self, message=None):
+        """ Implementation specific async method to handle playback.
+            This allows ogg123 service to use the "next method as well
+            as basic play/stop.
+        """
+        LOG.info('Ogg123Service._play')
+        self._is_playing = True
+        track = self.tracks[self.index]
+        # Indicate to audio service which track is being played
+        if self._track_start_callback:
+            self._track_start_callback(track)
+
+        # Replace file:// uri's with normal paths
+        track = track.replace('file://', '')
+
+        self.process = subprocess.Popen(['ogg123', track])
+        # Wait for completion or stop request
+        while self.process.poll() is None and not self._stop_signal:
+            sleep(0.25)
+
+        if self._stop_signal:
+            self.process.terminate()
+            self.process = None
+            self._is_playing = False
+            return
+
+        self.index += 1
+        # if there are more tracks available play next
+        if self.index < len(self.tracks):
+            self.emitter.emit(Message('Ogg123ServicePlay'))
+        else:
+            self._is_playing = False
+
+    def play(self):
+        LOG.info('Call Ogg123ServicePlay')
+        self.index = 0
+        self.emitter.emit(Message('Ogg123ServicePlay'))
+
+    def stop(self):
+        LOG.info('Ogg123ServiceStop')
+        self._stop_signal = True
+        while self._is_playing:
+            sleep(0.1)
+        self._stop_signal = False
+
+    def pause(self):
+        pass
+
+    def resume(self):
+        pass
+
+    def next(self):
+        # Terminate process to continue to next
+        self.process.terminate()
+
+    def previous(self):
+        pass
+
+    def lower_volume(self):
+        pass
+
+    def restore_volume(self):
+        pass
+
+
+def load_service(base_config, emitter):
+    backends = base_config.get('backends', [])
+    services = [(b, backends[b]) for b in backends
+                if backends[b]['type'] == 'ogg123' and
+                backends[b].get('active', True)]
+    instances = [Ogg123Service(s[1], emitter, s[0]) for s in services]
+    return instances

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -54,7 +54,11 @@
   // Mechanism used to play MP3 audio files
   // Override: SYSTEM
   "play_mp3_cmdline": "mpg123 %1",
-  
+
+  // Mechanism used to play OGG audio files
+  // Override: SYSTEM
+  "play_ogg_cmdline": "ogg123 -q %1",
+
   // Location where the system resides
   // NOTE: Although this is set here, an Enclosure can override the value.
   //       For example a mycroft-core running in a car could use the GPS.
@@ -292,6 +296,10 @@
     "backends": {
       "local": {
         "type": "mpg123",
+        "active": true
+      },
+      "ogg": {
+        "type": "ogg123",
         "active": true
       },
       "vlc": {

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -32,7 +32,7 @@ import mycroft.audio
 import mycroft.configuration
 from mycroft.util.format import nice_number
 # Officially exported methods from this file:
-# play_wav, play_mp3, get_cache_directory,
+# play_wav, play_mp3, play_ogg, get_cache_directory,
 # resolve_resource_file, wait_while_speaking
 from mycroft.util.log import LOG
 from mycroft.util.parse import extract_datetime, extractnumber, normalize
@@ -106,6 +106,14 @@ def play_mp3(uri):
             play_mp3_cmd[index] = (get_http(uri))
     return subprocess.Popen(play_mp3_cmd)
 
+def play_ogg(uri):
+    config = mycroft.configuration.Configuration.get()
+    play_cmd = config.get("play_ogg_cmdline")
+    play_ogg_cmd = str(play_cmd).split(" ")
+    for index, cmd in enumerate(play_ogg_cmd):
+        if cmd == "%1":
+            play_ogg_cmd[index] = (get_http(uri))
+    return subprocess.Popen(play_ogg_cmd)
 
 def record(file_path, duration, rate, channels):
     if duration > 0:

--- a/test/unittests/util/commented.json
+++ b/test/unittests/util/commented.json
@@ -28,6 +28,7 @@
   },
   "play_wav_cmdline": "aplay %1",
   "play_mp3_cmdline": "mpg123 %1",
+  "play_ogg_cmdline": "ogg123 %1",
   "location": {
     "city": {
       "code": "Lawrence",

--- a/test/unittests/util/plain.json
+++ b/test/unittests/util/plain.json
@@ -10,6 +10,7 @@
   },
   "play_wav_cmdline": "aplay %1",
   "play_mp3_cmdline": "mpg123 %1",
+  "play_ogg_cmdline": "ogg123 %1",
   "location": {
     "city": {
       "code": "Lawrence",


### PR DESCRIPTION
This is reimplementation of #1649 which became divergent.

## Description
Adds a Ogg123Service and a play_ogg exactly like Mpg123Service and play_mp3

## How to test
I have a skill for a podcast which does not have an mp3 feed:
https://github.com/joshuacox/skill-GNUworldOrder

## Contributor license agreement signed?
signed by @joshuacox
