### PR TITLE
Fix voc_match_cache member

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -223,6 +223,7 @@ class MycroftSkill(object):
         self.events = []
         self.scheduled_repeats = []
         self.skill_id = ''  # will be set from the path, so guaranteed unique
+        self.voc_match_cache = {}
 
     @property
     def emitter(self):
@@ -231,8 +232,6 @@ class MycroftSkill(object):
         """
         self.log.warning('self.emitter is deprecated switch to "self.bus"')
         return self.bus
-
-        self.voc_match_cache = {}
 
     @property
     def location(self):


### PR DESCRIPTION
## Description
Seems like a rebase/merge moved this one around. It's now moved back into
`__init__`

## How to test
Run the tests for skill alarm and make sure it works as intended.

## Contributor license agreement signed?
CLA [Yes]