### PR TITLE
Set the directory explicitly start-mycroft.sh scripts

### DIFF
--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -18,7 +18,8 @@ SOURCE="${BASH_SOURCE[0]}"
 
 script=${0}
 script=${script##*/}
-DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+cd -P "$( dirname "$SOURCE" )"
+DIR="$( pwd )"
 VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${DIR}/.venv"}
 
 function help() {

--- a/stop-mycroft.sh
+++ b/stop-mycroft.sh
@@ -18,7 +18,8 @@ SOURCE="${BASH_SOURCE[0]}"
 
 script=${0}
 script=${script##*/}
-DIR="$( cd -P "$( dirname "$SOURCE" )" && pwd )"
+cd -P "$( dirname "$SOURCE" )"
+DIR="$( pwd )"
 
 function help() {
     echo "${script}:  Mycroft service stopper"

--- a/stop-mycroft.sh
+++ b/stop-mycroft.sh
@@ -19,7 +19,6 @@ SOURCE="${BASH_SOURCE[0]}"
 script=${0}
 script=${script##*/}
 cd -P "$( dirname "$SOURCE" )"
-DIR="$( pwd )"
 
 function help() {
     echo "${script}:  Mycroft service stopper"


### PR DESCRIPTION
Explicitly setting the directory at the beginning of the start-mycroft.sh
and stop-mycroft.sh scripts.  The behaves better if invoked from a
different directory.

This is a cleaner and more reliable solution than #1722.  We can close that
PR once this is merged.

## How to test
Attempt to run using a path, e.g.
```
cd ~
./mycroft-core/start-mycroft.sh debug.sh
```

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
