### PR TITLE
Use the phonetic_spellings.txt in Mimic2

### DIFF
--- a/mycroft/res/text/en-us/phonetic_spellings.txt
+++ b/mycroft/res/text/en-us/phonetic_spellings.txt
@@ -2,3 +2,4 @@ jalepeno: hallipeenyo
 ai: A.I.
 mycroftai: mycroft A.I.
 spotify: spot-ify
+corgi: core-gee

--- a/mycroft/tts/mimic2_tts.py
+++ b/mycroft/tts/mimic2_tts.py
@@ -279,6 +279,14 @@ class Mimic2(TTS):
         create_signal("isSpeaking")
 
         sentence = self._normalized_numbers(sentence)
+
+        # Use the phonetic_spelling mechanism from the TTS base class
+        if self.phonetic_spelling:
+            for word in re.findall(r"[\w']+", sentence):
+                if word.lower() in self.spellings:
+                    sentence = sentence.replace(word,
+                                                self.spellings[word.lower()])
+
         chunks = sentence_chunker(sentence, self.chunk_size)
         for idx, req in enumerate(self._requests(chunks)):
             results = req.result().json()


### PR DESCRIPTION
The "phonetic_spellings.txt" mechanism converts odd words to strings that
represent what they should sound like when spoken.  For example, "mycroftai"
to "Mycroft A.I.".  This provides an easy mechanism to provide hints to
lots of Text to Speech engines.

This adds it to Mimic2, along with a spelling of "corgi".

## How to test
Try "say corgi" and "say mycroftai" before and after this change.

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
