### PR TITLE
Feature/skill api

### DIFF
--- a/mycroft/skills/__init__.py
+++ b/mycroft/skills/__init__.py
@@ -19,7 +19,7 @@ These classes, decorators and functions are used to build skills for Mycroft.
 
 
 from .mycroft_skill import (MycroftSkill, intent_handler, intent_file_handler,
-                            resting_screen_handler)
+                            resting_screen_handler, skill_api_method)
 from .fallback_skill import FallbackSkill
 from .common_iot_skill import CommonIoTSkill
 from .common_play_skill import CommonPlaySkill, CPSMatchLevel

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -39,6 +39,8 @@ from mycroft.util import (
 from mycroft.util.lang import set_active_lang
 from mycroft.util.log import LOG
 from mycroft.util.process_utils import ProcessStatus, StatusCallbackMap
+
+from .api import SkillApi
 from .core import FallbackSkill
 from .event_scheduler import EventScheduler
 from .intent_service import IntentService
@@ -211,6 +213,7 @@ def main(alive_hook=on_alive, started_hook=on_started, ready_hook=on_ready,
                                   on_stopping=stopping_hook)
     status = ProcessStatus('skills', bus, callbacks)
 
+    SkillApi.connect_bus(bus)
     skill_manager = _initialize_skill_manager(bus, watchdog)
 
     status.set_started()

--- a/mycroft/skills/api.py
+++ b/mycroft/skills/api.py
@@ -27,18 +27,25 @@ class SkillApi():
     bus = None
 
     @classmethod
-    def connect_bus(mycroft_bus):
+    def connect_bus(cls, mycroft_bus):
         """Registers the bus object to use."""
-        SkillApi.bus = mycroft_bus
+        cls.bus = mycroft_bus
 
     def __init__(self, method_dict):
         self.method_dict = method_dict
         for key in method_dict:
             def get_method(k):
-                def method(**kwargs):
+                def method(*args, **kwargs):
                     m = self.method_dict[k]
-                    method_msg = Message(m['type'], data=kwargs)
-                    return SkillApi.bus.wait_for_response(method_msg)
+                    data = {'args': args, 'kwargs': kwargs}
+                    method_msg = Message(m['type'], data)
+                    response = SkillApi.bus.wait_for_response(method_msg)
+                    if (response and response.data and
+                            'result' in response.data):
+                        return response.data['result']
+                    else:
+                        return None
+
                 return method
 
             self.__setattr__(key, get_method(key))

--- a/mycroft/skills/api.py
+++ b/mycroft/skills/api.py
@@ -1,0 +1,60 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Skill Api
+
+The skill api allows skills interact with eachother over the message bus
+just like interacting with any other object.
+"""
+from mycroft.messagebus.message import Message
+
+
+class SkillApi():
+    """SkillApi providing a simple interface to exported methods from skills
+
+    Methods are built from a method_dict provided when initializing the skill.
+    """
+    bus = None
+
+    @classmethod
+    def connect_bus(mycroft_bus):
+        """Registers the bus object to use."""
+        SkillApi.bus = mycroft_bus
+
+    def __init__(self, method_dict):
+        self.method_dict = method_dict
+        for key in method_dict:
+            def get_method(k):
+                def method(**kwargs):
+                    m = self.method_dict[k]
+                    method_msg = Message(m['type'], data=kwargs)
+                    return SkillApi.bus.wait_for_response(method_msg)
+                return method
+
+            self.__setattr__(key, get_method(key))
+
+    @staticmethod
+    def get(skill):
+        """Generate api object from skill id.
+        Arguments:
+            skill (str): skill id for target skill
+
+        Returns:
+            SkillApi
+        """
+        public_api_msg = '{}.public_api'.format(skill)
+        api = SkillApi.bus.wait_for_response(Message(public_api_msg))
+        if api:
+            return SkillApi(api.data)
+        else:
+            return None

--- a/mycroft/skills/mycroft_skill/__init__.py
+++ b/mycroft/skills/mycroft_skill/__init__.py
@@ -15,4 +15,4 @@
 from .mycroft_skill import MycroftSkill
 from .event_container import get_handler_name
 from .decorators import (intent_handler, intent_file_handler,
-                         resting_screen_handler)
+                         resting_screen_handler, skill_api_method)

--- a/mycroft/skills/mycroft_skill/decorators.py
+++ b/mycroft/skills/mycroft_skill/decorators.py
@@ -60,3 +60,15 @@ def resting_screen_handler(name):
         return func
 
     return real_decorator
+
+
+def skill_api_method(func):
+    """Decorator for adding a method to the skill's public api.
+
+    Methods with this decorator will be registered on the message bus
+    and an api object can be created for interaction with the skill.
+    """
+    # tag the method by adding an api_method member to it
+    if not hasattr(func, 'api_method') and hasattr(func, '__name__'):
+        func.api_method = True
+    return func

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -264,19 +264,51 @@ class MycroftSkill:
             self._register_public_api()
 
     def _register_public_api(self):
-        """Register handlers for the methods marked as public api methods."""
-        name = basename(self.root_dir.rstrip('/'))
-        # Register handlers for the public api
+        """ Find and register api methods.
+        Api methods has been tagged with the api_method member, for each
+        method where this is found the method a message bus handler is
+        registered.
+        Finally create a handler for fetching the api info from any requesting
+        skill.
+        """
+
+        def wrap_method(func):
+            """Boiler plate for returning the response to the sender."""
+            def wrapper(message):
+                result = func(*message.data['args'], **message.data['kwargs'])
+                self.bus.emit(message.response(data={'result': result}))
+
+            return wrapper
+
+        methods = [attr_name for attr_name in get_non_properties(self)
+                   if hasattr(getattr(self, attr_name), '__name__')]
+
+        for attr_name in methods:
+            method = getattr(self, attr_name)
+
+            if hasattr(method, 'api_method'):
+                doc = method.__doc__ or ''
+                name = method.__name__
+                self.public_api[name] = {
+                    'help': doc,
+                    'type': '{}.{}'.format(self.skill_id, name),
+                    'func': method
+                }
         for key in self.public_api:
             if ('type' in self.public_api[key] and
                     'func' in self.public_api[key]):
-                self.add_event(self.public_api[key]['type'],
-                               self.public_api[key]['func'])
+                LOG.debug('Adding api method: '
+                          '{}'.format(self.public_api[key]['type']))
+
                 # remove the function member since it shouldn't be
                 # reused and can't be sent over the messagebus
-                self.public_api[key].pop('func')
+                func = self.public_api[key].pop('func')
+                self.add_event(self.public_api[key]['type'],
+                               wrap_method(func))
 
-        self.add_event('{}.public_api'.format(name), self._send_public_api)
+        if self.public_api:
+            self.add_event('{}.public_api'.format(self.skill_id),
+                           self._send_public_api)
 
     def _register_system_event_handlers(self):
         """Add all events allowing the standard interaction with the Mycroft

--- a/test/unittests/skills/test_skill_api.py
+++ b/test/unittests/skills/test_skill_api.py
@@ -1,0 +1,154 @@
+from unittest import TestCase, mock
+
+from mycroft import MycroftSkill
+from mycroft.messagebus import Message
+from mycroft.skills import skill_api_method
+from mycroft.skills.api import SkillApi
+
+
+class Skill(MycroftSkill):
+    """Test skill with registered API methods."""
+    def __init__(self):
+        super().__init__()
+        self.registered_methods = {}
+
+    def add_event(self, event_type, func):
+        """Mock handler of add_event, simply storing type and method.
+
+        Used in testing to verify the wrapped methods
+        """
+        self.registered_methods[event_type] = func
+
+    @skill_api_method
+    def test_method(self):
+        """Documentation."""
+        return True
+
+    @skill_api_method
+    def test_method2(self, arg):
+        """Documentation."""
+        return 'TestResult'
+
+
+def load_test_skill():
+    """Helper for setting up the test skill.
+
+    Returns:
+        (MycroftSkill): created test skill
+    """
+    bus = mock.Mock()
+    test_skill = Skill()
+    test_skill.skill_id = 'test_skill'
+    test_skill.bind(bus)
+    return test_skill
+
+
+def create_skill_api_from_skill(skill):
+    """Helper creating an api from a skill.
+
+    Arguments:
+        skill (MycroftSkill): Skill to create api from.
+
+    Returns:
+        (SkillApi): API for the skill.
+    """
+    SkillApi.connect_bus(skill.bus)
+    return SkillApi(skill.public_api)
+
+
+class testSkillMethod(TestCase):
+    """Tests for the MycroftSkill class API setup."""
+    def test_public_api_event(self):
+        """Test that public api event handler is created."""
+        test_skill = load_test_skill()
+        self.assertTrue(
+            'test_skill.public_api' in test_skill.registered_methods
+        )
+
+    def test_public_api(self):
+        """Test that the public_api structure matches the decorators."""
+        test_skill = load_test_skill()
+        # Check that methods has been added
+        self.assertTrue('test_method' in test_skill.public_api)
+        self.assertTrue('test_method2' in test_skill.public_api)
+        # Test docstring
+        self.assertEqual(test_skill.public_api['test_method']['help'],
+                         'Documentation.')
+        # Test type
+        self.assertEqual(test_skill.public_api['test_method']['type'],
+                         '{}.{}'.format(test_skill.skill_id, 'test_method'))
+
+    def test_public_api_method(self):
+        """Verify message from wrapped api method."""
+        test_skill = load_test_skill()
+        api_method = test_skill.registered_methods['test_skill.test_method']
+
+        # Call method
+        call_msg = Message('test_skill.test_method',
+                           data={'args': [], 'kwargs': {}})
+        api_method(call_msg)
+        # Check response sent on the bus is the same as the method's return
+        # value
+        response = test_skill.bus.emit.call_args[0][0]
+        self.assertEqual(response.data['result'], test_skill.test_method())
+
+    def test_public_api_request(self):
+        """Test public api request handling.
+
+        Ensures that a request for the skill's available public api returns
+        expected content.
+        """
+        test_skill = load_test_skill()
+        sent_message = None
+
+        def capture_sent_message(message):
+            """Capture sent message."""
+            nonlocal sent_message
+            sent_message = message
+
+        test_skill.bus.emit.side_effect = capture_sent_message
+        get_api_method = test_skill.registered_methods['test_skill.public_api']
+        request_api_msg = Message('test_skill.public_api')
+
+        # Ensure that the sent public api contains the correct items
+        get_api_method(request_api_msg)
+        public_api = sent_message.data
+        self.assertTrue('test_method' in public_api)
+        self.assertTrue('test_method2' in public_api)
+        self.assertEqual(len(public_api), 2)
+
+
+class TestApiObject(TestCase):
+    """Tests for the generated SkillApi objects."""
+    def test_create_api_object(self):
+        """Check that expected methods are available."""
+        test_skill = load_test_skill()
+        test_api = create_skill_api_from_skill(test_skill)
+
+        hasattr(test_api, 'test_method')
+        hasattr(test_api, 'test_method2')
+
+    def test_call_api_method(self):
+        """Ensure that calling the methods works as expected."""
+        test_skill = load_test_skill()
+        test_api = create_skill_api_from_skill(test_skill)
+
+        expected_response = 'all is good'
+        sent_message = None
+
+        def capture_sent_message(message):
+            """Capture sent message and return expected response message."""
+            nonlocal sent_message
+            sent_message = message
+            return Message('', data={'result': expected_response})
+
+        test_api.bus.wait_for_response.side_effect = capture_sent_message
+
+        response = test_api.test_method('hello', person='you')
+
+        # Verify response
+        self.assertEqual(response, expected_response)
+        # Verify sent message
+        self.assertEqual(sent_message.msg_type, 'test_skill.test_method')
+        self.assertEqual(sent_message.data['args'], ('hello',))
+        self.assertEqual(sent_message.data['kwargs'], {'person': 'you'})


### PR DESCRIPTION
## Description
This is a suggestion for an easy way for skills to publish and use other skills shared methods. The idea is that for example the alarm skill wants to 

The skill api object is generated from the skill's public_api property. It's a dict where each key is turned into a method on the api object. The method is defined as
```
  "api_method": {
    "type": message type string
    "func": handler method
    "help": help string for cli
  }
```

This dict is generated from methods in the skill tagged with the `skill_api_method` decorator.

Example skill:
```python
from mycroft.skills import MycroftSkill, skill_api_method

class Test2(MycroftSkill):
    @skill_api_method
    def speak_meth(self, message):
        """Speak the test sentence."""
        self.speak('This is a test')
 
    @skill_api_method
    def speak_meth2(self, message):
        """Speak another test sentence."""
        self.speak('This is another test')
```

To use this skill from another skill

import the SkillApi class

```python
from mycroft.skills.api import SkillApi
```

and then get an api object and use that to trigger the skill:

```python
my_skill = SkillApi.get('myskill.forslund')
my_skill.speak_meth()
```

This also adds a help interface to the api in the CLI, `:api SKILL` will list available api methods.

## Contributor license agreement signed?
CLA [ Yes ]