### PR TITLE
restrict str.replace from doing a global string replacement

### DIFF
--- a/mycroft/tts/mimic2_tts.py
+++ b/mycroft/tts/mimic2_tts.py
@@ -246,7 +246,7 @@ class Mimic2(TTS):
                 for num in numbers
             ]
             for num, norm_num in normalized_num:
-                sentence = sentence.replace(num, norm_num)
+                sentence = sentence.replace(num, norm_num, 1)
         except TypeError:
             LOG.exception("type error in mimic2_tts.py _normalized_numbers()")
         return sentence


### PR DESCRIPTION
## Description
str.replace was globally replacing values in a string. this caused unwanted replacement of values in strings. limit str.replace to only do one replacement.


## How to test

- pull branch
- tell Mycroft "say 2 12". response should be two twelve and not two one two.


## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
