### PR TITLE
pyyaml fix for Arch and Manjaro builds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ websocket-client==0.32.0
 futures==3.0.3
 future==0.16.0
 requests-futures==0.9.5
-pyyaml==3.11
+pyyaml==3.13
 pyalsaaudio==0.8.2
 xmlrunner==1.7.7
 pyserial==3.0


### PR DESCRIPTION
All credit to @adocampo who validated this fix on Arch/Manjaro. 
I have built 18.8.1 on Ubuntu 18.04 LTS and it works perfectly with `pyyaml 3.13`
This fix should help those using Arch and derivatives like Manjaro.

## Description
(Description of what the PR does, such as fixes # {issue number})

## How to test
(Description of how to validate or test this PR)

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
