### PR TITLE
Use full path in function check-dependencies

### DIFF
--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -144,7 +144,7 @@ function launch-all() {
 }
 
 function check-dependencies() {
-  if [ ! -f .installed ] || ! md5sum -c &> /dev/null < .installed ; then
+  if [ ! -f ~/mycroft-core/.installed ] || ! md5sum -c &> /dev/null < ~/mycroft-core/.installed ; then
     echo "Please update dependencies by running ./dev_setup.sh again."
     if command -v notify-send >/dev/null ; then
       notify-send "Mycroft Dependencies Outdated" "Run ./dev_setup.sh again"


### PR DESCRIPTION
## Description
In the start-mycroft.sh file the check-dependencies function uses local file references for the .installed
file. Add a path to the .installed references.

## How to test
ssh into a picroft system using the "Lighting preview". From the pi directory "source mycroft-core/start-mycroft.sh" you should be dropped from the picroft system with the message to "Please update dependencies by running ./dev_setup.sh again."

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
