### PR TITLE
Reorganizing to make button press more responsive (again)

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -17,6 +17,8 @@ from copy import copy
 import json
 import requests
 from requests import HTTPError, RequestException
+import os
+import time
 
 from mycroft.configuration import Configuration
 from mycroft.configuration.config import DEFAULT_CONFIG, SYSTEM_CONFIG, \
@@ -88,9 +90,12 @@ class Api(object):
             finally:
                 identity_lock.release()
         else:  # Someone is updating the identity wait for release
-            LOG.debug('Refresh is already in progress, waiting until done')
-            self.identity = IdentityManager.load()
-            LOG.debug('new credentials loaded')
+            with identity_lock:
+                LOG.debug('Refresh is already in progress, waiting until done')
+                time.sleep(1.2)
+                os.sync()
+                self.identity = IdentityManager.load(lock=False)
+                LOG.debug('new credentials loaded')
 
     def send(self, params, no_refresh=False):
         """ Send request to mycroft backend.

--- a/mycroft/identity/__init__.py
+++ b/mycroft/identity/__init__.py
@@ -42,8 +42,6 @@ class IdentityManager(object):
     @staticmethod
     def _load():
         LOG.debug('Loading identity')
-        time.sleep(1.2)
-        os.sync()
         try:
             with FileSystemAccess('identity').open('identity2.json', 'r') as f:
                 IdentityManager.__identity = DeviceIdentity(**json.load(f))


### PR DESCRIPTION
## Description
The delay while loading files have caused the Mark-1 Button to respond very slowly. This moves the sleep out of the loading section and is handled by the token refresh instead.


## Contributor license agreement signed?
CLA [Yes]