### PR TITLE
Fix CLI screen corruption

### DIFF
--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -291,6 +291,7 @@ class MicMonitorThread(Thread):
                 meter_thresh = float(parts[-1])
                 meter_cur = float(parts[-2].split(" ")[0])
 
+
 class ScreenDrawThread(Thread):
     def __init__(self):
         Thread.__init__(self)
@@ -543,6 +544,7 @@ def _do_meter(height):
                 clr_bar = curses.color_pair(5)   # dark blue for 'silent'
             scr.addstr(curses.LINES - 1 - i, curses.COLS - len(str_thresh) - 4,
                        "*", clr_bar)
+
 
 def set_screen_dirty():
     global is_screen_dirty

--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -1066,7 +1066,21 @@ def gui_main(stdscr):
         while True:
             set_screen_dirty()
 
-            c = scr.get_wch()  # unicode char or int for special keys
+            try:
+                c = scr.get_wch()  # unicode char or int for special keys
+            except KeyboardInterrupt as e:
+                # User hit Ctrl+C to quit
+                if find_str:
+                    # End the find session
+                    find_str = None
+                    rebuild_filtered_log()
+                else:
+                    break
+            except:
+                # This happens in odd cases, such as when you Ctrl+Z suspend
+                # the CLI and then resume.  Curses fails on get_wch().
+                continue
+
             if isinstance(c, int):
                 code = c
             else:
@@ -1213,16 +1227,6 @@ def gui_main(stdscr):
                 # Accept typed character in the utterance
                 line += c
 
-            # DEBUG: Uncomment the following code to see what key codes
-            #        are generated when an unknown key is pressed.
-            # else:
-            #    line += str(c)
-
-    except KeyboardInterrupt as e:
-        # User hit Ctrl+C to quit
-        pass
-    except KeyboardInterrupt as e:
-        LOG.exception(e)
     finally:
         scr.erase()
         scr.refresh()

--- a/mycroft/client/text/main.py
+++ b/mycroft/client/text/main.py
@@ -1068,7 +1068,7 @@ def gui_main(stdscr):
 
             try:
                 c = scr.get_wch()  # unicode char or int for special keys
-            except KeyboardInterrupt as e:
+            except KeyboardInterrupt:
                 # User hit Ctrl+C to quit
                 if find_str:
                     # End the find session
@@ -1076,7 +1076,7 @@ def gui_main(stdscr):
                     rebuild_filtered_log()
                 else:
                     break
-            except:
+            except curses.error:
                 # This happens in odd cases, such as when you Ctrl+Z suspend
                 # the CLI and then resume.  Curses fails on get_wch().
                 continue


### PR DESCRIPTION
The CLI would often have temporary screen corruption.  This reworks
several things to correct that issue, although it looks like the
ultimate cause was drawing to the screen while in the middle of
waiting on a VT100 ESC keycode sequence.

* Rearchitected all screen drawing to run in a single thread.  Now
  call set_screen_dirty() instead of draw_screen()
* Added a lock on accessing the various Log buffers, preventing
  changes to the buffer in the middle of a redraw
* Modified key reading logic when ESC character is received.  Now
  uses a 1 second timeout if no subsequent keycodes are sent

## How to test
Start the CLI and hold the PgUp / PgDown key with a full log.  It would previously corrupt the screen.

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
