### PR TITLE
Strip trailing blank lines

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -669,7 +669,7 @@ class MycroftSkill(object):
         if filename:
             with open(filename) as f:
                 text = f.read().replace('{{', '{').replace('}}', '}')
-                return text.format(**data or {}).split('\n')
+                return text.format(**data or {}).rstrip('\n').split('\n')
         else:
             return None
 


### PR DESCRIPTION
## Description
In ascii mode many editors leaves a trailing \n at the end of file. This recently caused an issue with the installer-skill's german translation.

This will also remove trailing empty lines from the end of dialog files. If a blank line is intended add a single space and it will be included.

## How to test
Check that skills that use the feature such as installer still works.

## Contributor license agreement signed?
CLA [Yes]