### PR TITLE
Bugfix/unmunge

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -71,7 +71,8 @@ def unmunge_message(message, skill_id):
     if isinstance(message, Message) and isinstance(message.data, dict):
         skill_id = to_alnum(skill_id)
         for key in list(message.data.keys()):
-            if key[:len(skill_id)] == skill_id:
+            if key.startswith(skill_id):
+                # replace the munged key with the real one
                 new_key = key[len(skill_id):]
                 message.data[new_key] = message.data.pop(key)
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -70,7 +70,7 @@ def unmunge_message(message, skill_id):
     """
     if isinstance(message, Message) and isinstance(message.data, dict):
         skill_id = to_alnum(skill_id)
-        for key in message.data:
+        for key in list(message.data.keys()):
             if key[:len(skill_id)] == skill_id:
                 new_key = key[len(skill_id):]
                 message.data[new_key] = message.data.pop(key)


### PR DESCRIPTION
## Description
The unmunge of keywords would in rare cases miss keys due to the fact that the dict is modified while being iterated. This breaks out the keys into a list before iterating through them to ensure that all original keys are checked.

## How to test
Make sure intents works as they have previously.

## Contributor license agreement signed?
CLA [Yes]