### PR TITLE
Workaround for get-pip issue

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -145,7 +145,7 @@ function install_venv() {
     # Force version of pip for reproducability, but there is nothing special
     # about this version.  Update whenever a new version is released and
     # verified functional.
-    curl https://bootstrap.pypa.io/get-pip.py | "${VIRTUALENV_ROOT}/bin/python" - 'pip==18.0.0'
+    curl https://bootstrap.pypa.io/3.3/get-pip.py | "${VIRTUALENV_ROOT}/bin/python" - 'pip==18.0.0'
 }
 
 install_deps


### PR DESCRIPTION
## Description
get-pip pushed an updated script yesterday causing selecting specific pip versions to fail. This fetches the last release (3.3) of get-pip instead of the latest.

## How to test
Make sure Travis can build the project or remove the `.venv` folder and run `dev_setup.sh ` and make sure pip is installed as expected.

## Contributor license agreement signed?
CLA [Yes]