### PR TITLE
Add module specific lang option to GoogleCloudStt

### DIFF
--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -93,6 +93,8 @@ class GoogleSTT(TokenSTT):
 class GoogleCloudSTT(GoogleJsonSTT):
     def __init__(self):
         super(GoogleCloudSTT, self).__init__()
+        # override language with module specific language selection
+        self.lang = self.config.get('lang') or self.lang
 
     def execute(self, audio, language=None):
         self.lang = language or self.lang


### PR DESCRIPTION
## Description
In the current state of translations it's useful to be able to change the language when using the GoogleCloudSTT, (for example changing dialect (en-IN instead of en-US for example). This allows the google cloud module to handle a language different from the global language config by setting the "lang" parameter under the "google_cloud" config entry:

```json
    "google_cloud": {
      "lang": "sv-SE",
      "credential": {
      
      }
    }
```

## How to test
Requires google cloud credentials. Set the language like above and see the stt try to give you swedish.

## Contributor license agreement signed?
CLA [Yes]