### PR TITLE
Update gTTS-token module to fix google tts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 six==1.10.0
 requests==2.19.1
 gTTS==1.1.7
-gTTS-token==1.1.1
+gTTS-token==1.1.2
 backports.ssl-match-hostname==3.4.0.2
 PyAudio==0.2.11
 pyee==1.0.1


### PR DESCRIPTION
## Description
Bumping the gTTS-token module version to 1.1.2. A recent change on Google's side seem to have broken the gTTS-token module (used my the google_tts module)

## How to test
Switch over to google on home.mycroft.ai and select google as TTS from advanced settings.

## Contributor license agreement signed?
CLA [Yes]