### PR TITLE
Update requirements and pip install

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -139,7 +139,10 @@ VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${TOP}/.venv"}
 
 function install_venv() {
     python3 -m venv "${VIRTUALENV_ROOT}/" --without-pip
-    curl https://bootstrap.pypa.io/get-pip.py | "${VIRTUALENV_ROOT}/bin/python"
+    # Force version of pip for reproducability, but there is nothing special
+    # about this version.  Update whenever a new version is released and
+    # verified functional.
+    curl https://bootstrap.pypa.io/get-pip.py | "${VIRTUALENV_ROOT}/bin/python" - 'pip==18.0.0'
 }
 
 install_deps
@@ -178,11 +181,6 @@ fi
 # Start the virtual environment
 source "${VIRTUALENV_ROOT}/bin/activate"
 cd "${TOP}"
-
-# Force version of pip for reproducability, but there is nothing special
-# about this version.  Update whenever a new version is released and
-# verified functional.
-easy_install pip==18.0
 
 PYTHON=$( python -c "import sys;print('python{}.{}'.format(sys.version_info[0], sys.version_info[1]))" )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,14 +2,11 @@ six==1.10.0
 requests==2.19.1
 gTTS==1.1.7
 gTTS-token==1.1.1
-backports.ssl-match-hostname==3.4.0.2
 PyAudio==0.2.11
 pyee==1.0.1
 SpeechRecognition==3.8.1
 tornado==4.2.1
 websocket-client==0.32.0
-futures==3.0.3
-future==0.16.0
 requests-futures==0.9.5
 pyyaml==3.11
 pyalsaaudio==0.8.2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
 pep8==1.7.0
+coveralls==1.5.0
 pytest==3.5.0
 pytest-cov==2.5.1
 cov-core==1.15.0
-python-coveralls==2.9.1
 mock==2.0.0


### PR DESCRIPTION
## Description
- Removes three unused modules from requirements (identified by @j1nx in #1796, Thank You!)
- Replaces *python-coveralls* with the more modern *coveralls* module
- installs the preferred pip version in a single step instead of downgrading in a separate step using easy_install

## How to test
- Check that mycroft starts after recreating the .venv
- Check that coveralls generate a coverages report on this PR.

## Contributor license agreement signed?
CLA [Yes]
