### PR TITLE
Allow Padatious to override Adapt

### DIFF
--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -296,7 +296,8 @@ class IntentService(object):
                 report_timing(ident, 'intent_service', stopwatch,
                               {'intent_type': 'converse'})
                 return
-            elif intent and padatious_intent and padatious_intent.conf < 0.95:
+            elif intent and not (padatious_intent and
+                                 padatious_intent.conf >= 0.95):
                 # Send the message to the Adapt intent's handler unless
                 # Padatious is REALLY sure it was directed at it instead.
                 reply = message.reply(intent.get('intent_type'), intent)

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -26,8 +26,13 @@ from mycroft.util.log import LOG
 
 
 class PadatiousService(FallbackSkill):
+    instance = None
+
     def __init__(self, emitter, service):
         FallbackSkill.__init__(self)
+        if not PadatiousService.instance:
+            PadatiousService.instance = self
+
         self.config = Configuration.get()['padatious']
         self.service = service
         intent_cache = expanduser(self.config['intent_cache'])
@@ -113,8 +118,7 @@ class PadatiousService(FallbackSkill):
 
         utt = message.data.get('utterance')
         LOG.debug("Padatious fallback attempt: " + utt)
-        data = self.container.calc_intent(utt)
-
+        data = self.calc_intent(utt)
         if data.conf < 0.5:
             return False
 
@@ -124,3 +128,6 @@ class PadatiousService(FallbackSkill):
 
         self.emitter.emit(message.reply(data.name, data=data.matches))
         return True
+
+    def calc_intent(self, utt):
+        return self.container.calc_intent(utt)


### PR DESCRIPTION
Allow a Padatious intent to override Adapt when it is VERY
certain that the utterance is directed at it.  (95% confidence
or greater.)  Right now that only occurs if the intent match
for the given phrase is perfect.

This solves this kind of issue:
* Adapt:  Matching on "Set" and "Alarm"
* Padatious: Handling "is an alarm set"

## Description
(Description of what the PR does, such as fixes # {issue number})

## How to test
Can be tested by creating the example mentioned above:
* Adapt:  Matching on "Set.voc" and "Alarm.voc" (containing those words)
* Padatious: Handling "alarm.status" that contains "is an alarm set"

The Padatious intent should match on "is an alarm set" but not on "is a alarm set"

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
