### PR TITLE
Bugfix/settingsmeta typecast

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -426,6 +426,23 @@ class SkillSettings(dict):
                     LOG.error(e)
 
     def _type_cast(self, settings_meta, to_platform):
+        """Tranforms data type to be compatible with Home and or Core.
+
+        e.g.
+        Web to core
+        "true" => True, "1.4" =>  1.4
+
+        core to Web
+        False => "false'
+
+        Args:
+            settings_meta (dict): skills object
+            to_platform (str): platform to convert
+                               compatible data types to
+
+        Returns:
+            dict: skills object
+        """
         meta = settings_meta.copy()
         sections = meta['skillMetadata']['sections']
 
@@ -446,6 +463,15 @@ class SkillSettings(dict):
                             sections[i]['fields'][j]['value'] = True
                         elif value == 'false' or value == 'False':
                             sections[i]['fields'][j]['value'] = False
+
+                elif _type == 'number':
+                    value = field.get('value')
+
+                    if to_platform == 'core':
+                        if "." in value:
+                            sections[i]['fields'][j]['value'] = float(value)
+                        else:
+                            sections[i]['fields'][j]['value'] = int(value)
 
         meta['skillMetadata']['sections'] = sections
         return meta

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -371,7 +371,6 @@ class SkillSettings(dict):
             skills_settings = self._request_other_settings(hashed_meta)
         if not skills_settings:
             skills_settings = self._request_my_settings(hashed_meta)
-
         if skills_settings is not None:
             self.save_skill_settings(skills_settings)
             self.store()
@@ -426,6 +425,31 @@ class SkillSettings(dict):
                     # metadata to be able to edit later.
                     LOG.error(e)
 
+    def _type_cast(self, settings_meta, to_platform):
+        meta = settings_meta.copy()
+        sections = meta['skillMetadata']['sections']
+
+        for i, section in enumerate(sections):
+            for j, field in enumerate(section.get('fields', [])):
+                _type = field.get('type')
+                if _type == 'checkbox':
+                    value = field.get('value')
+
+                    if to_platform == 'web':
+                        if value is True or value == 'True':
+                            sections[i]['fields'][j]['value'] = 'true'
+                        elif value is False or value == 'False':
+                            sections[i]['fields'][j]['value'] = 'false'
+
+                    elif to_platform == 'core':
+                        if value == 'true' or value == 'True':
+                            sections[i]['fields'][j]['value'] = True
+                        elif value == 'false' or value == 'False':
+                            sections[i]['fields'][j]['value'] = False
+
+        meta['skillMetadata']['sections'] = sections
+        return meta
+
     def _request_my_settings(self, identifier):
         """ Get skill settings for this device associated
             with the identifier
@@ -442,6 +466,8 @@ class SkillSettings(dict):
         # this loads the settings into memory for use in self.store
         for skill_settings in settings:
             if skill_settings['identifier'] == identifier:
+                skill_settings = \
+                    self._type_cast(skill_settings, to_platform='core')
                 self._remote_settings = skill_settings
                 return skill_settings
         return None
@@ -481,7 +507,8 @@ class SkillSettings(dict):
         if len(user_skill) == 0:
             return None
         else:
-            return user_skill[0]
+            settings = self._type_cast(user_skill[0], to_platform='core')
+            return settings
 
     def _put_metadata(self, settings_meta):
         """ PUT settingsmeta to backend to be configured in server.
@@ -491,6 +518,7 @@ class SkillSettings(dict):
                 settings_meta (dict): dictionary of the current settings meta
                                       data
         """
+        settings_meta = self._type_cast(settings_meta, to_platform='web')
         return self.api.request({
             "method": "PUT",
             "path": self._api_path,

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -473,6 +473,9 @@ class SkillSettings(dict):
                         else:
                             sections[i]['fields'][j]['value'] = int(value)
 
+                    elif to_platform == 'web':
+                        sections[i]['fields'][j]['value'] = str(value)
+
         meta['skillMetadata']['sections'] = sections
         return meta
 


### PR DESCRIPTION
## Description
Home and Core did not have compatible data types for booleans and numbers. This applies to skill settings field number and checkboxes. Home accepted "false" and "true" but not python False and True. This PR fixes that so data types are converted to correct formats for home and web. 

NOTE: this requires skills to change update boolean types for checkboxes.
see skill-date-time typecast_compatibility 

## How to test
Pull this branch.
Pull typecast_compatibility branch for skill-date-time
Test by asking "what time is it"

## Contributor license agreement signed?
CLA [X] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
