### PR TITLE
Immediately speak warning while Padatious trains

### DIFF
--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -109,7 +109,6 @@ class PadatiousService(FallbackSkill):
     def handle_fallback(self, message):
         if not self.finished_training_event.is_set():
             LOG.debug('Waiting for Padatious training to finish...')
-            # self.finished_training_event.wait()
             return False
 
         utt = message.data.get('utterance')

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -64,7 +64,7 @@ class PadatiousService(FallbackSkill):
             single_thread = message.data.get('single_thread', False)
         self.finished_training_event.clear()
 
-        LOG.info('Training...')
+        LOG.info('Training...'+str(single_thread))
         self.container.train(single_thread=single_thread)
         LOG.info('Training complete.')
 
@@ -107,13 +107,13 @@ class PadatiousService(FallbackSkill):
         self._register_object(message, 'entity', self.container.load_entity)
 
     def handle_fallback(self, message):
+        if not self.finished_training_event.is_set():
+            LOG.debug('Waiting for Padatious training to finish...')
+            # self.finished_training_event.wait()
+            return False
+
         utt = message.data.get('utterance')
         LOG.debug("Padatious fallback attempt: " + utt)
-
-        if not self.finished_training_event.is_set():
-            LOG.debug('Waiting for training to finish...')
-            self.finished_training_event.wait()
-
         data = self.container.calc_intent(utt)
 
         if data.conf < 0.5:

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -64,7 +64,7 @@ class PadatiousService(FallbackSkill):
             single_thread = message.data.get('single_thread', False)
         self.finished_training_event.clear()
 
-        LOG.info('Training...'+str(single_thread))
+        LOG.info('Training... (single_thread={})'.format(single_thread))
         self.container.train(single_thread=single_thread)
         LOG.info('Training complete.')
 


### PR DESCRIPTION
At startup, Padatious was blocking in the fallback while the
training occurred.  As a result, any attempts to use Mycroft
during that period would queue up rather than giving the
user feedback.  Now it immediately returns False, allowing
user notification to occur elsewhere.

## How to test
Say anything during skill startup

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
