### PR TITLE
Better logging around why writing .PHO file fails.

### DIFF
--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -351,8 +351,8 @@ class TTS(object):
         try:
             with open(pho_file, "w") as cachefile:
                 cachefile.write(phonemes)
-        except:
-            LOG.debug("Failed to write .PHO to cache")
+        except Exception:
+            LOG.exception("Failed to write %s to cache" % pho_file)
             pass
 
     def load_phonemes(self, key):


### PR DESCRIPTION
I need to know why this is failing, and the logs here give no indication of what file is being written or why it is failing. This commit hopefully fixes that (I say "hopefully" because I can't easily run it on the failing platform.)

I'd appreciate this making it into 18.2.13 so I can debug this more thoroughly in the next release. It doesn't appear to be a permissions issue, but as of now I just don't get enough info from this error to diagnose things further.