### PR TITLE
 fix for broken communication with Arduino,  added missing skill.error.dialog for language de-de

### DIFF
--- a/mycroft/client/enclosure/__init__.py
+++ b/mycroft/client/enclosure/__init__.py
@@ -69,7 +69,13 @@ class EnclosureReader(Thread):
             try:
                 data = self.serial.readline()[:-2]
                 if data:
-                    self.process(data.decode())
+                    try:
+                        data_str = data.decode()
+                    except UnicodeError as e:
+                        data_str = data.decode('utf-8', errors='replace')
+                        LOG.warning('Invalid characters in response from '
+                                    ' enclosure: {}'.format(repr(e)))
+                    self.process(data_str)
             except Exception as e:
                 LOG.error("Reading error: {0}".format(e))
 

--- a/mycroft/res/text/de-de/skill.error.dialog
+++ b/mycroft/res/text/de-de/skill.error.dialog
@@ -1,0 +1,1 @@
+Bei der Verarbeitung der Anfrage ist ein Fehler im Skill {{skill}} aufgetreten.


### PR DESCRIPTION
## Description
1) fix for broken communication with Arduino:
After Mid July update Mark-I faceplate (eyes and led display controlled by Arduino) no longer worked
see: https://community.mycroft.ai/t/mark-i-no-longer-works-after-update/3929/10?u=dominik
2) added missing skill.error.dialog for language de-de
when Mycroft lang is set to "de-de" and an internal skill error occurs Mycroft says "skill.error" as no skill.error.dialog for german exists

## How to test
apply patch, restart all mycroft-services

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)