### PR TITLE
Test/test setup

### DIFF
--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -43,10 +43,14 @@ from mycroft.messagebus.message import Message
 from mycroft.skills.core import create_skill_descriptor, load_skill, \
     MycroftSkill, FallbackSkill
 from mycroft.skills.settings import SkillSettings
+from mycroft.configuration import Configuration
 
 MainModule = '__init__'
 
 DEFAULT_EVALUAITON_TIMEOUT = 30
+
+# Set a configuration value to allow skills to check if they're in a test
+Configuration.get()['test_env'] = True
 
 
 # Easy way to show colors on terminals


### PR DESCRIPTION
## Description
The test setup function will be run after the skill is loaded but before the testing starts. This provides a place to setup things that is standard for all test cases. (unlike the test_runner which will run for all test cases)

This also introduces a "test_env" value in the config during tests which can be used in cases where the skill needs to know it's being tested.

## How to test
Create a skill and run a test that checks the test_env config value.
```python
if 'test_env' in self.config_core:
    print('HELLO')
```

and check that it's being run.

## Contributor license agreement signed?
CLA [Yes]
