### PR TITLE
Fix ambiguous time handling

### DIFF
--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -310,7 +310,8 @@ def extract_datetime_en(string, currentDate):
         s = s.lower().replace('?', '').replace('.', '').replace(',', '') \
             .replace(' the ', ' ').replace(' a ', ' ').replace(' an ', ' ') \
             .replace("o' clock", "o'clock").replace("o clock", "o'clock") \
-            .replace("o ' clock", "o'clock").replace("o 'clock", "o'clock")
+            .replace("o ' clock", "o'clock").replace("o 'clock", "o'clock") \
+            .replace("oclock", "o'clock")
 
         wordList = s.split()
         for idx, word in enumerate(wordList):
@@ -817,16 +818,18 @@ def extract_datetime_en(string, currentDate):
             HH = HH + 12 if remainder == "pm" and HH < 12 else HH
             HH = HH - 12 if remainder == "am" and HH >= 12 else HH
 
-            if not military and not(remainder in ['am', 'pm']):
-                if not daySpecified or dayOffset < 1:
-                    # ambiguous time, detect whether they mean this evening or
-                    # the next morning based on whether it has already passed
-                    if HH > dateNow.hour:
-                        # has passed, assume the next morning
-                        dayOffset += 1
-                    elif HH <= 12:
-                        # forthcoming, assume this afternoon/evening
-                        HH += 12
+            if (not military and
+                    remainder not in ['am', 'pm', 'hours', 'minutes'] and
+                    ((not daySpecified) or dayOffset < 1)):
+                # ambiguous time, detect whether they mean this evening or
+                # the next morning based on whether it has already passed
+                if dateNow.hour < HH:
+                    pass  # No modification needed
+                elif dateNow.hour < HH + 12:
+                    HH += 12
+                else:
+                    # has passed, assume the next morning
+                    dayOffset += 1
 
             if timeQualifier in timeQualifiersPM and HH < 12:
                 HH += 12

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -351,6 +351,20 @@ class TestNormalize(unittest.TestCase):
         testExtract("remind me to call mom at 10am next saturday",
                     "2017-07-08 10:00:00", "remind me to call mom")
 
+    def test_extract_ambiguous_time_en(self):
+        morning = datetime(2017, 6, 27, 8, 1, 2)
+        evening = datetime(2017, 6, 27, 20, 1, 2)
+        noonish = datetime(2017, 6, 27, 12, 1, 2)
+        self.assertEqual(
+            extract_datetime('feed fish at 10 o\'clock', morning)[0],
+            datetime(2017, 6, 27, 10, 0, 0))
+        self.assertEqual(
+            extract_datetime('feed fish at 10 o\'clock', noonish)[0],
+            datetime(2017, 6, 27, 22, 0, 0))
+        self.assertEqual(
+            extract_datetime('feed fish at 10 o\'clock', evening)[0],
+            datetime(2017, 6, 27, 22, 0, 0))
+
     def test_extract_relativedatetime_en(self):
         def extractWithFormat(text):
             date = datetime(2017, 6, 27, 10, 1, 2)


### PR DESCRIPTION
## Description

Before noon an ambigous time (like *feed the fish at 10 o'clock*) skipped a day forward. This updates the logic to handle a bit better.

Adds a test for the ambigous time

## How to test
Test with alarm skill and/or reminder skill and check that the times are what's expected.

## Contributor license agreement signed?
CLA [Yes] 
