### PR TITLE
Add new MycroftSkill.ask_yesno() method

### DIFF
--- a/mycroft/res/text/en-us/no.voc
+++ b/mycroft/res/text/en-us/no.voc
@@ -1,0 +1,3 @@
+cancel
+nevermind
+forget it

--- a/mycroft/res/text/en-us/no.voc
+++ b/mycroft/res/text/en-us/no.voc
@@ -1,3 +1,4 @@
-cancel
-nevermind
-forget it
+no
+nope
+nah
+negative

--- a/mycroft/res/text/en-us/yes.voc
+++ b/mycroft/res/text/en-us/yes.voc
@@ -1,0 +1,3 @@
+cancel
+nevermind
+forget it

--- a/mycroft/res/text/en-us/yes.voc
+++ b/mycroft/res/text/en-us/yes.voc
@@ -1,3 +1,5 @@
-cancel
-nevermind
-forget it
+yes
+yeah
+yep
+sure
+please

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -372,13 +372,8 @@ class MycroftSkill(object):
             else:
                 return get_announcement()
 
-        # TODO: Load with something like mycroft.dialog.get_all()
-        cancel_voc = 'text/' + self.lang + '/cancel.voc'
-        with open(resolve_resource_file(cancel_voc)) as f:
-            cancel_words = list(filter(bool, f.read().split('\n')))
-
         def is_cancel(utterance):
-            return utterance in cancel_words
+            return self.is_match(utterance, 'cancel')
 
         def validator_default(utterance):
             # accept anything except 'cancel'
@@ -412,6 +407,53 @@ class MycroftSkill(object):
 
             line = on_fail_fn(response)
             self.speak(line, expect_response=True)
+
+    def ask_yesno(self, prompt, data=None):
+        """
+        Read prompt and wait for a yes/no answer
+
+        This automatically deals with translation and common variants,
+        such as 'yeah', 'sure', etc.
+
+        Args:
+              prompt (str): a dialog id or string to read
+        Returns:
+              string:  'yes', 'no' or whatever the user response if not
+                       one of those, including None
+        """
+        resp = self.get_response(dialog=prompt, data=data)
+
+        if self.is_match(resp, 'yes'):
+            return 'yes'
+
+        if self.is_match(resp, 'no'):
+            return 'no'
+
+        return resp
+
+    def is_match(self, utt, voc_filename, lang=None):
+        """ Determine if the given utterance contains the vocabular proviced
+
+        This checks for vocabulary match in the utternce instead of the other
+        way around to allow the user to say things like "yes, please" and
+        still match against voc files with only "yes" in it.
+
+        Args:
+            utt (str): Utterance to be tested
+            voc_filename (str): Name of vocabulary file (e.g. 'yes' for
+                                'res/text/en-us/yes.voc')
+            lang (str): Language code, defaults to self.long
+
+        Returns:
+            bool: True if the utterance has the given vocabulary it
+        """
+        lang = lang or self.lang
+        voc = join('text', self.lang, voc_filename+".voc")
+        with open(resolve_resource_file(voc)) as f:
+            words = list(filter(bool, f.read().split('\n')))
+        if (utt and any(i.strip() in utt for i in words)):
+            return True
+        return False
 
     def report_metric(self, name, data):
         """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -359,6 +359,12 @@ class MycroftSkill(object):
         data = data or {}
 
         def get_announcement():
+            nonlocal announcement
+            # The dialog param can be either a spoken string or a dialog file
+            # TODO: 18.08 merge dialog/announcement
+            if not exists(join(self.root_dir, 'dialog', self.lang,
+                               dialog + '.dialog')) and not announcement:
+                announcement = dialog
             return announcement or self.dialog_renderer.render(dialog, data)
 
         if not get_announcement():


### PR DESCRIPTION
New function allows simple yes/no queries to be asked, capturing common
affirmations (e.g. "yes", "yeah", "yep", "sure", ...) and rejections
("no", "nope", ...) that are consistent across all skills.

The method will return a normalized 'yes', 'no' or whatever else is spoken
for further parsing.  None is also possible.

This also adds the MycroftSkill.is_match() method to assist in matching
translated synonyms within an utterance.

## Description
(Description of what the PR does, such as fixes # {issue number})

## How to test
(Description of how to validate or test this PR)

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
