### PR TITLE
Remove deprecated extractnumber

### DIFF
--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -36,7 +36,7 @@ from mycroft.util.format import nice_number
 # play_wav, play_mp3, play_ogg, get_cache_directory,
 # resolve_resource_file, wait_while_speaking
 from mycroft.util.log import LOG
-from mycroft.util.parse import extract_datetime, extractnumber, normalize
+from mycroft.util.parse import extract_datetime, extract_number, normalize
 from mycroft.util.signal import *
 
 

--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -70,15 +70,6 @@ def match_one(query, choices):
         return best
 
 
-# TODO:18.08
-def extractnumber(text, short_scale=True, ordinals=False, lang="en-us"):
-    """ Depreciated, replaced by extract_number. Will be removed
-    in the 18.08b release.
-
-    """
-    return extract_number(text, short_scale, ordinals, lang)
-
-
 def extract_number(text, short_scale=True, ordinals=False, lang="en-us"):
     """Takes in a string and extracts a number.
 
@@ -108,7 +99,7 @@ def extract_number(text, short_scale=True, ordinals=False, lang="en-us"):
         return extractnumber_sv(text)
     elif lang_lower.startswith("de"):
         return extractnumber_de(text)
-    # TODO: extractnumber for other languages
+    # TODO: extractnumber_xx for other languages
     return text
 
 

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -18,7 +18,7 @@ import unittest
 from datetime import datetime
 
 from mycroft.util.parse import extract_datetime
-from mycroft.util.parse import extractnumber
+from mycroft.util.parse import extract_number
 from mycroft.util.parse import fuzzy_match
 from mycroft.util.parse import get_gender
 from mycroft.util.parse import match_one
@@ -59,79 +59,79 @@ class TestNormalize(unittest.TestCase):
                                    remove_articles=False),
                          "this is an extra test")
 
-    def test_extractnumber(self):
-        self.assertEqual(extractnumber("this is the first test",
-                                       ordinals=True), 1)
-        self.assertEqual(extractnumber("this is 2 test"), 2)
-        self.assertEqual(extractnumber("this is second test",
-                                       ordinals=True), 2)
-        self.assertEqual(extractnumber("this is the third test"), 1.0 / 3.0)
-        self.assertEqual(extractnumber("this is the third test",
-                                       ordinals=True), 3.0)
-        self.assertEqual(extractnumber("this is test number 4"), 4)
-        self.assertEqual(extractnumber("one third of a cup"), 1.0 / 3.0)
-        self.assertEqual(extractnumber("three cups"), 3)
-        self.assertEqual(extractnumber("1/3 cups"), 1.0 / 3.0)
-        self.assertEqual(extractnumber("quarter cup"), 0.25)
-        self.assertEqual(extractnumber("1/4 cup"), 0.25)
-        self.assertEqual(extractnumber("one fourth cup"), 0.25)
-        self.assertEqual(extractnumber("2/3 cups"), 2.0 / 3.0)
-        self.assertEqual(extractnumber("3/4 cups"), 3.0 / 4.0)
-        self.assertEqual(extractnumber("1 and 3/4 cups"), 1.75)
-        self.assertEqual(extractnumber("1 cup and a half"), 1.5)
-        self.assertEqual(extractnumber("one cup and a half"), 1.5)
-        self.assertEqual(extractnumber("one and a half cups"), 1.5)
-        self.assertEqual(extractnumber("one and one half cups"), 1.5)
-        self.assertEqual(extractnumber("three quarter cups"), 3.0 / 4.0)
-        self.assertEqual(extractnumber("three quarters cups"), 3.0 / 4.0)
-        self.assertEqual(extractnumber("twenty two"), 22)
-        self.assertEqual(extractnumber("two hundred"), 200)
-        self.assertEqual(extractnumber("nine thousand"), 9000)
-        self.assertEqual(extractnumber("six hundred sixty six"), 666)
-        self.assertEqual(extractnumber("two million"), 2000000)
-        self.assertEqual(extractnumber("two million five hundred thousand "
-                                       "tons of spinning metal"), 2500000)
-        self.assertEqual(extractnumber("six trillion"), 60000000000.0)
-        self.assertEqual(extractnumber("six trillion", short_scale=False),
+    def test_extract_number(self):
+        self.assertEqual(extract_number("this is the first test",
+                                        ordinals=True), 1)
+        self.assertEqual(extract_number("this is 2 test"), 2)
+        self.assertEqual(extract_number("this is second test",
+                                        ordinals=True), 2)
+        self.assertEqual(extract_number("this is the third test"), 1.0 / 3.0)
+        self.assertEqual(extract_number("this is the third test",
+                                        ordinals=True), 3.0)
+        self.assertEqual(extract_number("this is test number 4"), 4)
+        self.assertEqual(extract_number("one third of a cup"), 1.0 / 3.0)
+        self.assertEqual(extract_number("three cups"), 3)
+        self.assertEqual(extract_number("1/3 cups"), 1.0 / 3.0)
+        self.assertEqual(extract_number("quarter cup"), 0.25)
+        self.assertEqual(extract_number("1/4 cup"), 0.25)
+        self.assertEqual(extract_number("one fourth cup"), 0.25)
+        self.assertEqual(extract_number("2/3 cups"), 2.0 / 3.0)
+        self.assertEqual(extract_number("3/4 cups"), 3.0 / 4.0)
+        self.assertEqual(extract_number("1 and 3/4 cups"), 1.75)
+        self.assertEqual(extract_number("1 cup and a half"), 1.5)
+        self.assertEqual(extract_number("one cup and a half"), 1.5)
+        self.assertEqual(extract_number("one and a half cups"), 1.5)
+        self.assertEqual(extract_number("one and one half cups"), 1.5)
+        self.assertEqual(extract_number("three quarter cups"), 3.0 / 4.0)
+        self.assertEqual(extract_number("three quarters cups"), 3.0 / 4.0)
+        self.assertEqual(extract_number("twenty two"), 22)
+        self.assertEqual(extract_number("two hundred"), 200)
+        self.assertEqual(extract_number("nine thousand"), 9000)
+        self.assertEqual(extract_number("six hundred sixty six"), 666)
+        self.assertEqual(extract_number("two million"), 2000000)
+        self.assertEqual(extract_number("two million five hundred thousand "
+                                        "tons of spinning metal"), 2500000)
+        self.assertEqual(extract_number("six trillion"), 60000000000.0)
+        self.assertEqual(extract_number("six trillion", short_scale=False),
                          6e+18)
-        self.assertEqual(extractnumber("one point five"), 1.5)
-        self.assertEqual(extractnumber("three dot fourteen"), 3.14)
-        self.assertEqual(extractnumber("zero point two"), 0.2)
-        self.assertEqual(extractnumber("billions of years older"),
+        self.assertEqual(extract_number("one point five"), 1.5)
+        self.assertEqual(extract_number("three dot fourteen"), 3.14)
+        self.assertEqual(extract_number("zero point two"), 0.2)
+        self.assertEqual(extract_number("billions of years older"),
                          1000000000.0)
-        self.assertEqual(extractnumber("billions of years older",
-                                       short_scale=False),
+        self.assertEqual(extract_number("billions of years older",
+                                        short_scale=False),
                          1000000000000.0)
-        self.assertEqual(extractnumber("one hundred thousand"), 100000)
-        self.assertEqual(extractnumber("minus 2"), -2)
-        self.assertEqual(extractnumber("negative seventy"), -70)
-        self.assertEqual(extractnumber("thousand million"), 1000000000)
-        self.assertEqual(extractnumber("sixth third"),
+        self.assertEqual(extract_number("one hundred thousand"), 100000)
+        self.assertEqual(extract_number("minus 2"), -2)
+        self.assertEqual(extract_number("negative seventy"), -70)
+        self.assertEqual(extract_number("thousand million"), 1000000000)
+        self.assertEqual(extract_number("sixth third"),
                          1 / 6 / 3)
-        self.assertEqual(extractnumber("sixth third", ordinals=True),
+        self.assertEqual(extract_number("sixth third", ordinals=True),
                          3)
-        self.assertEqual(extractnumber("thirty second"), 30)
-        self.assertEqual(extractnumber("thirty second", ordinals=True), 32)
-        self.assertEqual(extractnumber("this is the billionth test",
-                                       ordinals=True), 1e09)
-        self.assertEqual(extractnumber("this is the billionth test"), 1e-9)
-        self.assertEqual(extractnumber("this is the billionth test",
-                                       ordinals=True,
-                                       short_scale=False), 1e12)
-        self.assertEqual(extractnumber("this is the billionth test",
-                                       short_scale=False), 1e-12)
+        self.assertEqual(extract_number("thirty second"), 30)
+        self.assertEqual(extract_number("thirty second", ordinals=True), 32)
+        self.assertEqual(extract_number("this is the billionth test",
+                                        ordinals=True), 1e09)
+        self.assertEqual(extract_number("this is the billionth test"), 1e-9)
+        self.assertEqual(extract_number("this is the billionth test",
+                                        ordinals=True,
+                                        short_scale=False), 1e12)
+        self.assertEqual(extract_number("this is the billionth test",
+                                        short_scale=False), 1e-12)
         # TODO handle this case
         # self.assertEqual(
-        #    extractnumber("6 dot six six six"),
+        #    extract_number("6 dot six six six"),
         #    6.666)
-        self.assertTrue(extractnumber("The tennis player is fast") is False)
-        self.assertTrue(extractnumber("fraggle") is False)
+        self.assertTrue(extract_number("The tennis player is fast") is False)
+        self.assertTrue(extract_number("fraggle") is False)
 
-        self.assertTrue(extractnumber("fraggle zero") is not False)
-        self.assertEqual(extractnumber("fraggle zero"), 0)
+        self.assertTrue(extract_number("fraggle zero") is not False)
+        self.assertEqual(extract_number("fraggle zero"), 0)
 
-        self.assertTrue(extractnumber("grobo 0") is not False)
-        self.assertEqual(extractnumber("grobo 0"), 0)
+        self.assertTrue(extract_number("grobo 0") is not False)
+        self.assertEqual(extract_number("grobo 0"), 0)
 
     def test_extractdatetime_en(self):
         def extractWithFormat(text):

--- a/test/unittests/util/test_parse_de.py
+++ b/test/unittests/util/test_parse_de.py
@@ -18,7 +18,7 @@ import unittest
 from datetime import datetime
 
 from mycroft.util.parse import extract_datetime
-from mycroft.util.parse import extractnumber
+from mycroft.util.parse import extract_number
 from mycroft.util.parse import normalize
 
 
@@ -34,40 +34,41 @@ class TestNormalize(unittest.TestCase):
                                    remove_articles=False),
                          "dies ist der Extra-Test")
 
-    def test_extractnumber(self):
-        self.assertEqual(extractnumber("dies ist der 1. Test",
-                                       lang="de-de"), 1)
-        self.assertEqual(extractnumber("dies ist der erste Test",
-                                       lang="de-de"), 1)
-        self.assertEqual(extractnumber("dies ist 2 Test", lang="de-de"), 2)
-        self.assertEqual(extractnumber("dies ist zweiter Test", lang="de-de"),
+    def test_extract_number(self):
+        self.assertEqual(extract_number("dies ist der 1. Test",
+                                        lang="de-de"), 1)
+        self.assertEqual(extract_number("dies ist der erste Test",
+                                        lang="de-de"), 1)
+        self.assertEqual(extract_number("dies ist 2 Test", lang="de-de"), 2)
+        self.assertEqual(extract_number("dies ist zweiter Test", lang="de-de"),
                          2)
         self.assertEqual(
-            extractnumber("dies ist der dritte Test", lang="de-de"), 3)
+            extract_number("dies ist der dritte Test", lang="de-de"), 3)
         self.assertEqual(
-            extractnumber("dies ist der Test Nummer 4", lang="de-de"), 4)
-        self.assertEqual(extractnumber("ein drittel einer Tasse",
-                                       lang="de-de"), 1.0 / 3.0)
-        self.assertEqual(extractnumber("drei Tassen", lang="de-de"), 3)
-        self.assertEqual(extractnumber("1/3 Tasse", lang="de-de"), 1.0 / 3.0)
-        self.assertEqual(extractnumber("eine viertel Tasse", lang="de-de"),
+            extract_number("dies ist der Test Nummer 4", lang="de-de"), 4)
+        self.assertEqual(extract_number("ein drittel einer Tasse",
+                                        lang="de-de"), 1.0 / 3.0)
+        self.assertEqual(extract_number("drei Tassen", lang="de-de"), 3)
+        self.assertEqual(extract_number("1/3 Tasse", lang="de-de"), 1.0 / 3.0)
+        self.assertEqual(extract_number("eine viertel Tasse", lang="de-de"),
                          0.25)
-        self.assertEqual(extractnumber("1/4 Tasse", lang="de-de"), 0.25)
-        self.assertEqual(extractnumber("viertel Tasse", lang="de-de"), 0.25)
-        self.assertEqual(extractnumber("2/3 Tasse", lang="de-de"), 2.0 / 3.0)
-        self.assertEqual(extractnumber("3/4 Tasse", lang="de-de"), 3.0 / 4.0)
-        self.assertEqual(extractnumber("1 und 3/4 Tassen", lang="de-de"), 1.75)
-        self.assertEqual(extractnumber("1 Tasse und eine halbe", lang="de-de"),
-                         1.5)
+        self.assertEqual(extract_number("1/4 Tasse", lang="de-de"), 0.25)
+        self.assertEqual(extract_number("viertel Tasse", lang="de-de"), 0.25)
+        self.assertEqual(extract_number("2/3 Tasse", lang="de-de"), 2.0 / 3.0)
+        self.assertEqual(extract_number("3/4 Tasse", lang="de-de"), 3.0 / 4.0)
+        self.assertEqual(extract_number("1 und 3/4 Tassen", lang="de-de"),
+                         1.75)
+        self.assertEqual(extract_number("1 Tasse und eine halbe",
+                                        lang="de-de"), 1.5)
         self.assertEqual(
-            extractnumber("eine Tasse und eine halbe", lang="de-de"), 1.5)
+            extract_number("eine Tasse und eine halbe", lang="de-de"), 1.5)
         self.assertEqual(
-            extractnumber("eine und eine halbe Tasse", lang="de-de"), 1.5)
-        self.assertEqual(extractnumber("ein und ein halb Tassen",
-                                       lang="de-de"), 1.5)
-        self.assertEqual(extractnumber("drei Viertel Tasse", lang="de-de"),
+            extract_number("eine und eine halbe Tasse", lang="de-de"), 1.5)
+        self.assertEqual(extract_number("ein und ein halb Tassen",
+                                        lang="de-de"), 1.5)
+        self.assertEqual(extract_number("drei Viertel Tasse", lang="de-de"),
                          3.0 / 4.0)
-        self.assertEqual(extractnumber("drei Viertel Tassen", lang="de-de"),
+        self.assertEqual(extract_number("drei Viertel Tassen", lang="de-de"),
                          3.0 / 4.0)
 
     def test_extractdatetime_de(self):

--- a/test/unittests/util/test_parse_fr.py
+++ b/test/unittests/util/test_parse_fr.py
@@ -19,7 +19,7 @@ from datetime import datetime
 
 from mycroft.util.parse import get_gender
 from mycroft.util.parse import extract_datetime
-from mycroft.util.parse import extractnumber
+from mycroft.util.parse import extract_number
 from mycroft.util.parse import normalize
 
 
@@ -39,50 +39,52 @@ class TestNormalize_fr(unittest.TestCase):
                          "la dernière tentative")
 
     def test_extractnumber_fr(self):
-        self.assertEqual(extractnumber("voici le premier test", lang="fr-fr"),
+        self.assertEqual(extract_number("voici le premier test", lang="fr-fr"),
                          1)
-        self.assertEqual(extractnumber("c'est 2 tests", lang="fr-fr"), 2)
-        self.assertEqual(extractnumber("voici le second test", lang="fr-fr"),
+        self.assertEqual(extract_number("c'est 2 tests", lang="fr-fr"), 2)
+        self.assertEqual(extract_number("voici le second test", lang="fr-fr"),
                          2)
-        self.assertEqual(extractnumber("voici trois tests",
-                                       lang="fr-fr"),
+        self.assertEqual(extract_number("voici trois tests",
+                                        lang="fr-fr"),
                          3)
-        self.assertEqual(extractnumber("voici le test numéro 4", lang="fr-fr"),
-                         4)
-        self.assertEqual(extractnumber("un tiers de litre", lang="fr-fr"),
+        self.assertEqual(extract_number("voici le test numéro 4",
+                                        lang="fr-fr"), 4)
+        self.assertEqual(extract_number("un tiers de litre", lang="fr-fr"),
                          1.0 / 3.0)
-        self.assertEqual(extractnumber("3 cuillères", lang="fr-fr"), 3)
-        self.assertEqual(extractnumber("1/3 de litre", lang="fr-fr"),
+        self.assertEqual(extract_number("3 cuillères", lang="fr-fr"), 3)
+        self.assertEqual(extract_number("1/3 de litre", lang="fr-fr"),
                          1.0 / 3.0)
-        self.assertEqual(extractnumber("un quart de bol", lang="fr-fr"), 0.25)
-        self.assertEqual(extractnumber("1/4 de verre", lang="fr-fr"), 0.25)
-        self.assertEqual(extractnumber("2/3 de bol", lang="fr-fr"), 2.0 / 3.0)
-        self.assertEqual(extractnumber("3/4 de bol", lang="fr-fr"), 3.0 / 4.0)
-        self.assertEqual(extractnumber("1 et 3/4 de bol", lang="fr-fr"), 1.75)
-        self.assertEqual(extractnumber("1 bol et demi", lang="fr-fr"), 1.5)
-        self.assertEqual(extractnumber("un bol et demi", lang="fr-fr"), 1.5)
-        self.assertEqual(extractnumber("un et demi bols", lang="fr-fr"), 1.5)
-        self.assertEqual(extractnumber("un bol et un demi", lang="fr-fr"), 1.5)
-        self.assertEqual(extractnumber("trois quarts de bol", lang="fr-fr"),
+        self.assertEqual(extract_number("un quart de bol", lang="fr-fr"), 0.25)
+        self.assertEqual(extract_number("1/4 de verre", lang="fr-fr"), 0.25)
+        self.assertEqual(extract_number("2/3 de bol", lang="fr-fr"), 2.0 / 3.0)
+        self.assertEqual(extract_number("3/4 de bol", lang="fr-fr"), 3.0 / 4.0)
+        self.assertEqual(extract_number("1 et 3/4 de bol", lang="fr-fr"), 1.75)
+        self.assertEqual(extract_number("1 bol et demi", lang="fr-fr"), 1.5)
+        self.assertEqual(extract_number("un bol et demi", lang="fr-fr"), 1.5)
+        self.assertEqual(extract_number("un et demi bols", lang="fr-fr"), 1.5)
+        self.assertEqual(extract_number("un bol et un demi", lang="fr-fr"),
+                         1.5)
+        self.assertEqual(extract_number("trois quarts de bol", lang="fr-fr"),
                          3.0 / 4.0)
-        self.assertEqual(extractnumber("32.2 degrés", lang="fr-fr"), 32.2)
-        self.assertEqual(extractnumber("2 virgule 2 cm", lang="fr-fr"), 2.2)
-        self.assertEqual(extractnumber("2 virgule 0 2 cm", lang="fr-fr"), 2.02)
-        self.assertEqual(extractnumber("ça fait virgule 2 cm", lang="fr-fr"),
+        self.assertEqual(extract_number("32.2 degrés", lang="fr-fr"), 32.2)
+        self.assertEqual(extract_number("2 virgule 2 cm", lang="fr-fr"), 2.2)
+        self.assertEqual(extract_number("2 virgule 0 2 cm", lang="fr-fr"),
+                         2.02)
+        self.assertEqual(extract_number("ça fait virgule 2 cm", lang="fr-fr"),
                          0.2)
-        self.assertEqual(extractnumber("point du tout", lang="fr-fr"),
+        self.assertEqual(extract_number("point du tout", lang="fr-fr"),
                          "point tout")
-        self.assertEqual(extractnumber("32.00 secondes", lang="fr-fr"), 32)
-        self.assertEqual(extractnumber("mange trente-et-une bougies",
-                                       lang="fr-fr"), 31)
-        self.assertEqual(extractnumber("un trentième",
-                                       lang="fr-fr"), 1.0 / 30.0)
-        self.assertEqual(extractnumber("un centième",
-                                       lang="fr-fr"), 0.01)
-        self.assertEqual(extractnumber("un millième",
-                                       lang="fr-fr"), 0.001)
-        self.assertEqual(extractnumber("un 20e",
-                                       lang="fr-fr"), 1.0 / 20.0)
+        self.assertEqual(extract_number("32.00 secondes", lang="fr-fr"), 32)
+        self.assertEqual(extract_number("mange trente-et-une bougies",
+                                        lang="fr-fr"), 31)
+        self.assertEqual(extract_number("un trentième",
+                                        lang="fr-fr"), 1.0 / 30.0)
+        self.assertEqual(extract_number("un centième",
+                                        lang="fr-fr"), 0.01)
+        self.assertEqual(extract_number("un millième",
+                                        lang="fr-fr"), 0.001)
+        self.assertEqual(extract_number("un 20e",
+                                        lang="fr-fr"), 1.0 / 20.0)
 
     def test_extractdatetime_fr(self):
         def extractWithFormat_fr(text):

--- a/test/unittests/util/test_parse_it.py
+++ b/test/unittests/util/test_parse_it.py
@@ -19,7 +19,7 @@ from datetime import datetime
 
 from mycroft.util.parse import get_gender
 from mycroft.util.parse import extract_datetime
-from mycroft.util.parse import extractnumber
+from mycroft.util.parse import extract_number
 from mycroft.util.parse import normalize
 
 
@@ -42,100 +42,83 @@ class TestNormalize(unittest.TestCase):
                          u"questo è il test extra")
 
     def test_extractnumber_it(self):
-        self.assertEqual(extractnumber(u"questo è il primo test",
-                                       lang="it"), 1)
-        self.assertEqual(extractnumber(u"questo è il 2 test",
-                                       lang="it"), 2)
-        self.assertEqual(extractnumber(u"questo è il secondo test",
-                                       lang="it"), 2)
-        self.assertEqual(extractnumber(u"questo è un terzo di test",
-                                       lang="it"), 1.0 / 3.0)
-        self.assertEqual(extractnumber(u"questo è test numero 4",
-                                       lang="it"), 4)
-        self.assertEqual(extractnumber("un terzo di tazza",
-                                       lang="it"), 1.0 / 3.0)
-        self.assertEqual(extractnumber("tre tazze",
-                                       lang="it"), 3)
-        self.assertEqual(extractnumber("1/3 tazze",
-                                       lang="it"), 1.0 / 3.0)
-        self.assertEqual(extractnumber("un quarto di tazza",
-                                       lang="it"), 0.25)
-        self.assertEqual(extractnumber("1/4 tazza",
-                                       lang="it"), 0.25)
-        self.assertEqual(extractnumber("2/3 tazza",
-                                       lang="it"), 2.0 / 3.0)
-        self.assertEqual(extractnumber("3/4 tazza",
-                                       lang="it"), 3.0 / 4.0)
-        self.assertEqual(extractnumber("1 e 1/4 tazza",
-                                       lang="it"), 1.25)
-        self.assertEqual(extractnumber("1 tazza e mezzo",
-                                       lang="it"), 1.5)
-        self.assertEqual(extractnumber("una tazza e mezzo",
-                                       lang="it"), 1.5)
-        self.assertEqual(extractnumber("una e mezza tazza",
-                                       lang="it"), 1.5)
-        self.assertEqual(extractnumber("una e una mezza tazza",
-                                       lang="it"), 1.5)
-        self.assertEqual(extractnumber("tre quarti tazza",
-                                       lang="it"), 3.0 / 4.0)
-        self.assertEqual(extractnumber("tre quarto tazza",
-                                       lang="it"), 3.0 / 4.0)
-        self.assertEqual(extractnumber("sette punto cinque",
-                                       lang="it"), 7.5)
-        self.assertEqual(extractnumber("sette punto 5",
-                                       lang="it"), 7.5)
-        self.assertEqual(extractnumber("sette e mezzo",
-                                       lang="it"), 7.5)
-        self.assertEqual(extractnumber("sette e ottanta",
-                                       lang="it"), 7.80)
-        self.assertEqual(extractnumber("sette e otto",
-                                       lang="it"), 7.8)
-        self.assertEqual(extractnumber("sette e zero otto",
-                                       lang="it"), 7.08)
-        self.assertEqual(extractnumber("sette e zero zero otto",
-                                       lang="it"), 7.008)
-        self.assertEqual(extractnumber("venti tredicesimi",
-                                       lang="it"), 20.0 / 13.0)
-        self.assertEqual(extractnumber("sei virgola sessanta sei",
-                                       lang="it"), 6.66)
-        self.assertEqual(extractnumber("sei virgola sessantasei",
-                                       lang="it"), 6.66)
-        self.assertEqual(extractnumber("seicento sessanta  sei",
-                                       lang="it"), 666)
-        self.assertEqual(extractnumber("seicento punto zero sei",
-                                       lang="it"), 600.06)
-        self.assertEqual(extractnumber("seicento punto zero zero sei",
-                                       lang="it"), 600.006)
-        self.assertEqual(extractnumber("seicento punto zero zero zero sei",
-                                       lang="it"), 600.0006)
-        self.assertEqual(extractnumber("tre decimi ",
-                                       lang="it"), 0.30000000000000004)
-        self.assertEqual(extractnumber("dodici centesimi",
-                                       lang="it"), 0.12)
-        self.assertEqual(extractnumber("cinque e quaranta due millesimi",
-                                       lang="it"), 5.042)
-        self.assertEqual(extractnumber("mille e uno",
-                                       lang="it"), 1001)
-        self.assertEqual(extractnumber("due mila venti due dollari ",
-                                       lang="it"), 2022)
-        self.assertEqual(extractnumber(
+        self.assertEqual(extract_number(u"questo è il primo test",
+                                        lang="it"), 1)
+        self.assertEqual(extract_number(u"questo è il 2 test", lang="it"), 2)
+        self.assertEqual(extract_number(u"questo è il secondo test",
+                                        lang="it"), 2)
+        self.assertEqual(extract_number(u"questo è un terzo di test",
+                                        lang="it"), 1.0 / 3.0)
+        self.assertEqual(extract_number(u"questo è test numero 4", lang="it"),
+                         4)
+        self.assertEqual(extract_number("un terzo di tazza", lang="it"),
+                         1.0 / 3.0)
+        self.assertEqual(extract_number("tre tazze", lang="it"), 3)
+        self.assertEqual(extract_number("1/3 tazze", lang="it"), 1.0 / 3.0)
+        self.assertEqual(extract_number("un quarto di tazza", lang="it"), 0.25)
+        self.assertEqual(extract_number("1/4 tazza", lang="it"), 0.25)
+        self.assertEqual(extract_number("2/3 tazza", lang="it"), 2.0 / 3.0)
+        self.assertEqual(extract_number("3/4 tazza", lang="it"), 3.0 / 4.0)
+        self.assertEqual(extract_number("1 e 1/4 tazza", lang="it"), 1.25)
+        self.assertEqual(extract_number("1 tazza e mezzo", lang="it"), 1.5)
+        self.assertEqual(extract_number("una tazza e mezzo", lang="it"), 1.5)
+        self.assertEqual(extract_number("una e mezza tazza", lang="it"), 1.5)
+        self.assertEqual(extract_number("una e una mezza tazza",
+                                        lang="it"), 1.5)
+        self.assertEqual(extract_number("tre quarti tazza",
+                                        lang="it"), 3.0 / 4.0)
+        self.assertEqual(extract_number("tre quarto tazza",
+                                        lang="it"), 3.0 / 4.0)
+        self.assertEqual(extract_number("sette punto cinque", lang="it"), 7.5)
+        self.assertEqual(extract_number("sette punto 5", lang="it"), 7.5)
+        self.assertEqual(extract_number("sette e mezzo", lang="it"), 7.5)
+        self.assertEqual(extract_number("sette e ottanta", lang="it"), 7.80)
+        self.assertEqual(extract_number("sette e otto", lang="it"), 7.8)
+        self.assertEqual(extract_number("sette e zero otto", lang="it"), 7.08)
+        self.assertEqual(extract_number("sette e zero zero otto",
+                                        lang="it"), 7.008)
+        self.assertEqual(extract_number("venti tredicesimi",
+                                        lang="it"), 20.0 / 13.0)
+        self.assertEqual(extract_number("sei virgola sessanta sei",
+                                        lang="it"), 6.66)
+        self.assertEqual(extract_number("sei virgola sessantasei",
+                                        lang="it"), 6.66)
+        self.assertEqual(extract_number("seicento sessanta  sei",
+                                        lang="it"), 666)
+        self.assertEqual(extract_number("seicento punto zero sei",
+                                        lang="it"), 600.06)
+        self.assertEqual(extract_number("seicento punto zero zero sei",
+                                        lang="it"), 600.006)
+        self.assertEqual(extract_number("seicento punto zero zero zero sei",
+                                        lang="it"), 600.0006)
+        self.assertEqual(extract_number("tre decimi ",
+                                        lang="it"), 0.30000000000000004)
+        self.assertEqual(extract_number("dodici centesimi",
+                                        lang="it"), 0.12)
+        self.assertEqual(extract_number("cinque e quaranta due millesimi",
+                                        lang="it"), 5.042)
+        self.assertEqual(extract_number("mille e uno",
+                                        lang="it"), 1001)
+        self.assertEqual(extract_number("due mila venti due dollari ",
+                                        lang="it"), 2022)
+        self.assertEqual(extract_number(
             "cento quattordici mila quattrocento undici dollari ",
             lang="it"), 114411)
-        self.assertEqual(extractnumber("ventitre dollari ", lang="it"), 23)
-        self.assertEqual(extractnumber("quarantacinque minuti ",
-                                       lang="it"), 45)
-        self.assertEqual(extractnumber("ventuno anni ",
-                                       lang="it"), 21)
-        self.assertEqual(extractnumber("ventotto euro ",
-                                       lang="it"), 28)
-        self.assertEqual(extractnumber("dodici e quarantacinque ",
-                                       lang="it"), 12.45)
-        self.assertEqual(extractnumber("quarantotto euro ",
-                                       lang="it"), 48)
-        self.assertEqual(extractnumber("novantanove euro ",
-                                       lang="it"), 99)
-        self.assertEqual(extractnumber("avvisa se qualcuno arriva ",
-                                       lang="it"), False)
+        self.assertEqual(extract_number("ventitre dollari ", lang="it"), 23)
+        self.assertEqual(extract_number("quarantacinque minuti ",
+                                        lang="it"), 45)
+        self.assertEqual(extract_number("ventuno anni ",
+                                        lang="it"), 21)
+        self.assertEqual(extract_number("ventotto euro ",
+                                        lang="it"), 28)
+        self.assertEqual(extract_number("dodici e quarantacinque ",
+                                        lang="it"), 12.45)
+        self.assertEqual(extract_number("quarantotto euro ",
+                                        lang="it"), 48)
+        self.assertEqual(extract_number("novantanove euro ",
+                                        lang="it"), 99)
+        self.assertEqual(extract_number("avvisa se qualcuno arriva ",
+                                        lang="it"), False)
 
     def test_spaces_it(self):
         self.assertEqual(normalize(u"questo   e'  il    test",

--- a/test/unittests/util/test_parse_pt.py
+++ b/test/unittests/util/test_parse_pt.py
@@ -19,7 +19,7 @@ from datetime import datetime
 
 from mycroft.util.parse import get_gender
 from mycroft.util.parse import extract_datetime
-from mycroft.util.parse import extractnumber
+from mycroft.util.parse import extract_number
 from mycroft.util.parse import normalize
 
 
@@ -43,54 +43,54 @@ class TestNormalize(unittest.TestCase):
                                                            u" extra")
 
     def test_extractnumber_pt(self):
-        self.assertEqual(extractnumber("isto e o primeiro teste", lang="pt"),
+        self.assertEqual(extract_number("isto e o primeiro teste", lang="pt"),
                          1)
-        self.assertEqual(extractnumber("isto e o 2 teste", lang="pt"), 2)
-        self.assertEqual(extractnumber("isto e o segundo teste", lang="pt"),
+        self.assertEqual(extract_number("isto e o 2 teste", lang="pt"), 2)
+        self.assertEqual(extract_number("isto e o segundo teste", lang="pt"),
                          2)
-        self.assertEqual(extractnumber(u"isto e um terço de teste",
-                                       lang="pt"), 1.0 / 3.0)
-        self.assertEqual(extractnumber("isto e o teste numero quatro",
-                                       lang="pt"), 4)
-        self.assertEqual(extractnumber(u"um terço de chavena", lang="pt"),
+        self.assertEqual(extract_number(u"isto e um terço de teste",
+                                        lang="pt"), 1.0 / 3.0)
+        self.assertEqual(extract_number("isto e o teste numero quatro",
+                                        lang="pt"), 4)
+        self.assertEqual(extract_number(u"um terço de chavena", lang="pt"),
                          1.0 / 3.0)
-        self.assertEqual(extractnumber("3 canecos", lang="pt"), 3)
-        self.assertEqual(extractnumber("1/3 canecos", lang="pt"), 1.0 / 3.0)
-        self.assertEqual(extractnumber("quarto de hora", lang="pt"), 0.25)
-        self.assertEqual(extractnumber("1/4 hora", lang="pt"), 0.25)
-        self.assertEqual(extractnumber("um quarto hora", lang="pt"), 0.25)
-        self.assertEqual(extractnumber("2/3 pinga", lang="pt"), 2.0 / 3.0)
-        self.assertEqual(extractnumber("3/4 pinga", lang="pt"), 3.0 / 4.0)
-        self.assertEqual(extractnumber("1 e 3/4 cafe", lang="pt"), 1.75)
-        self.assertEqual(extractnumber("1 cafe e meio", lang="pt"), 1.5)
-        self.assertEqual(extractnumber("um cafe e um meio", lang="pt"), 1.5)
+        self.assertEqual(extract_number("3 canecos", lang="pt"), 3)
+        self.assertEqual(extract_number("1/3 canecos", lang="pt"), 1.0 / 3.0)
+        self.assertEqual(extract_number("quarto de hora", lang="pt"), 0.25)
+        self.assertEqual(extract_number("1/4 hora", lang="pt"), 0.25)
+        self.assertEqual(extract_number("um quarto hora", lang="pt"), 0.25)
+        self.assertEqual(extract_number("2/3 pinga", lang="pt"), 2.0 / 3.0)
+        self.assertEqual(extract_number("3/4 pinga", lang="pt"), 3.0 / 4.0)
+        self.assertEqual(extract_number("1 e 3/4 cafe", lang="pt"), 1.75)
+        self.assertEqual(extract_number("1 cafe e meio", lang="pt"), 1.5)
+        self.assertEqual(extract_number("um cafe e um meio", lang="pt"), 1.5)
         self.assertEqual(
-            extractnumber("tres quartos de chocolate", lang="pt"),
+            extract_number("tres quartos de chocolate", lang="pt"),
             3.0 / 4.0)
-        self.assertEqual(extractnumber(u"três quarto de chocolate",
-                                       lang="pt"), 3.0 / 4.0)
-        self.assertEqual(extractnumber("sete ponto cinco", lang="pt"), 7.5)
-        self.assertEqual(extractnumber("sete ponto 5", lang="pt"), 7.5)
-        self.assertEqual(extractnumber("sete e meio", lang="pt"), 7.5)
-        self.assertEqual(extractnumber("sete e oitenta", lang="pt"), 7.80)
-        self.assertEqual(extractnumber("sete e oito", lang="pt"), 7.8)
-        self.assertEqual(extractnumber("sete e zero oito",
-                                       lang="pt"), 7.08)
-        self.assertEqual(extractnumber("sete e zero zero oito",
-                                       lang="pt"), 7.008)
-        self.assertEqual(extractnumber("vinte treze avos", lang="pt"),
+        self.assertEqual(extract_number(u"três quarto de chocolate",
+                                        lang="pt"), 3.0 / 4.0)
+        self.assertEqual(extract_number("sete ponto cinco", lang="pt"), 7.5)
+        self.assertEqual(extract_number("sete ponto 5", lang="pt"), 7.5)
+        self.assertEqual(extract_number("sete e meio", lang="pt"), 7.5)
+        self.assertEqual(extract_number("sete e oitenta", lang="pt"), 7.80)
+        self.assertEqual(extract_number("sete e oito", lang="pt"), 7.8)
+        self.assertEqual(extract_number("sete e zero oito",
+                                        lang="pt"), 7.08)
+        self.assertEqual(extract_number("sete e zero zero oito",
+                                        lang="pt"), 7.008)
+        self.assertEqual(extract_number("vinte treze avos", lang="pt"),
                          20.0 / 13.0)
-        self.assertEqual(extractnumber("seis virgula seiscentos e sessenta",
-                                       lang="pt"), 6.66)
-        self.assertEqual(extractnumber("seiscentos e sessenta e seis",
-                                       lang="pt"), 666)
+        self.assertEqual(extract_number("seis virgula seiscentos e sessenta",
+                                        lang="pt"), 6.66)
+        self.assertEqual(extract_number("seiscentos e sessenta e seis",
+                                        lang="pt"), 666)
 
-        self.assertEqual(extractnumber("seiscentos ponto zero seis",
-                                       lang="pt"), 600.06)
-        self.assertEqual(extractnumber("seiscentos ponto zero zero seis",
-                                       lang="pt"), 600.006)
-        self.assertEqual(extractnumber("seiscentos ponto zero zero zero seis",
-                                       lang="pt"), 600.0006)
+        self.assertEqual(extract_number("seiscentos ponto zero seis",
+                                        lang="pt"), 600.06)
+        self.assertEqual(extract_number("seiscentos ponto zero zero seis",
+                                        lang="pt"), 600.006)
+        self.assertEqual(extract_number("seiscentos ponto zero zero zero seis",
+                                        lang="pt"), 600.0006)
 
     def test_agressive_pruning_pt(self):
         self.assertEqual(normalize("uma palavra", lang="pt"),

--- a/test/unittests/util/test_parse_sv.py
+++ b/test/unittests/util/test_parse_sv.py
@@ -18,46 +18,46 @@ import unittest
 from datetime import datetime
 
 from mycroft.util.parse import extract_datetime
-from mycroft.util.parse import extractnumber
+from mycroft.util.parse import extract_number
 from mycroft.util.parse import normalize
 
 
 class TestNormalize(unittest.TestCase):
     def test_extractnumber_sv(self):
-        self.assertEqual(extractnumber("1 och en halv deciliter",
-                                       lang='sv-se'), 1.5)
-        self.assertEqual(extractnumber("det här är det första testet",
-                                       lang='sv-se'), 1)
-        self.assertEqual(extractnumber("det här är test nummer 2",
-                                       lang='sv-se'), 2)
-        self.assertEqual(extractnumber("det här är det andra testet",
-                                       lang='sv-se'), 2)
-        self.assertEqual(extractnumber("det här är tredje testet",
-                                       lang='sv-se'), 3)
-        self.assertEqual(extractnumber("det här är test nummer 4",
-                                       lang='sv-se'), 4)
-        self.assertEqual(extractnumber("en tredjedels dl",
-                                       lang='sv-se'), 1.0 / 3.0)
-        self.assertEqual(extractnumber("tre deciliter",
-                                       lang='sv-se'), 3)
-        self.assertEqual(extractnumber("1/3 deciliter",
-                                       lang='sv-se'), 1.0 / 3.0)
-        self.assertEqual(extractnumber("en kvarts dl",
-                                       lang='sv-se'), 0.25)
-        self.assertEqual(extractnumber("1/4 dl",
-                                       lang='sv-se'), 0.25)
-        self.assertEqual(extractnumber("en kvarts dl",
-                                       lang='sv-se'), 0.25)
-        self.assertEqual(extractnumber("2/3 dl",
-                                       lang='sv-se'), 2.0 / 3.0)
-        self.assertEqual(extractnumber("3/4 dl",
-                                       lang='sv-se'), 3.0 / 4.0)
-        self.assertEqual(extractnumber("1 och 3/4 dl",
-                                       lang='sv-se'), 1.75)
-        self.assertEqual(extractnumber("tre fjärdedels dl",
-                                       lang='sv-se'), 3.0 / 4.0)
-        self.assertEqual(extractnumber("trekvarts kopp",
-                                       lang='sv-se'), 3.0 / 4.0)
+        self.assertEqual(extract_number("1 och en halv deciliter",
+                                        lang='sv-se'), 1.5)
+        self.assertEqual(extract_number("det här är det första testet",
+                                        lang='sv-se'), 1)
+        self.assertEqual(extract_number("det här är test nummer 2",
+                                        lang='sv-se'), 2)
+        self.assertEqual(extract_number("det här är det andra testet",
+                                        lang='sv-se'), 2)
+        self.assertEqual(extract_number("det här är tredje testet",
+                                        lang='sv-se'), 3)
+        self.assertEqual(extract_number("det här är test nummer 4",
+                                        lang='sv-se'), 4)
+        self.assertEqual(extract_number("en tredjedels dl",
+                                        lang='sv-se'), 1.0 / 3.0)
+        self.assertEqual(extract_number("tre deciliter",
+                                        lang='sv-se'), 3)
+        self.assertEqual(extract_number("1/3 deciliter",
+                                        lang='sv-se'), 1.0 / 3.0)
+        self.assertEqual(extract_number("en kvarts dl",
+                                        lang='sv-se'), 0.25)
+        self.assertEqual(extract_number("1/4 dl",
+                                        lang='sv-se'), 0.25)
+        self.assertEqual(extract_number("en kvarts dl",
+                                        lang='sv-se'), 0.25)
+        self.assertEqual(extract_number("2/3 dl",
+                                        lang='sv-se'), 2.0 / 3.0)
+        self.assertEqual(extract_number("3/4 dl",
+                                        lang='sv-se'), 3.0 / 4.0)
+        self.assertEqual(extract_number("1 och 3/4 dl",
+                                        lang='sv-se'), 1.75)
+        self.assertEqual(extract_number("tre fjärdedels dl",
+                                        lang='sv-se'), 3.0 / 4.0)
+        self.assertEqual(extract_number("trekvarts kopp",
+                                        lang='sv-se'), 3.0 / 4.0)
 
     def test_extractdatetime_sv(self):
         def extractWithFormat(text):


### PR DESCRIPTION
## Description
Removing the deprecated mycroft.util.parse.extractnumber(), use extract_number() instead.

## How to test
Run skilltester (timer still uses this)

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
