### PR TITLE
Add "wait" option to MycroftSkill.speak() and speak_dialog()

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -972,7 +972,7 @@ class MycroftSkill(object):
                 expect_response (bool): set to True if Mycroft should listen
                                         for a response immediately after
                                         speaking the utterance.
-                wait (bool):            set to True to block while the utterance
+                wait (bool):            set to True to block while the text
                                         is being spoken.
         """
         # registers the skill as being active

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -997,13 +997,12 @@ class MycroftSkill(object):
                 expect_response (bool): set to True if Mycroft should listen
                                         for a response immediately after
                                         speaking the utterance.
-                wait (bool):            set to True to block while the dialog
+                wait (bool):            set to True to block while the text
                                         is being spoken.
         """
         data = data or {}
-        self.speak(self.dialog_renderer.render(key, data), expect_response)
-        if wait:
-            wait_while_speaking()
+        self.speak(self.dialog_renderer.render(key, data),
+                   expect_response, wait)
 
     def init_dialog(self, root_directory):
         # If "<skill>/dialog/<lang>" exists, load from there.  Otherwise

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -964,7 +964,7 @@ class MycroftSkill(object):
         re.compile(regex)  # validate regex
         self.bus.emit(Message('register_vocab', {'regex': regex}))
 
-    def speak(self, utterance, expect_response=False):
+    def speak(self, utterance, expect_response=False, wait=False):
         """ Speak a sentence.
 
             Args:
@@ -972,6 +972,8 @@ class MycroftSkill(object):
                 expect_response (bool): set to True if Mycroft should listen
                                         for a response immediately after
                                         speaking the utterance.
+                wait (bool):            set to True to block while the utterance
+                                        is being spoken.
         """
         # registers the skill as being active
         self.enclosure.register(self.name)
@@ -982,19 +984,26 @@ class MycroftSkill(object):
             self.bus.emit(message.reply("speak", data))
         else:
             self.bus.emit(Message("speak", data))
+        if wait:
+            wait_while_speaking()
 
-    def speak_dialog(self, key, data=None, expect_response=False):
+    def speak_dialog(self, key, data=None, expect_response=False, wait=False):
         """ Speak a random sentence from a dialog file.
 
             Args:
-                key (str): dialog file key (filename without extension)
+                key (str): dialog file key (e.g. "hello" to speak from the file
+                                            "locale/en-us/hello.dialog")
                 data (dict): information used to populate sentence
                 expect_response (bool): set to True if Mycroft should listen
                                         for a response immediately after
                                         speaking the utterance.
+                wait (bool):            set to True to block while the dialog
+                                        is being spoken.
         """
         data = data or {}
         self.speak(self.dialog_renderer.render(key, data), expect_response)
+        if wait:
+            wait_while_speaking()
 
     def init_dialog(self, root_directory):
         # If "<skill>/dialog/<lang>" exists, load from there.  Otherwise

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1058,7 +1058,7 @@ class MycroftSkill(object):
                 self.bus.emit(Message("mycroft.stop.handled",
                                       {"by": "skill:"+str(self.skill_id)}))
             timer.cancel()
-        except:
+        except:  # noqa
             timer.cancel()
             LOG.error("Failed to stop skill: {}".format(self.name),
                       exc_info=True)
@@ -1099,7 +1099,7 @@ class MycroftSkill(object):
             Message("detach_skill", {"skill_id": str(self.skill_id) + ":"}))
         try:
             self.stop()
-        except:
+        except:  # noqa
             LOG.error("Failed to stop skill: {}".format(self.name),
                       exc_info=True)
 


### PR DESCRIPTION
The new "wait" option will cause the speak function to block until all
of the given dialog has been spoken by Mycroft.  This means:
    self.speak("Hello world", wait=True)
is now equivalent to:
    self.speak("Hello world")
    wait_while_speaking()

## How to test
In a skill, run the following and watch logs in the CLI
```python
    self.log.info("Not using wait...")
    self.speak("Speaking a long utterance without doing a wait, watch me in the logs.")
    self.log.info("Done")

    self.log.info("Using wait...")
    self.speak("Speaking a long utterance with wait set to True, watch me in the logs.",
                     wait=True)
    self.log.info("Done")
```

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
