### PR TITLE
Fix updating padatious intents after intent reload

### DIFF
--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -58,7 +58,10 @@ class PadatiousService(FallbackSkill):
         self.train_time = get_time() + self.train_delay
 
     def train(self, message=None):
-        single_thread = message.data.get('single_thread', False)
+        if message is None:
+            single_thread = False
+        else:
+            single_thread = message.data.get('single_thread', False)
         self.finished_training_event.clear()
 
         LOG.info('Training...')


### PR DESCRIPTION
## Description
Training is called from wait_and_train with None as message, this commit adds propper handling for this case.

## How to test
Install for example the cocktails skill and make sure the skill is usable afterwards.

## Contributor license agreement signed?
CLA [Yes]