### PR TITLE
Fix date format for today/tomorrow/yesterday

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1144,9 +1144,9 @@ class MycroftSkill(object):
 
             Args:
                 handler:               method to be called
-                when (datetime/int):   local datetime or number of seconds in
-                                       the future when the handler should be
-                                       called
+                when (datetime/int):   datetime (in system timezone) or number
+                                       of seconds in the future when the
+                                       handler should be called
                 data (dict, optional): data to send when the handler is called
                 name (str, optional):  reference name
                                        NOTE: This will not warn or replace a
@@ -1165,9 +1165,10 @@ class MycroftSkill(object):
 
             Args:
                 handler:                method to be called
-                when (datetime):        local time for first calling the
-                                        handler, or None to initially trigger
-                                        <frequency> seconds from now
+                when (datetime):        time (in system timezone) for first
+                                        calling the handler, or None to
+                                        initially trigger <frequency> seconds
+                                        from now
                 frequency (float/int):  time in seconds between calls
                 data (dict, optional):  data to send when the handler is called
                 name (str, optional):   reference name, must be unique

--- a/mycroft/util/format.py
+++ b/mycroft/util/format.py
@@ -148,7 +148,7 @@ class DateTimeFormat:
                 format_str = 'tomorrow'
             elif now.date() == dt.date():
                 format_str = 'today'
-            elif yesterday.date() = dt.date():
+            elif yesterday.date() == dt.date():
                 format_str = 'yesterday'
 
         return self.lang_config[lang]['date_format'][format_str].format(

--- a/mycroft/util/format.py
+++ b/mycroft/util/format.py
@@ -142,11 +142,13 @@ class DateTimeFormat:
                 if dt.month == now.month and dt.day > now.day:
                     format_str = 'date_full_no_year_month'
 
-            if (now + datetime.timedelta(1)).day == dt.day:
+            tomorrow = now + datetime.timedelta(days=1)
+            yesterday = now - datetime.timedelta(days=1)
+            if tomorrow.date() == dt.date():
                 format_str = 'tomorrow'
-            if now.day == dt.day:
+            elif now.date() == dt.date():
                 format_str = 'today'
-            if (now - datetime.timedelta(1)).day == dt.day:
+            elif yesterday.date() = dt.date():
                 format_str = 'yesterday'
 
         return self.lang_config[lang]['date_format'][format_str].format(


### PR DESCRIPTION
The test for today/tomorrow/yesterday was only looking at the day,
not the month and year.  So on July 14, 2018 it would claim that
the date June 14 2018 and July 14 2020 are all "today".

## How to test
"Create an alarm for 30 days from now" would say the alarm was set for today.  Now
it should list the future date.

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
