### PR TITLE
Remove trailing references to MycroftSkill.emitter

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -520,7 +520,8 @@ class MycroftSkill(object):
         Looks for all functions that have been marked by a decorator
         and read the intent data from them
         """
-        for attr_name in dir(self):
+        attributes = [a for a in dir(self) if not a == 'emitter']
+        for attr_name in attributes:
             method = getattr(self, attr_name)
 
             if hasattr(method, 'intents'):

--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -310,7 +310,7 @@ class SkillTest(object):
         # and be handled one by one. We cant make assumptions about threading
         # in the core or the skill
         q = Queue()
-        s.emitter.q = q
+        s.bus.q = q
 
         # Set up context before calling intent
         # This option makes it possible to better isolate (reduce dependance)
@@ -360,7 +360,7 @@ class SkillTest(object):
                 break
 
         # Stop emmiter from sending on queue
-        s.emitter.q = None
+        s.bus.q = None
 
         # remove the skill which is not responding
         self.emitter.remove_all_listeners('speak')


### PR DESCRIPTION
## Description
- references in skill_tester.py
- when going through the methods to check for decorations the emitter
was triggered and generated a Warning, this explicitly ignores the member "emitter"

## How to test
Run a test case and check that no warnings regarding "self.emitter" are generated.

## Contributor license agreement signed?
CLA [Yes]