### PR TITLE
Order results from translate_namedvalues()

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import imp
+import collections
 import operator
 import sys
 import time
@@ -603,7 +604,7 @@ class MycroftSkill(object):
         """
 
         delim = delim or ','
-        result = {}
+        result = collections.OrderedDict()
         if not name.endswith(".value"):
             name += ".value"
 
@@ -1049,7 +1050,7 @@ class MycroftSkill(object):
                 self.bus.emit(Message("mycroft.stop.handled",
                                       {"by": "skill:"+str(self.skill_id)}))
             timer.cancel()
-        except:
+        except:  # noqa
             timer.cancel()
             LOG.error("Failed to stop skill: {}".format(self.name),
                       exc_info=True)
@@ -1090,7 +1091,7 @@ class MycroftSkill(object):
             Message("detach_skill", {"skill_id": str(self.skill_id) + ":"}))
         try:
             self.stop()
-        except:
+        except:  # noqa
             LOG.error("Failed to stop skill: {}".format(self.name),
                       exc_info=True)
 


### PR DESCRIPTION
Switch to an OrderedDict() for translate_namedvalues(), maintaining the
sequence of values defined in the original "list.value" file.  This is
useful in circumstances where there are multiple values, but the order
of listing indicates some sort of preference.

This is used in the Alarm skill to allow synonyms like "weekdays"/"weekday",
"Mondays/Monday", but the first value is used when building the status string.
For example "You have an alarm for 8am on Mondays".  Generically, this lets
translators consistently provide preferred names for values by adjusting the
order.