### PR TITLE
Fix Ctrl+C and Ctrl+X in CLI

### DIFF
--- a/mycroft/client/text/__main__.py
+++ b/mycroft/client/text/__main__.py
@@ -56,5 +56,5 @@ def main():
         curses.endwin()
         save_settings()
 
-
-main()
+if __name__ == "__main__":
+    main()

--- a/mycroft/client/text/__main__.py
+++ b/mycroft/client/text/__main__.py
@@ -56,5 +56,6 @@ def main():
         curses.endwin()
         save_settings()
 
+
 if __name__ == "__main__":
     main()

--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -1075,8 +1075,9 @@ def gui_main(stdscr):
                     # End the find session
                     find_str = None
                     rebuild_filtered_log()
+                    continue  # Consumed the Ctrl+C, get next character
                 else:
-                    break
+                    c = 24  # treat as Ctrl+X (Exit)
             except curses.error:
                 # This happens in odd cases, such as when you Ctrl+Z suspend
                 # the CLI and then resume.  Curses fails on get_wch().
@@ -1224,6 +1225,8 @@ def gui_main(stdscr):
                     # End the find session
                     find_str = None
                     rebuild_filtered_log()
+                else:
+                    break
             elif code > 31 and isinstance(c, str):
                 # Accept typed character in the utterance
                 line += c
@@ -1232,7 +1235,6 @@ def gui_main(stdscr):
         scr.erase()
         scr.refresh()
         scr = None
-        pass
 
 
 def simple_cli():


### PR DESCRIPTION
There were several quirks in the shutdown of the CLI client:
* Consumed Ctrl+C wasn't being handled cleanly
* main() got called twice, requiring two Ctrl+Cs to exit

## How to test
Start CLI.  Hit Ctrl+C.  Previously it took two Ctrl+Cs to exit

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
