### PR TITLE
Add 'venv-activate.sh' script

### DIFF
--- a/venv-activate.sh
+++ b/venv-activate.sh
@@ -24,5 +24,7 @@ if [ "$0" = "$BASH_SOURCE" ] ; then
     echo "ERROR: Invoke with 'source venv-activate.sh' or '. venv-activate.sh'"
 else
     echo "Entering mycroft-core virtual environment.  Run 'deactivate' to exit"
-    source .venv/bin/activate
+    MVA_SRC_DIR="$( cd "$( dirname "${BASH_SOURCE}" )" ; pwd -P )"
+    source ${MVA_SRC_DIR}/.venv/bin/activate
+    unset MVA_SRC_DIR
 fi

--- a/venv-activate.sh
+++ b/venv-activate.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright 2018 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This script places the user in the mycroft-core virtual environment,
+# necessary to run unit tests or to interact directly with mycroft-core
+# via an interactive Python shell.
+
+if [ "$0" = "$BASH_SOURCE" ] ; then
+    # Prevent running in script then exiting immediately
+    echo "ERROR: Invoke with 'source venv-activate.sh' or '. venv-activate.sh'"
+else
+    echo "Entering mycroft-core virtual environment.  Run 'deactivate' to exit"
+    source .venv/bin/activate
+fi


### PR DESCRIPTION
## Description

This script in the root of a Github checkout makes it easier for devs to discover
the virtual environment which Mycroft should run under.  Virtual
environments are new to many, so the commands aren't obvious even
if they are only one liners.

====  Documentation Notes ====
Should probably be mentioned in the Getting Started docs for
Github users.  This mirrors the 'mycroft-venv-activate' alias found
under Mark 1/Picroft.

(Description of what the PR does, such as fixes # {issue number})

## How to test
Github install, try running "bash venv-activate.sh" and then ". venv-activate.sh"

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
