### PR TITLE
MAXCORES bug fix in dev_setup.sh 

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -198,12 +198,11 @@ if ! pip install -r test-requirements.txt; then
   echo "Warning test requirements wasn't installed, Note: normal operation should still work fine..."
 fi
 
-SYSMEM=$(free|awk '/^Mem:/{print $2}')
-MAXCORES=$(($SYSMEM / 512000))
+MINCORES=1
 CORES=$(nproc)
 
-if [[ ${MAXCORES} -lt ${CORES} ]]; then
-  CORES=${MAXCORES}
+if [[ ${CORES} -lt ${MINCORES} ]]; then
+  CORES=${MINCORES}
 fi
 echo "Building with $CORES cores."
 

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -198,8 +198,15 @@ if ! pip install -r test-requirements.txt; then
   echo "Warning test requirements wasn't installed, Note: normal operation should still work fine..."
 fi
 
+SYSMEM=$(free|awk '/^Mem:/{print $2}')
+MAXCORES=$(($SYSMEM / 512000))
 MINCORES=1
 CORES=$(nproc)
+
+# ensure MAXCORES is > 0
+if [[ ${MAXCORES} -lt 1 ]]; then
+	MAXCORES=${MINCORES}
+fi
 
 # look for positive integer
 if ! [[ ${CORES} =~ ^[0-9]+$ ]]; then

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -211,7 +211,10 @@ fi
 # look for positive integer
 if ! [[ ${CORES} =~ ^[0-9]+$ ]]; then
   CORES=${MINCORES}
+elif [[ ${MAXCORES} -lt ${CORES} ]]; then
+  CORES=${MAXCORES}
 fi
+
 echo "Building with $CORES cores."
 
 #build and install pocketsphinx

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -201,7 +201,8 @@ fi
 MINCORES=1
 CORES=$(nproc)
 
-if [[ ${CORES} -lt ${MINCORES} ]]; then
+# look for positive integer
+if ! [[ ${CORES} =~ ^[0-9]+$ ]]; then
   CORES=${MINCORES}
 fi
 echo "Building with $CORES cores."


### PR DESCRIPTION
Replaced MAXCORES and SYSMEM with MINCORES=1 and check to ensure at least 1 core will be used to compile mimic

## Description
- Removes SYSMEM and MAXCORES variables
- Adds MINCORES=1
- Changes check for CORES to look for positive integers,   if fail CORES is set to ${MAXCORES}

## How to test
use dev_setup.sh to build mimic

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
Agreement request sent from Jeremy Wallace (wallace.jeremyc@gmail.com)
