### PR TITLE
remove isSpeaking signal on audio startup

### DIFF
--- a/mycroft/audio/main.py
+++ b/mycroft/audio/main.py
@@ -32,6 +32,7 @@ from mycroft.messagebus.message import Message
 from mycroft.util import reset_sigint_handler, wait_for_exit_signal, \
     create_daemon, create_echo_function
 from mycroft.util.log import LOG
+from mycroft.util import check_for_signal
 
 try:
     import pulsectl
@@ -466,6 +467,7 @@ class AudioService(object):
 def main():
     """ Main function. Run when file is invoked. """
     reset_sigint_handler()
+    check_for_signal("isSpeaking")
     ws = WebsocketClient()
     Configuration.init(ws)
     speech.init(ws)

--- a/mycroft/audio/main.py
+++ b/mycroft/audio/main.py
@@ -30,9 +30,8 @@ from mycroft.configuration import Configuration
 from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.util import reset_sigint_handler, wait_for_exit_signal, \
-    create_daemon, create_echo_function
+    create_daemon, create_echo_function, check_for_signal
 from mycroft.util.log import LOG
-from mycroft.util import check_for_signal
 
 try:
     import pulsectl


### PR DESCRIPTION
## Description

fixes #1530 

"stuck waiting for the "isSpeaking" "signal" to clear. I dug into the "signals" and found they were just files written to /tmp/mycroft/ipc/signal.

Why didn't "isSpeaking" clear? I can only guess it was an earlier stop-mycroft.sh with unlucky timing. After stop-mycroft.sh, the file was still there. I removed the file and it worked.

Hours were lost."

## How to test
create a isSpeaking signal, kill mycroft process sudenly, check that after reboot it does not hang in wait_while_speaking methods

## Contributor license agreement signed?
CLA [yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
