### PR TITLE
Make audiotest wait until playback is complete

### DIFF
--- a/mycroft/util/audio_test.py
+++ b/mycroft/util/audio_test.py
@@ -13,11 +13,15 @@
 # limitations under the License.
 #
 import argparse
+import os
+from contextlib import contextmanager
 
 from speech_recognition import Recognizer
 
 from mycroft.client.speech.mic import MutableMicrophone
 from mycroft.util import play_wav
+from mycroft.util.log import LOG
+import logging
 
 """
 Audio Test
@@ -25,6 +29,33 @@ A tool for recording X seconds of audio, and then playing them back. Useful
 for testing hardware, and ensures
 compatibility with mycroft recognizer loop code.
 """
+
+# Reduce loglevel
+LOG.level = 'ERROR'
+logging.getLogger('urllib3').setLevel(logging.WARNING)
+
+
+@contextmanager
+def mute_output():
+    """ Context manager blocking stdout and stderr completely.
+
+    Redirects stdout and stderr to dev-null and restores them on exit.
+    """
+    # Open a pair of null files
+    null_fds = [os.open(os.devnull, os.O_RDWR) for i in range(2)]
+    # Save the actual stdout (1) and stderr (2) file  descriptors.
+    orig_fds = [os.dup(1), os.dup(2)]
+    # Assign the null pointers to stdout and stderr.
+    os.dup2(null_fds[0], 1)
+    os.dup2(null_fds[1], 2)
+    try:
+        yield
+    finally:
+        # Re-assign the real stdout/stderr back to (1) and (2)
+        os.dup2(orig_fds[0], 1)
+        os.dup2(orig_fds[1], 2)
+        for fd in null_fds + orig_fds:
+            os.close(fd)
 
 
 def record(filename, duration):
@@ -44,18 +75,27 @@ def main():
     parser.add_argument(
         '-d', '--duration', dest='duration', type=int, default=10,
         help="Duration of recording in seconds (Default: 10)")
+    parser.add_argument(
+        '-v', '--verbose', dest='verbose', action='store_true', default=False,
+        help="Add extra output regarding the recording")
     args = parser.parse_args()
 
     print(" ===========================================================")
     print(" ==         STARTING TO RECORD, MAKE SOME NOISE!          ==")
     print(" ===========================================================")
 
-    record(args.filename, args.duration)
+    if not args.verbose:
+        with mute_output():
+            record(args.filename, args.duration)
+    else:
+        record(args.filename, args.duration)
 
     print(" ===========================================================")
     print(" ==           DONE RECORDING, PLAYING BACK...             ==")
     print(" ===========================================================")
-    play_wav(args.filename)
+    status = play_wav(args.filename).wait()
+    if status:
+        print('An error occured while playing back audio ({})'.format(status))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Adding the wait will show a lot of extra debug while waiting, to reduce unnecessary Output the log level is reduced and the ALSA lib output is muted unless the --verbose is used.

## How to test
Run the audiotest and check that it works.

## Contributor license agreement signed?
CLA [Yes]