### PR TITLE
Add locking when accessing the IdentityManager

### DIFF
--- a/mycroft/util/combo_lock.py
+++ b/mycroft/util/combo_lock.py
@@ -1,0 +1,48 @@
+from threading import Lock
+from fasteners.process_lock import InterProcessLock
+
+
+class ComboLock():
+    """ A combined process and thread lock. """
+    def __init__(self, path):
+        self.plock = InterProcessLock(path)
+        self.tlock = Lock()
+
+    def acquire(self, blocking=True):
+        """ Acquire lock, locks thread and process lock.
+
+        Arguments:
+            blocking(bool): Set's blocking mode of acquire operation.
+                            Default True.
+
+        Returns: True if lock succeeded otherwise False
+        """
+        if not blocking:
+            # Lock thread
+            tlocked = self.tlock.acquire(blocking=False)
+            if not tlocked:
+                return False
+            # Lock process
+            plocked = self.plock.acquire(blocking=False)
+            if not plocked:
+                # Release thread lock if process couldn't be locked
+                self.tlock.release()
+                return False
+        else:  # blocking, just wait and acquire ALL THE LOCKS!!!
+            self.tlock.acquire()
+            self.plock.acquire()
+        return True
+
+    def release(self):
+        """ Release acquired lock. """
+        self.plock.release()
+        self.tlock.release()
+
+    def __enter__(self):
+        """ Context handler, acquires lock in blocking mode. """
+        self.acquire()
+        return self
+
+    def __exit__(self, _type, value, traceback):
+        """ Releases the lock. """
+        self.release()

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ pychromecast==0.7.7
 python-vlc==1.1.2
 pulsectl==17.7.4
 google-api-python-client==1.6.4
+fasteners==0.14.1
 
 msm==0.5.19
 msk==0.3.11


### PR DESCRIPTION

## Description
Adds the mycroft.util.combo_lock ComboLock class for interprocess/Thread
lock.

Loading updated to be more reliable:
- Flush and sync file
- wait 1.2 seconds before load

Split the logic from the locking so the lock can be avoided when calling
update from save or load from get.

## How to test
This one requires a bit of code review. Please check that the locking logic is good and if there's deadlock conditions I haven't thought of.

## Contributor license agreement signed?
CLA [Yes]
