### PR TITLE
feature: allow adapt context across skills

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -865,7 +865,7 @@ class MycroftSkill(object):
                                                       'registered.')
         return False
 
-    def set_context(self, context, word=''):
+    def set_context(self, context, word='', origin=None):
         """
             Add context to intent service
 
@@ -877,9 +877,12 @@ class MycroftSkill(object):
             raise ValueError('context should be a string')
         if not isinstance(word, str):
             raise ValueError('word should be a string')
+
+        origin = origin or ''
         context = to_alnum(self.skill_id) + context
         self.bus.emit(Message('add_context',
-                              {'context': context, 'word': word}))
+                              {'context': context, 'word': word,
+                               'origin': origin}))
 
     def handle_set_cross_context(self, message):
         """
@@ -888,7 +891,9 @@ class MycroftSkill(object):
         """
         context = message.data.get("context")
         word = message.data.get("word")
-        self.set_context(context, word)
+        origin = message.data.get("origin")
+
+        self.set_context(context, word, origin)
 
     def handle_remove_cross_context(self, message):
         """
@@ -907,7 +912,8 @@ class MycroftSkill(object):
                 word:       word connected to keyword
         """
         self.bus.emit(Message("mycroft.skill.set_cross_context",
-                              {"context": context, "word": word}))
+                              {"context": context, "word": word,
+                               "origin": self.skill_id}))
 
     def remove_cross_skill_context(self, context):
         """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -274,7 +274,8 @@ class MycroftSkill(object):
                            self.handle_enable_intent)
             self.add_event('mycroft.skill.disable_intent',
                            self.handle_disable_intent)
-
+            self.add_event("mycroft.skill.cross_context",
+                           self.handle_cross_context)
             name = 'mycroft.skills.settings.update'
             func = self.settings.run_poll
             bus.on(name, func)
@@ -877,6 +878,25 @@ class MycroftSkill(object):
         context = to_alnum(self.skill_id) + context
         self.bus.emit(Message('add_context',
                               {'context': context, 'word': word}))
+
+    def handle_cross_context(self, message):
+        """
+            Add global context to intent service
+
+        """
+        context = message.data.get("context")
+        word = message.data.get("word")
+        self.set_context(context, word)
+
+    def set_cross_skill_context(self, context, word):
+        """
+            Tell all skills to add a context to intent service
+
+            Args:
+                context:    Keyword
+                word:       word connected to keyword
+        """
+        self.bus.emit(Message("mycroft.skill.cross_context", {"context": context, "word": word}))
 
     def remove_context(self, context):
         """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -888,7 +888,7 @@ class MycroftSkill(object):
         word = message.data.get("word")
         self.set_context(context, word)
 
-    def set_cross_skill_context(self, context, word):
+    def set_cross_skill_context(self, context, word=''):
         """
             Tell all skills to add a context to intent service
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -896,7 +896,8 @@ class MycroftSkill(object):
                 context:    Keyword
                 word:       word connected to keyword
         """
-        self.bus.emit(Message("mycroft.skill.cross_context", {"context": context, "word": word}))
+        self.bus.emit(Message("mycroft.skill.cross_context",
+                              {"context": context, "word": word}))
 
     def remove_context(self, context):
         """

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -274,8 +274,10 @@ class MycroftSkill(object):
                            self.handle_enable_intent)
             self.add_event('mycroft.skill.disable_intent',
                            self.handle_disable_intent)
-            self.add_event("mycroft.skill.cross_context",
-                           self.handle_cross_context)
+            self.add_event("mycroft.skill.set_cross_context",
+                           self.handle_set_cross_context)
+            self.add_event("mycroft.skill.remove_cross_context",
+                           self.handle_remove_cross_context)
             name = 'mycroft.skills.settings.update'
             func = self.settings.run_poll
             bus.on(name, func)
@@ -879,7 +881,7 @@ class MycroftSkill(object):
         self.bus.emit(Message('add_context',
                               {'context': context, 'word': word}))
 
-    def handle_cross_context(self, message):
+    def handle_set_cross_context(self, message):
         """
             Add global context to intent service
 
@@ -887,6 +889,14 @@ class MycroftSkill(object):
         context = message.data.get("context")
         word = message.data.get("word")
         self.set_context(context, word)
+
+    def handle_remove_cross_context(self, message):
+        """
+            Remove global context from intent service
+
+        """
+        context = message.data.get("context")
+        self.remove_context(context)
 
     def set_cross_skill_context(self, context, word=''):
         """
@@ -896,15 +906,25 @@ class MycroftSkill(object):
                 context:    Keyword
                 word:       word connected to keyword
         """
-        self.bus.emit(Message("mycroft.skill.cross_context",
+        self.bus.emit(Message("mycroft.skill.set_cross_context",
                               {"context": context, "word": word}))
 
-    def remove_context(self, context):
+    def remove_cross_skill_context(self, context):
         """
-            remove_context removes a keyword from from the context manager.
+           tell all skills to remove a keyword from the context manager.
         """
         if not isinstance(context, str):
             raise ValueError('context should be a string')
+        self.bus.emit(Message("mycroft.skill.remove_cross_context",
+                              {"context": context}))
+
+    def remove_context(self, context):
+        """
+            remove a keyword from the context manager.
+        """
+        if not isinstance(context, str):
+            raise ValueError('context should be a string')
+        context = to_alnum(self.skill_id) + context
         self.bus.emit(Message('remove_context', {'context': context}))
 
     def register_vocabulary(self, entity, entity_type):

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -94,13 +94,21 @@ class ContextManager(object):
 
         missing_entities = list(missing_entities)
         context = []
+        last = ''
+        depth = 0
         for i in range(max_frames):
             frame_entities = [entity.copy() for entity in
                               relevant_frames[i].entities]
             for entity in frame_entities:
                 entity['confidence'] = entity.get('confidence', 1.0) \
-                    / (2.0 + i)
+                    / (2.0 + depth)
             context += frame_entities
+
+            # Update depth
+            if entity['origin'] != last or entity['origin'] == '':
+                depth += 1
+            last = entity['origin']
+            print(depth)
 
         result = []
         if len(missing_entities) > 0:
@@ -408,12 +416,14 @@ class IntentService(object):
         entity = {'confidence': 1.0}
         context = message.data.get('context')
         word = message.data.get('word') or ''
+        origin = message.data.get('origin') or ''
         # if not a string type try creating a string from it
         if not isinstance(word, str):
             word = str(word)
         entity['data'] = [(word, context)]
         entity['match'] = word
         entity['key'] = word
+        entity['origin'] = origin
         self.context_manager.inject_context(entity)
 
     def handle_remove_context(self, message):

--- a/test/unittests/skills/test_core.py
+++ b/test/unittests/skills/test_core.py
@@ -405,7 +405,7 @@ class MycroftSkillTest(unittest.TestCase):
         s = SimpleSkill1()
         s.bind(self.emitter)
         s.remove_context('Donatello')
-        expected = [{'context': 'Donatello'}]
+        expected = [{'context': 'ADonatello'}]
         check_remove_context(expected)
 
     @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)

--- a/test/unittests/skills/test_core.py
+++ b/test/unittests/skills/test_core.py
@@ -373,17 +373,18 @@ class MycroftSkillTest(unittest.TestCase):
         s.bind(self.emitter)
         # No context content
         s.set_context('TurtlePower')
-        expected = [{'context': 'ATurtlePower', 'word': ''}]
+        expected = [{'context': 'ATurtlePower', 'origin': '', 'word': ''}]
         check_set_context(expected)
 
         # context with content
         s.set_context('Technodrome', 'Shredder')
-        expected = [{'context': 'ATechnodrome', 'word': 'Shredder'}]
+        expected = [{'context': 'ATechnodrome', 'origin': '',
+                     'word': 'Shredder'}]
         check_set_context(expected)
 
         # UTF-8 context
         s.set_context(u'Smörgåsbord€15')
-        expected = [{'context': u'ASmörgåsbord€15', 'word': ''}]
+        expected = [{'context': u'ASmörgåsbord€15', 'origin': '', 'word': ''}]
         check_set_context(expected)
 
         self.emitter.reset()


### PR DESCRIPTION
## Description

self.set_context does not let you share contexts across skills because of the intent name munged in the context

This PR adds a new method to set a context in all skills

This allows for better interactions between skills 

Someone asked about this in mattermost recently, i also need it in my location tracker skill to provide a default location

EDIT: 

added methods to also remove context

fixed a bug with remove context where skill id wasn't munged, 

`context = to_alnum(self.skill_id) + context`

## How to test

in skill A use self.set_cross_skill_context, check that you can trigger an intent from skill B requiring that context

from skill C remove the context with self.remove_cross_skill_context, check that you can not trigger skill B, doing this you are also testing the bug fix for the standard remove_context, it is now correctly munging skill id into the keyword name


## Contributor license agreement signed?
CLA [yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
