### PR TITLE
Fix now_utc() to return aware datetime

### DIFF
--- a/mycroft/util/time.py
+++ b/mycroft/util/time.py
@@ -48,7 +48,7 @@ def now_utc():
     Returns:
         (datetime): The current time in Universal Time, aka GMT
     """
-    return datetime.utcnow()
+    return to_utc(datetime.utcnow())
 
 
 def now_local(tz=None):


### PR DESCRIPTION
The mycroft.util.time.now_utc() was returning a naive datetime object, potentially causing
issues in skills running on instances that aren't using UTC system-wide.  This didn't impact
Picroft or Mark 1, but Github installs would experience issues with skills such as the Alarm.

## Description
(Description of what the PR does, such as fixes # {issue number})

## How to test
(Description of how to validate or test this PR)

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
