### PR TITLE
Remove deprecated API.find*() methods

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -303,21 +303,6 @@ class DeviceApi(Api):
             path = '/' + self.identity.uuid + '/voice?arch=' + arch
             return self.request({'path': path})['link']
 
-    def find(self):
-        """ Deprecated, see get_location() """
-        # TODO: Eliminate ASAP, for backwards compatibility only
-        return self.get()
-
-    def find_setting(self):
-        """ Deprecated, see get_settings() """
-        # TODO: Eliminate ASAP, for backwards compatibility only
-        return self.get_settings()
-
-    def find_location(self):
-        """ Deprecated, see get_location() """
-        # TODO: Eliminate ASAP, for backwards compatibility only
-        return self.get_location()
-
     def get_oauth_token(self, dev_cred):
         """
             Get Oauth token for dev_credential dev_cred.


### PR DESCRIPTION
The API.find/find_setting/find_location() methods were replaced by
API.get/get_setting/get_location() some time ago.  Permanently removing
the deprecated functions.

## How to test
Everything should still work without these features, these were deprecated some time ago.

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
