### PR TITLE
Switch msm branch to 18.08

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -101,7 +101,7 @@
         // Relative to "data_dir"
         "cache": ".skills-repo",
         "url": "https://github.com/MycroftAI/mycroft-skills",
-        "branch": "18.02"
+        "branch": "18.08"
       }
     },
     // Directory to look for user skills

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ python-vlc==1.1.2
 pulsectl==17.7.4
 google-api-python-client==1.6.4
 
-msm==0.5.18
+msm==0.5.19
 msk==0.3.11
 adapt-parser==0.3.0
 padatious==0.4.5


### PR DESCRIPTION
## Description
Switches the specified msm branch from 18.02 to 18.08 and updates msm to 0.5.19 which changes the default branch (if no branch is specified on the command line for example) to 18.08.

## Contributor license agreement signed?
CLA [Yes]