### PR TITLE
allow disabling intent in initialize

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -124,8 +124,8 @@ def load_skill(skill_descriptor, emitter, skill_id, BLACKLISTED_SKILLS=None):
             skill.skill_id = skill_id
             skill.load_data_files(path)
             # Set up intent handlers
-            skill.initialize()
             skill._register_decorated()
+            skill.initialize()
             LOG.info("Loaded " + name)
 
             # The very first time a skill is run, speak the intro


### PR DESCRIPTION
## Description

in some skill i want to start with intents disabled (self.enable_intent + self.disable_intent), however initialize is called before registering intents made with decorators


## How to test

verify things work normally

use self.disable_intent(name) in initialize method, check that name will not trigger

## Contributor license agreement signed?
CLA [yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
