### PR TITLE
Bugfix/skill loading remnants

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -123,13 +123,18 @@ def load_skill(skill_descriptor, bus, skill_id, BLACKLISTED_SKILLS=None):
             skill.settings.allow_overwrite = True
             skill.settings.load_skill_settings_from_file()
             skill.bind(bus)
-            skill.skill_id = skill_id
-            skill.load_data_files(path)
-            # Set up intent handlers
-            skill._register_decorated()
-            skill.initialize()
-            LOG.info("Loaded " + name)
+            try:
+                skill.skill_id = skill_id
+                skill.load_data_files(path)
+                # Set up intent handlers
+                skill._register_decorated()
+                skill.initialize()
+            except Exception as e:
+                # If an exception occurs, make sure to clean up the skill
+                skill.default_shutdown()
+                raise e
 
+            LOG.info("Loaded " + name)
             # The very first time a skill is run, speak the intro
             first_run = skill.settings.get("__mycroft_skill_firstrun", True)
             if first_run:

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -317,6 +317,7 @@ class SkillManager(Thread):
         skill["instance"] = load_skill(desc,
                                        self.bus, skill["id"],
                                        BLACKLISTED_SKILLS)
+
         skill["last_modified"] = modified
         if skill['instance'] is not None:
             self.bus.emit(Message('mycroft.skills.loaded',
@@ -480,7 +481,8 @@ class SkillManager(Thread):
 
         # loop trough skills list and call converse for skill with skill_id
         for skill in self.loaded_skills:
-            if self.loaded_skills[skill]["id"] == skill_id:
+            if (self.loaded_skills[skill]["instance"] and
+                    self.loaded_skills[skill]["id"] == skill_id):
                 try:
                     instance = self.loaded_skills[skill]["instance"]
                 except BaseException:

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -392,8 +392,10 @@ class SkillManager(Thread):
         try:
             info = {}
             for s in self.loaded_skills:
+                is_active = (self.loaded_skills[s].get('active', True) and
+                             self.loaded_skills[s].get('instance') is not None)
                 info[basename(s)] = {
-                    'active': self.loaded_skills[s].get('active', True),
+                    'active': is_active,
                     'id': self.loaded_skills[s]['id']
                 }
             self.bus.emit(Message('mycroft.skills.list', data=info))


### PR DESCRIPTION
## Description
If skills raises an exception during the initialization step the registered intent handlers remained keeping the skill alive in memory resulting things like multiple handlers triggering on the same event.

This runs shutdown of the skill if loading fails during intent registration or initialization step to make sure no event/intent handlers are left around. Also preforms a check to skip converse on skills that failed to load.

## How to test
Run a skill that raises an exception in the initialize step, something similar to:

```python
from mycroft import MycroftSkill, intent_handler, AdaptIntent


class StartupTest(MycroftSkill):
    def initialize(self):
        raise Exception

    @intent_handler(AdaptIntent().require('test'))
    def test_crash(self, message):
        self.speak('The handler exists!')


def create_skill():
    return StartupTest()
```

Make sure that the intent handler can't be triggered

## Contributor license agreement signed?
CLA [Yes]