### PR TITLE
Remove stray lock.release()

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -117,8 +117,8 @@ def mute_and_speak(utterance, ident):
     LOG.info("Speak: " + utterance)
     try:
         tts.execute(utterance, ident)
-    finally:
-        lock.release()
+    except Exception as e:
+        LOG.error('TTS execution failed ({})'.format(repr(e)))
 
 
 def handle_stop(event):


### PR DESCRIPTION
## Description

This fixes a stray lock.release() causing a silent

`RuntimeError: release unlocked lock`

after TTS execution but just before reporting the timing for the TTS system. This removes the extra release and uses only `with lock` context manager's release.

## How to test
Not sure the best way, I used the debugger and set a breakpoint at mycroft/audio/speech.py L92 and checked that the program reached that point without incidents.

## Contributor license agreement signed?
CLA [Yes]