### PR TITLE
Improve date-time formatting in English

### DIFF
--- a/mycroft/res/text/en-us/date_time.json
+++ b/mycroft/res/text/en-us/date_time.json
@@ -32,7 +32,7 @@
     "date_format": {
     "date_full": "{weekday}, {month} {day}, {formatted_year}",
     "date_full_no_year": "{weekday}, {month} {day}",
-    "date_full_no_year_month": "{weekday}, {day}",
+    "date_full_no_year_month": "{weekday}, the {day}",
     "today": "today",
     "tomorrow": "tomorrow",
     "yesterday": "yesterday"

--- a/mycroft/res/text/en-us/date_time_test.json
+++ b/mycroft/res/text/en-us/date_time_test.json
@@ -29,7 +29,7 @@
     "1": {"datetime_param": "2017, 1, 31, 0, 2, 3", "now": "None", "assertEqual": "tuesday, january thirty-first, twenty seventeen"},
     "2": {"datetime_param": "2018, 2, 4, 0, 2, 3", "now": "2017, 1, 1, 0, 2, 3", "assertEqual": "sunday, february fourth, twenty eighteen"},
     "3": {"datetime_param": "2018, 2, 4, 0, 2, 3", "now": "2018, 1, 1, 0, 2, 3", "assertEqual": "sunday, february fourth"},
-    "4": {"datetime_param": "2018, 2, 4, 0, 2, 3", "now": "2018, 2, 1, 0, 2, 3", "assertEqual": "sunday, fourth"},
+    "4": {"datetime_param": "2018, 2, 4, 0, 2, 3", "now": "2018, 2, 1, 0, 2, 3", "assertEqual": "sunday, the fourth"},
     "5": {"datetime_param": "2018, 2, 4, 0, 2, 3", "now": "2018, 2, 3, 0, 2, 3", "assertEqual": "tomorrow"},
     "6": {"datetime_param": "2018, 2, 4, 0, 2, 3", "now": "2018, 2, 4, 0, 2, 3", "assertEqual": "today"},
     "7": {"datetime_param": "2018, 2, 4, 0, 2, 3", "now": "2018, 2, 5, 0, 2, 3", "assertEqual": "yesterday"},
@@ -37,7 +37,7 @@
     "9": {"datetime_param": "2018, 2, 4, 0, 2, 3", "now": "2019, 2, 6, 0, 2, 3", "assertEqual": "sunday, february fourth, twenty eighteen"}
   },
   "test_nice_date_time": {
-    "1": {"datetime_param": "2017, 1, 31, 13, 22, 3", "now": "None", "use_24hour": "False", "use_ampm": "True", "assertEqual": "tuesday, january thirty-first, twenty seventeen at one twenty two PM"},
+    "1": {"datetime_param": "2017, 1, 31, 13, 22, 3", "now": "None", "use_24hour": "False", "use_ampm": "True", "assertEqual": "tuesday, january thirty-first, twenty seventeen at one twenty two p.m."},
     "2": {"datetime_param": "2017, 1, 31, 13, 22, 3", "now": "None", "use_24hour": "True", "use_ampm": "False", "assertEqual": "tuesday, january thirty-first, twenty seventeen at thirteen twenty two"}
   }
 }


### PR DESCRIPTION
The pronunciation of English date-time was awkward without the word "the"
for dates like "Monday, the 16th at eight a.m."

Also corrected the tests to use the newer lower case "a.m." instead of "AM"

## How to test
Set an alarm for next week, it will awkwardly pronounce the date.

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
