### PR TITLE
Load identity if no refresh token exists

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -63,6 +63,10 @@ class Api(object):
         return self.send(params)
 
     def check_token(self):
+        # If the identity hasn't been loaded, load it
+        if not self.identity.has_refresh():
+            self.identity = IdentityManager.load()
+        # If refresh is needed perform a refresh
         if self.identity.refresh and self.identity.is_expired():
             self.identity = IdentityManager.load()
             # if no one else has updated the token refresh it

--- a/mycroft/identity/__init__.py
+++ b/mycroft/identity/__init__.py
@@ -32,6 +32,9 @@ class DeviceIdentity(object):
     def is_expired(self):
         return self.refresh and 0 < self.expires_at <= time.time()
 
+    def has_refresh(self):
+        return self.refresh != ""
+
 
 class IdentityManager(object):
     __identity = None


### PR DESCRIPTION
## Description
Always one more thing!

Will now load the credentials if no refresh token exist. This means that no refresh will occur
 if a refresh isn't possible and the credentials will be loaded from disk if the process hasn't done so
once.

## How to test
Do a pairing and check that voice process start producing data.

## Contributor license agreement signed?
CLA [ Yas ]
