### PR TITLE
Move Mark-1 specific image code from api to mark-1 enclosure

### DIFF
--- a/mycroft/enclosure/api.py
+++ b/mycroft/enclosure/api.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from PIL import Image
-
 from .display_manager import DisplayManager
 from mycroft.messagebus.message import Message
 
@@ -245,128 +243,26 @@ class EnclosureAPI:
                                'yOffset': y,
                                'clearPrev': refresh}))
 
-    def mouth_display_png(self, image_absolute_path, threshold=70,
+    def mouth_display_png(self, image_absolute_path,
                           invert=False, x=0, y=0, refresh=True):
-        """Converts a png image into the appropriate encoding for the
-            Arduino Mark I enclosure.
+        """ Send an image to the enclosure.
 
-            NOTE: extract this out of api.py when re structuing the
-                  enclosure folder
-
-            Args:
-                image_absolute_path (string): The absolute path of the image
-                threshold (int): The value ranges from 0 to 255. The pixel will
-                                 draw on the faceplate it the value is below a
-                                 threshold
-                invert (bool): inverts the image being drawn.
-                x (int): x offset for image
-                y (int): y offset for image
-                refresh (bool): specify whether to clear the faceplate before
-                                displaying the new image or not.
-                                Useful if you'd like to display muliple images
-                                on the faceplate at once.
+        Args:
+            image_absolute_path (string): The absolute path of the image
+            invert (bool): inverts the image being drawn.
+            x (int): x offset for image
+            y (int): y offset for image
+            refresh (bool): specify whether to clear the faceplate before
+                            displaying the new image or not.
+                            Useful if you'd like to display muliple images
+                            on the faceplate at once.
             """
         self.display_manager.set_active(self.name)
-
-        # to understand how this funtion works you need to understand how the
-        # Mark I arduino proprietary encoding works to display to the faceplate
-        img = Image.open(image_absolute_path).convert("RGBA")
-        img2 = Image.new('RGBA', img.size, (255, 255, 255))
-        width = img.size[0]
-        height = img.size[1]
-
-        # strips out alpha value and blends it with the RGB values
-        img = Image.alpha_composite(img2, img)
-        img = img.convert("L")
-
-        # crop image to only allow a max width of 16
-        if width > 32:
-            img = img.crop((0, 0, 32, height))
-            width = img.size[0]
-            height = img.size[1]
-
-        # crop the image to limit the max height of 8
-        if height > 8:
-            img = img.crop((0, 0, width, 8))
-            width = img.size[0]
-            height = img.size[1]
-
-        encode = ""
-
-        # Each char value represents a width number starting with B=1
-        # then increment 1 for the next. ie C=2
-        width_codes = ['B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L',
-                       'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W',
-                       'X', 'Y', 'Z', '[', '\\', ']', '^', '_', '`', 'a']
-
-        height_codes = ['B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']
-
-        encode += width_codes[width - 1]
-        encode += height_codes[height - 1]
-
-        # Turn the image pixels into binary values 1's and 0's
-        # the Mark I face plate encoding uses binary values to
-        # binary_values returns a list of 1's and 0s'. ie ['1', '1', '0', ...]
-        binary_values = []
-        for i in range(width):
-            for j in range(height):
-                if img.getpixel((i, j)) < threshold:
-                    if invert is False:
-                        binary_values.append('1')
-                    else:
-                        binary_values.append('0')
-                else:
-                    if invert is False:
-                        binary_values.append('0')
-                    else:
-                        binary_values.append('1')
-
-        # these values are used to determine how binary values
-        # needs to be grouped together
-        number_of_top_pixel = 0
-        number_of_bottom_pixel = 0
-
-        if height > 4:
-            number_of_top_pixel = 4
-            number_of_bottom_pixel = height - 4
-        else:
-            number_of_top_pixel = height
-
-        # this loop will group together the individual binary values
-        # ie. binary_list = ['1111', '001', '0101', '100']
-        binary_list = []
-        binary_code = ''
-        increment = 0
-        alternate = False
-        for val in binary_values:
-            binary_code += val
-            increment += 1
-            if increment == number_of_top_pixel and alternate is False:
-                # binary code is reversed for encoding
-                binary_list.append(binary_code[::-1])
-                increment = 0
-                binary_code = ''
-                alternate = True
-            elif increment == number_of_bottom_pixel and alternate is True:
-                binary_list.append(binary_code[::-1])
-                increment = 0
-                binary_code = ''
-                alternate = False
-
-        # Code to let the Makrk I arduino know where to place the
-        # pixels on the faceplate
-        pixel_codes = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
-                       'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P']
-
-        for binary_values in binary_list:
-            number = int(binary_values, 2)
-            pixel_code = pixel_codes[number]
-            encode += pixel_code
-
-        self.bus.emit(Message("enclosure.mouth.display",
-                              {'img_code': encode,
+        self.bus.emit(Message("enclosure.mouth.display_image",
+                              {'img_path': image_absolute_path,
                                'xOffset': x,
                                'yOffset': y,
+                               'invert': invert,
                                'clearPrev': refresh}))
 
     def weather_display(self, img_code, temp):

--- a/mycroft/enclosure/display_manager.py
+++ b/mycroft/enclosure/display_manager.py
@@ -153,11 +153,12 @@ def init_display_manager_bus_connection():
 
     # Should remove needs to be an object so it can be referenced in functions
     # [https://stackoverflow.com/questions/986006/how-do-i-pass-a-variable-by-reference]
+    display_manager = DisplayManager()
     should_remove = [True]
 
     def check_flag(flag):
         if flag[0] is True:
-            remove_active()
+            display_manager.remove_active()
 
     def set_delay(event=None):
         should_remove[0] = True
@@ -172,10 +173,10 @@ def init_display_manager_bus_connection():
     def remove_wake_word():
         data = _read_data()
         if "active_skill" in data and data["active_skill"] == "wakeword":
-            remove_active()
+            display_manager.remove_active()
 
     def set_wakeword_skill(event=None):
-        set_active("wakeword")
+        display_manager.set_active("wakeword")
         Timer(10, remove_wake_word).start()
 
     bus = WebsocketClient()


### PR DESCRIPTION
## Description
Move the image conversion from the enclosure api to the enclosure. Instead of converting and sending the display code to the enclosure the image path is sent to the enclosure and is converted there instead.

Also fix a bug preventing active skills from automatically being unregistered

## How to test
Make sure the mycroft-timer skill works as expected.

## Contributor license agreement signed?
CLA [Yes]