### PR TITLE
Fix incorrect escape sequences found by skill test

### DIFF
--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -55,7 +55,7 @@ class MustacheDialogRenderer(object):
                 # double (or more) '{' followed by any number of whitespace
                 # followed by actual key followed by any number of whitespace
                 # followed by double (or more) '}'
-                template_text = re.sub('\{\{+\s*(.*?)\s*\}\}+', r'{\1}',
+                template_text = re.sub(r'\{\{+\s*(.*?)\s*\}\}+', r'{\1}',
                                        template_text)
 
                 self.templates[template_name].append(template_text)

--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -463,7 +463,7 @@ class EvaluationRule(object):
                                     "file '" + d + ".dialog'") \
                         from template_load_exception
                 # Allow custom fields to be anything
-                d = [re.sub('{.*?\}', '.*', t) for t in dialogs]
+                d = [re.sub(r'{.*?\}', r'.*', t) for t in dialogs]
                 # Create rule allowing any of the sentences for that dialog
                 rules = [['match', 'utterance', r] for r in d]
                 self.rule.append(['or'] + rules)


### PR DESCRIPTION
## Description
One occurrence in `dialog/__init__.py` and one in `skill_tester.py`. To handle this the strings were marked as raw-strings.

## How to test
Check that dialogs are rendered as intended.

## Contributor license agreement signed?
CLA [Yes]