### PR TITLE
Remove announcement parameter from get_response

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -346,16 +346,15 @@ class MycroftSkill(object):
         """
         Prompt user and wait for response
 
-        The given dialog will be spoken, then immediately trigger
-        listening and return user response.  The response can optionally be
-        validated.
+        The given dialog is spoken, followed immediately by listening
+        for a user response.  The response can optionally be
+        validated before returning.
 
         Example:
             color = self.get_response('ask.favorite.color')
 
         Args:
-            dialog (str): Announcement dialog to read to the user,
-                          can be dialog file or literal string.
+            dialog (str): Announcement dialog to speak to the user
             data (dict): Data used to render the dialog
             validator (any): Function with following signature
                 def validator(utterance):
@@ -373,12 +372,7 @@ class MycroftSkill(object):
         data = data or {}
 
         def get_announcement():
-            # The dialog param can be either a litteral string or a dialog file
-            if not exists(join(self.root_dir, 'dialog', self.lang,
-                               dialog + '.dialog')):
-                return dialog  # litteral string
-            else:
-                return self.dialog_renderer.render(dialog, data)
+            return self.dialog_renderer.render(dialog, data)
 
         if not get_announcement():
             raise ValueError('dialog message required')

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -341,22 +341,22 @@ class MycroftSkill(object):
         self.converse = default_converse
         return converse.response
 
-    def get_response(self, dialog='', data=None, announcement='',
-                     validator=None, on_fail=None, num_retries=-1):
+    def get_response(self, dialog='', data=None, validator=None,
+                     on_fail=None, num_retries=-1):
         """
         Prompt user and wait for response
 
-        The given dialog or announcement will be spoken, the immediately
-        listen and return user response.  The response can optionally be
+        The given dialog will be spoken, then immediately trigger
+        listening and return user response.  The response can optionally be
         validated.
 
         Example:
             color = self.get_response('ask.favorite.color')
 
         Args:
-            dialog (str): Announcement dialog to read to the user
+            dialog (str): Announcement dialog to read to the user,
+                          can be dialog file or literal string.
             data (dict): Data used to render the dialog
-            announcement (str): Literal string (overrides dialog)
             validator (any): Function with following signature
                 def validator(utterance):
                     return utterance != "red"
@@ -373,16 +373,15 @@ class MycroftSkill(object):
         data = data or {}
 
         def get_announcement():
-            nonlocal announcement
-            # The dialog param can be either a spoken string or a dialog file
-            # TODO: 18.08 merge dialog/announcement
+            # The dialog param can be either a litteral string or a dialog file
             if not exists(join(self.root_dir, 'dialog', self.lang,
-                               dialog + '.dialog')) and not announcement:
-                announcement = dialog
-            return announcement or self.dialog_renderer.render(dialog, data)
+                               dialog + '.dialog')):
+                return dialog  # litteral string
+            else:
+                return self.dialog_renderer.render(dialog, data)
 
         if not get_announcement():
-            raise ValueError('announcement or dialog message required')
+            raise ValueError('dialog message required')
 
         def on_fail_default(utterance):
             fail_data = data.copy()


### PR DESCRIPTION
## Description
get_response now uses the dialogue parameter for both strings and dialogue
files.

## How to test
Test a skill that uses the get_response method such as the timer skill and make sure it still works.

## Contributor license agreement signed?
CLA [Yes]