### PR TITLE
Add retry limit for chromecast detection

### DIFF
--- a/mycroft/audio/services/chromecast/__init__.py
+++ b/mycroft/audio/services/chromecast/__init__.py
@@ -152,7 +152,7 @@ def autodetect(config, emitter):
     """
         Autodetect chromecasts on the network and create backends for each
     """
-    casts = pychromecast.get_chromecasts()
+    casts = pychromecast.get_chromecasts(timeout=5, tries=2, retry_wait=2)
     ret = []
     for c in casts:
         LOG.info(c.name + " found.")


### PR DESCRIPTION
## Description
Limit the connection tries to 2 and lower the timeout to 5 seconds.

## Contributor license agreement signed?
CLA [Yes]