### PR TITLE
Fix camel case splitting

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -39,7 +39,7 @@ from mycroft.metrics import report_metric, report_timing, Stopwatch
 from mycroft.skills.settings import SkillSettings
 from mycroft.skills.skill_data import (load_vocabulary, load_regex, to_alnum,
                                        munge_regex, munge_intent_parser)
-from mycroft.util import resolve_resource_file
+from mycroft.util import camel_case_split, resolve_resource_file
 from mycroft.util.log import LOG
 
 MainModule = '__init__'
@@ -648,7 +648,7 @@ class MycroftSkill(object):
 
             except Exception as e:
                 # Convert "MyFancySkill" to "My Fancy Skill" for speaking
-                handler_name = re.sub(r"([a-z])([A-Z])", r"\1 \2", self.name)
+                handler_name = camel_case_split(self.name)
                 msg_data = {'skill': handler_name}
                 msg = dialog.get('skill.error', self.lang, msg_data)
                 self.speak(msg)

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 from __future__ import absolute_import
+import re
 import socket
 import subprocess
 from os.path import join, expanduser
@@ -362,3 +363,10 @@ def create_echo_function(name, whitelist=None):
             pass
         LOG(name).debug(message)
     return echo
+
+
+def camel_case_split(identifier: str) -> str:
+    """Split camel case string"""
+    regex = '.+?(?:(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|$)'
+    matches = re.finditer(regex, identifier)
+    return ' '.join([m.group(0) for m in matches])


### PR DESCRIPTION
Signed-off-by: Julien Kassar <github@kassisol.com>

## Description
It returns the passed argument `PublicIPSkill` to `Public IP Skill` instead of `Public IPSkill`

Found the function to split correctly camel case in this [post](https://stackoverflow.com/questions/29916065/how-to-do-camelcase-split-in-python)

## Contributor license agreement signed?
CLA [Yes]