### PR TITLE
Check for a Precise model automatically for custom wake words

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -39,6 +39,10 @@ class TriggerReload(Exception):
     pass
 
 
+class NoModelAvailable(Exception):
+    pass
+
+
 class HotWordEngine(object):
     def __init__(self, key_phrase="hey mycroft", config=None, lang="en-us"):
         self.key_phrase = str(key_phrase).lower()
@@ -170,11 +174,11 @@ class PreciseHotword(HotWordEngine):
                 model_url, self.folder,
                 on_download=lambda: LOG.info('Updated precise model')
             )
-        except HTTPError:
+        except (HTTPError, ValueError):
             if isfile(model_file):
                 LOG.info("Couldn't find remote model.  Using local file")
             else:
-                raise RuntimeError('Failed to download model:', model_url)
+                raise NoModelAvailable('Failed to download model:', model_url)
         return model_file
 
     @staticmethod
@@ -267,6 +271,11 @@ class HotWordFactory(object):
                 complete.set()
                 sleep(0.5)
                 loop.reload()
+            except NoModelAvailable:
+                LOG.warning('Could not found find model for {} on {}.'.format(
+                    hotword, module
+                ))
+                instance = None
             except Exception:
                 LOG.exception(
                     'Could not create hotword. Falling back to default.')
@@ -286,7 +295,7 @@ class HotWordFactory(object):
             config = Configuration.get()['hotwords']
         config = config[hotword]
 
-        module = config.get("module", "pocketsphinx")
+        module = config.get("module", "precise")
         return cls.load_module(module, hotword, config, lang, loop) or \
             cls.load_module('pocketsphinx', hotword, config, lang, loop) or \
             cls.CLASSES['pocketsphinx']()

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -248,7 +248,7 @@ class RecognizerLoop(EventEmitter):
         config = self.config_core.get("hotwords", {word: {}})
 
         if word not in config:
-            config[word] = {'module': 'pocketsphinx'}
+            config[word] = {'module': 'precise'}
         if phonemes:
             config[word]["phonemes"] = phonemes
         if thresh:


### PR DESCRIPTION
## Description
This PR automatically tries using a precise model for wake words before using pocketsphinx. For testing the model and this PR, I've uploaded a `christopher-precise` model as to not automatically switch people using Pocketsphinx, yet.

## How to test
 - Make sure the normal wake word still works
 - Change your wake word to `christopher`. Make sure it uses *Pocketsphinx*.
 - Change your wake word to `christopher-precise`. To do this manually, add `{'listener': {'wake_word': 'christopher-precise'}}` to `~/.mycroft/mycroft.conf`. Make sure it uses *Precise* (Will be much more sensitive and say `loaded "christopher-precise" via precise`
