### PR TITLE
Remove Docker check from `source-venv` to be consistent with dev_setup.sh, which always initializes a virtualenv.

### DIFF
--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -75,10 +75,7 @@ function name-to-script-path() {
 }
 
 function source-venv() {
-    # Enter Python virtual environment, unless under Docker
-    if [ ! -f "/.dockerenv" ] ; then
-        source ${VIRTUALENV_ROOT}/bin/activate
-    fi
+    source ${VIRTUALENV_ROOT}/bin/activate
 }
 
 first_time=true


### PR DESCRIPTION
Not sure if this is the correct fix, but it seems to work.

Closes #1730