### PR TITLE
padatious enable/disable

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -695,10 +695,12 @@ class MycroftSkill(object):
                 handler:     function to register with intent
         """
         name = str(self.skill_id) + ':' + intent_file
-        self.emitter.emit(Message("padatious:register_intent", {
+        data = {
             "file_name": join(self.vocab_dir, intent_file),
             "name": name
-        }))
+        }
+        self.emitter.emit(Message("padatious:register_intent", data))
+        self.registered_intents.append((intent_file, data))
         self.add_event(name, handler, 'mycroft.skill.handler')
 
     def register_entity_file(self, entity_file):
@@ -782,7 +784,10 @@ class MycroftSkill(object):
             intent = intents[names.index(intent_name)]
             self.registered_intents.remove((intent_name, intent))
             intent.name = intent_name
-            self.register_intent(intent, None)
+            if ".intent" in intent_name:
+                self.register_intent_file(intent, None)
+            else:
+                self.register_intent(intent, None)
             LOG.debug('Enabling intent ' + intent_name)
             return True
         LOG.error('Could not enable ' + intent_name + ', it hasn\'t been '

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -783,10 +783,10 @@ class MycroftSkill(object):
         if intent_name in names:
             intent = intents[names.index(intent_name)]
             self.registered_intents.remove((intent_name, intent))
-            intent.name = intent_name
             if ".intent" in intent_name:
-                self.register_intent_file(intent, None)
+                self.register_intent_file(intent_name, None)
             else:
+                intent.name = intent_name
                 self.register_intent(intent, None)
             LOG.debug('Enabling intent ' + intent_name)
             return True

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -48,6 +48,7 @@ class PadatiousService(FallbackSkill):
         self.emitter = emitter
         self.emitter.on('padatious:register_intent', self.register_intent)
         self.emitter.on('padatious:register_entity', self.register_entity)
+        self.emitter.on('detach_intent', self.handle_detach_intent)
         self.emitter.on('mycroft.skills.initialized', self.train)
         self.register_fallback(self.handle_fallback, 5)
         self.finished_training_event = Event()
@@ -77,6 +78,10 @@ class PadatiousService(FallbackSkill):
         if self.train_time <= get_time() + 0.01:
             self.train_time = -1.0
             self.train()
+
+    def handle_detach_intent(self, message):
+        intent_name = message.data.get('intent_name')
+        self.container.remove_intent(intent_name)
 
     def _register_object(self, message, object_name, register_func):
         file_name = message.data['file_name']


### PR DESCRIPTION
## Description
Padatious intents were ignored by self.enable_intent and self.disable_intent

this PR makes padatious service listen for detach intent messages, and allows padatious intent support for these 2 methods

## How to test

self.disable_intent("name.intent"), verify that intent does not trigger
self.enable_intent("name.intent"), verify that intent triggers again

## Contributor license agreement signed?
CLA [yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
