### PR TITLE
Add protection for naive skill authors

### DIFF
--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -142,7 +142,7 @@ def load_settings():
             max_log_lines = config["max_log_lines"]
         if "show_meter" in config:
             show_meter = config["show_meter"]
-    except:
+    except Exception:
         pass
 
 
@@ -690,12 +690,12 @@ def do_draw_main(scr):
         y += 1
 
     # Command line at the bottom
-    l = line
+    ln = line
     if len(line) > 0 and line[0] == ":":
         scr.addstr(curses.LINES - 2, 0, "Command ('help' for options):",
                    CLR_CMDLINE)
         scr.addstr(curses.LINES - 1, 0, ":", CLR_CMDLINE)
-        l = line[1:]
+        ln = line[1:]
     else:
         prompt = "Input (':' for command, Ctrl+C to quit)"
         if show_last_key:
@@ -707,7 +707,7 @@ def do_draw_main(scr):
         scr.addstr(curses.LINES - 1, 0, ">", CLR_HEADING)
 
     _do_meter(cy_chat_area + 2)
-    scr.addstr(curses.LINES - 1, 2, l, CLR_INPUT)
+    scr.addstr(curses.LINES - 1, 2, ln, CLR_INPUT)
 
     # Curses doesn't actually update the display until refresh() is called
     scr.refresh()
@@ -718,6 +718,7 @@ def make_titlebar(title, bar_length):
 
 ##############################################################################
 # Help system
+
 
 help_struct = [
     (

--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -90,6 +90,7 @@ CLR_INPUT = 0
 CLR_LOG1 = 0
 CLR_LOG2 = 0
 CLR_LOG_DEBUG = 0
+CLR_LOG_ERROR = 0
 CLR_LOG_CMDMESSAGE = 0
 CLR_METER_CUR = 0
 CLR_METER = 0
@@ -209,13 +210,13 @@ class LogMonitorThread(Thread):
 
                 with log_lock:
                     if ignore:
-                        mergedLog.append(self.logid + line.strip())
+                        mergedLog.append(self.logid + line.rstrip())
                     else:
                         if bSimple:
-                            print(line.strip())
+                            print(line.rstrip())
                         else:
-                            filteredLog.append(self.logid + line.strip())
-                            mergedLog.append(self.logid + line.strip())
+                            filteredLog.append(self.logid + line.rstrip())
+                            mergedLog.append(self.logid + line.rstrip())
                             if not auto_scroll:
                                 log_line_offset += 1
 
@@ -416,6 +417,7 @@ def init_screen():
     global CLR_LOG1
     global CLR_LOG2
     global CLR_LOG_DEBUG
+    global CLR_LOG_ERROR
     global CLR_LOG_CMDMESSAGE
     global CLR_METER_CUR
     global CLR_METER
@@ -440,6 +442,7 @@ def init_screen():
         CLR_LOG1 = curses.color_pair(3)
         CLR_LOG2 = curses.color_pair(6)
         CLR_LOG_DEBUG = curses.color_pair(4)
+        CLR_LOG_ERROR = curses.color_pair(2)
         CLR_LOG_CMDMESSAGE = curses.color_pair(2)
         CLR_METER_CUR = curses.color_pair(2)
         CLR_METER = curses.color_pair(4)
@@ -601,6 +604,8 @@ def do_draw_main(scr):
         if " - DEBUG - " in log:
             log = log.replace("Skills ", "")
             clr = CLR_LOG_DEBUG
+        elif " - ERROR - " in log:
+            clr = CLR_LOG_ERROR
         else:
             if logid == "1":
                 clr = CLR_LOG1

--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -142,8 +142,9 @@ def load_settings():
             max_log_lines = config["max_log_lines"]
         if "show_meter" in config:
             show_meter = config["show_meter"]
-    except Exception:
-        pass
+    except Exception as e:
+        LOG.info("Ignoring failed load of settings file")
+        LOG.exception(e)
 
 
 def save_settings():

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -50,7 +50,7 @@ class PadatiousService(FallbackSkill):
 
         self.container = IntentContainer(intent_cache)
 
-        self.bus = bus
+        self._bus = bus
         self.bus.on('padatious:register_intent', self.register_intent)
         self.bus.on('padatious:register_entity', self.register_entity)
         self.bus.on('detach_intent', self.handle_detach_intent)


### PR DESCRIPTION
It is fairly common for new skill authors to attempt actions in the __init__()
method which are not legal yet, as the Skill has not been fully connected to
the Mycroft system.  This adds an @property protection layer for the two most common
issues:
* Accessing MycroftSkill.bus
* Accessing MycroftSkill.enclosure

Now those are properties instead of variables and provide appropriate warnings
when used before they exist.

Also enhancing the handling of error logs in the CLI to highlight problems such
as this:
* Color "- ERROR -" log messages in red
* Retaining leading characters from log messages, improving readability in formatted messages

## How to test
Create a skill that uses the bus in the __init__(), e.g.:
```python
class PersonalSkill(MycroftSkill):

    def __init__(self):
        super().__init__(name="PersonalSkill")
        self.bus.emit("Don't do it!")   # access bus directly
        self.speak("Don't do i t!")     # access bus inside speak()
        self.enclosure.eyes_blink()     # access enclosure
```

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
