### PR TITLE
Fix fudge-ups when replacing emitter/ws with bus

### DIFF
--- a/mycroft/audio/services/mpg123/__init__.py
+++ b/mycroft/audio/services/mpg123/__init__.py
@@ -76,14 +76,14 @@ class Mpg123Service(AudioBackend):
         self.index += 1
         # if there are more tracks available play next
         if self.index < len(self.tracks):
-            bus.emit(Message('Mpg123ServicePlay'))
+            self.bus.emit(Message('Mpg123ServicePlay'))
         else:
             self._is_playing = False
 
     def play(self):
         LOG.info('Call Mpg123ServicePlay')
         self.index = 0
-        bus.emit(Message('Mpg123ServicePlay'))
+        self.bus.emit(Message('Mpg123ServicePlay'))
 
     def stop(self):
         LOG.info('Mpg123ServiceStop')


### PR DESCRIPTION
## Description
A couple of instances in the mpg123 audio backend didn't contain 'self.', this resolves those allowing the backend to be used again.

Thanks to @jarbasal for reporting

## How to test
Try the npr news skill and check that it works.

## Contributor license agreement signed?
CLA [Yes]