### PR TITLE
Fix path in recent locale support

### DIFF
--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -120,7 +120,7 @@ class DialogLoader(object):
                 if f.endswith(".dialog"):
                     self.__renderer.load_template_file(
                         f.replace('.dialog', ''),
-                        join(directory, path, f))
+                        join(path, f))
         return self.__renderer
 
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -577,7 +577,7 @@ class MycroftSkill(object):
         root_path = join(self.root_dir, 'locale', self.lang)
         for path, _, files in os.walk(root_path):
             if res_name in files:
-                return join(root_path, path, res_name)
+                return join(path, res_name)
 
         # Not found
         return None

--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -82,7 +82,7 @@ def load_vocabulary(basedir, bus, skill_id):
         for f in files:
             if f.endswith(".voc"):
                 vocab_type = to_alnum(skill_id) + splitext(f)[0]
-                load_vocab_from_file(join(basedir, path, f), vocab_type, bus)
+                load_vocab_from_file(join(path, f), vocab_type, bus)
 
 
 def load_regex(basedir, bus, skill_id):
@@ -97,7 +97,7 @@ def load_regex(basedir, bus, skill_id):
     for path, _, files in walk(basedir):
         for f in files:
             if f.endswith(".rx"):
-                load_regex_from_file(join(basedir, path, f), bus, skill_id)
+                load_regex_from_file(join(path, f), bus, skill_id)
 
 
 def to_alnum(skill_id):


### PR DESCRIPTION
The recent changes to support the 'locale' directory were incorrectly
joining the os.walk() path and filename, resulting in double-directories,
like "./vocab/en-us/./vocab/en-us/Something.voc"

## How to test
I noticed then when running the skill tester (go into a skill directory like ```cd /opt/mycroft/skills/mycroft-joke.mycroftai``` and run ```python -m test.integrationtests.skills.runner .```  It fails before this PR, works afterwards.

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
