### PR TITLE
Allow reference dates with tzinfo

### DIFF
--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -990,8 +990,7 @@ def extract_datetime_en(string, currentDate):
                                     year=int(currentYear),
                                     month=int(temp.strftime("%m")),
                                     day=int(temp.strftime("%d")),
-                                    tzinfo=extractedDate.tzinfo
-                                )
+                                    tzinfo=extractedDate.tzinfo)
             else:
                 extractedDate = extractedDate.replace(
                     year=int(currentYear) + 1,

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -983,24 +983,29 @@ def extract_datetime_en(string, currentDate):
             temp = datetime.strptime(datestr, "%B %d %Y")
         extractedDate = extractedDate.replace(hour=0, minute=0, second=0)
         if not hasYear:
-            temp = temp.replace(year=extractedDate.year)
+            temp = temp.replace(year=extractedDate.year,
+                                tzinfo=extractedDate.tzinfo)
             if extractedDate < temp:
                 extractedDate = extractedDate.replace(year=int(currentYear),
                                                       month=int(
                                                           temp.strftime(
                                                               "%m")),
                                                       day=int(temp.strftime(
-                                                          "%d")))
+                                                          "%d")),
+                                                      tzinfo=extractedDate.tzinfo
+                                                          )
             else:
                 extractedDate = extractedDate.replace(
                     year=int(currentYear) + 1,
                     month=int(temp.strftime("%m")),
-                    day=int(temp.strftime("%d")))
+                    day=int(temp.strftime("%d")),
+                    tzinfo=extractedDate.tzinfo)
         else:
             extractedDate = extractedDate.replace(
                 year=int(temp.strftime("%Y")),
                 month=int(temp.strftime("%m")),
-                day=int(temp.strftime("%d")))
+                day=int(temp.strftime("%d")),
+                tzinfo=extractedDate.tzinfo)
     else:
         # ignore the current HH:MM:SS if relative using days or greater
         if not timeStr and hrOffset == 0 and minOffset == 0 and secOffset == 0:
@@ -1010,7 +1015,8 @@ def extract_datetime_en(string, currentDate):
         temp = datetime(timeStr)
         extractedDate = extractedDate.replace(hour=temp.strftime("%H"),
                                               minute=temp.strftime("%M"),
-                                              second=temp.strftime("%S"))
+                                              second=temp.strftime("%S"),
+                                              tzinfo=extractedDate.tzinfo)
 
     if yearOffset != 0:
         extractedDate = extractedDate + relativedelta(years=yearOffset)

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -986,14 +986,12 @@ def extract_datetime_en(string, currentDate):
             temp = temp.replace(year=extractedDate.year,
                                 tzinfo=extractedDate.tzinfo)
             if extractedDate < temp:
-                extractedDate = extractedDate.replace(year=int(currentYear),
-                                                      month=int(
-                                                          temp.strftime(
-                                                              "%m")),
-                                                      day=int(temp.strftime(
-                                                          "%d")),
-                                                      tzinfo=extractedDate.tzinfo
-                                                          )
+                extractedDate = extractedDate.replace(
+                                    year=int(currentYear),
+                                    month=int(temp.strftime("%m")),
+                                    day=int(temp.strftime("%d")),
+                                    tzinfo=extractedDate.tzinfo
+                                )
             else:
                 extractedDate = extractedDate.replace(
                     year=int(currentYear) + 1,


### PR DESCRIPTION
The extract_datetime_en() function could cause an exception if the currentData parameter contained tzinfo.

## How to test
If I recall, call extract_datetime( "set an alarm for August 8th at 8pm", now_local() ).  It shouldn't cause an exception anymore.

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
