### PR TITLE
Make the combo lock handle multiple users

### DIFF
--- a/mycroft/util/combo_lock.py
+++ b/mycroft/util/combo_lock.py
@@ -1,10 +1,22 @@
 from threading import Lock
 from fasteners.process_lock import InterProcessLock
+from os.path import exists
+from os import chmod
 
 
 class ComboLock():
-    """ A combined process and thread lock. """
+    """ A combined process and thread lock.
+
+    Arguments:
+        path (str): path to the lockfile for the lock
+    """
     def __init__(self, path):
+        # Create lock file if it doesn't exist and set permissions for
+        # all users to lock/unlock
+        if not exists(path):
+            f = open(path, 'w+')
+            f.close()
+            chmod(path, 0o777)
         self.plock = InterProcessLock(path)
         self.tlock = Lock()
 

--- a/mycroft/util/combo_lock.py
+++ b/mycroft/util/combo_lock.py
@@ -1,3 +1,17 @@
+# Copyright 2018 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 from threading import Lock
 from fasteners.process_lock import InterProcessLock
 from os.path import exists


### PR DESCRIPTION
## Description
On the Mark-1 the locking would fail since the first time the lock is
accessed the process is run under root (script checking the enclosure
version). This caused the locking to fail since the normal mycroft
processes got an access error (lock-file owned by root)

This change creates lock-files and sets the permissions to `0o777`
if the file doesn't exist so it's accessible for all users

## How to test
Install the change on a mark-1, reboot and verify that all the processes starts correctly.

## Contributor license agreement signed?
CLA [Yes]