### PR TITLE
Add CommonPlaySkill, unifying search and control

### DIFF
--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -1,0 +1,173 @@
+# Copyright 2018 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum
+from abc import ABC, abstractmethod
+from mycroft import MycroftSkill
+from mycroft.skills.audioservice import AudioService
+from mycroft.messagebus.message import Message
+
+
+class CPSMatchLevel(Enum):
+        EXACT = 1
+        MULTI_KEY = 2
+        TITLE = 3
+        ARTIST = 4
+        CATEGORY = 5
+        GENERIC = 6
+
+
+class CommonPlaySkill(MycroftSkill, ABC):
+    def __init__(self, name=None, bus=None):
+        super().__init__(name, bus)
+        self.audioservice = None
+
+    def bind(self, bus):
+        if bus:
+            super().bind(bus)
+            self.audioservice = AudioService(self.bus)
+            self.add_event('play:query', self.__handle_play_query)
+            self.add_event('play:start', self.__handle_play_start)
+
+    def __handle_play_query(self, message):
+        search_phrase = message.data["phrase"]
+
+        # First, notify the requestor that we are attempting to handle
+        # (this extends a timeout while this skill looks for a match)
+        self.bus.emit(message.response({"phrase": search_phrase,
+                                        "skill_id": self.skill_id,
+                                        "searching": True}))
+
+        # Now invoke the CPS handler to let the skill perform its search
+        result = self.CPS__match_query_phrase(search_phrase)
+
+        if result:
+            match = result[0]
+            level = result[1]
+            callback = result[2] if len(result) > 2 else None
+            confidence = self.__calc_confidence(match, search_phrase, level)
+            self.bus.emit(message.response({"phrase": search_phrase,
+                                            "skill_id": self.skill_id,
+                                            "callback_data": callback,
+                                            "conf": confidence}))
+        else:
+            # Signal we are done (can't handle it)
+            self.bus.emit(message.response({"phrase": search_phrase,
+                                            "skill_id": self.skill_id,
+                                            "searching": False}))
+
+    def __calc_confidence(self, match, phrase, level):
+        # Assume the more of the words that get consumed, the better the match
+        consumed_pct = len(match.split()) / len(phrase.split())
+        if consumed_pct > 1.0:
+            consumed_pct = 1.0
+
+        if level == CPSMatchLevel.EXACT:
+            return 1.0
+        elif level == CPSMatchLevel.MULTI_KEY:
+            return 0.9 + (consumed_pct / 10)
+        elif level == CPSMatchLevel.TITLE:
+            return 0.8 + (consumed_pct / 10)
+        elif level == CPSMatchLevel.ARTIST:
+            return 0.7 + (consumed_pct / 10)
+        elif level == CPSMatchLevel.CATEGORY:
+            return 0.6 + (consumed_pct / 10)
+        elif level == CPSMatchLevel.GENERIC:
+            return 0.5 + (consumed_pct / 10)
+        else:
+            return 0.0  # should never happen
+
+    def __handle_play_start(self, message):
+        if message.data["skill_id"] != self.skill_id:
+            # Not for this skill!
+            return
+        phrase = message.data["phrase"]
+        data = message.data.get("callback_data")
+
+        # Stop any currently playing audio
+        if self.audioservice.is_playing:
+            self.audioservice.stop()
+        self.bus.emit(Message("mycroft.stop"))
+
+        # Save for play() later, e.g. if phrase includes service modifiers like
+        # "... on the chromecast"
+        self.play_service_string = phrase
+
+        # Invoke derived class to provide playback data
+        self.CPS__start(phrase, data)
+
+    def CPS__play(self, url):
+        """
+        Begin playback of media pointed to by 'url'
+
+        Args:
+            url (str): Audio to play
+        """
+        self.audioservice.play(url, self.play_service_string)
+
+    def stop(self):
+        if self.audioservice.is_playing:
+            self.audioservice.stop()
+            return True
+        else:
+            return False
+
+    ######################################################################
+    # Abstract methods
+    # All of the following must be implemented by a skill that wants to
+    # act as a CommonPlay Skill
+    @abstractmethod
+    def CPS__match_query_phrase(self, phrase):
+        """
+        Analyze phrase to see if it is a play-able phrase with this
+        skill.
+
+        Args:
+            phrase (str): User phrase uttered after "Play", e.g. "some music"
+
+        Returns:
+            (match, CPSMatchLevel[, callback_data]) or None: Tupple containing
+                 a string with the appropriate matching phrase, the PlayMatch
+                 type, and optionally data to return in the callback if the
+                 match is selected.
+        """
+        # Derived classes must implement this, e.g.
+        #
+        # if phrase in ["Zoosh"]:
+        #     return ("Zoosh", CPSMatchLevel.Generic, {"hint": "music"})
+        # or:
+        # zoosh_song = find_zoosh(phrase)
+        # if zoosh_song and "Zoosh" in phrase:
+        #     # "play Happy Birthday in Zoosh"
+        #     return ("Zoosh", CPSMatchLevel.MULTI_KEY, {"song": zoosh_song})
+        # elif zoosh_song:
+        #     # "play Happy Birthday"
+        #     return ("Zoosh", CPSMatchLevel.TITLE, {"song": zoosh_song})
+        # elif "Zoosh" in phrase
+        #     # "play Zoosh"
+        #     return ("Zoosh", CPSMatchLevel.GENERIC, {"cmd": "random"})
+        return None
+
+    @abstractmethod
+    def CPS__start(self, phrase, data):
+        """
+        Begin playing whatever is specified in 'phrase'
+
+        Args:
+            phrase (str): User phrase uttered after "Play", e.g. "some music"
+            data (dict): Callback data specified in match_query_phrase()
+        """
+        # Derived classes must implement this, e.g.
+        # self.play("http://zoosh.com/stream_music")
+        pass

--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -20,18 +20,19 @@ from mycroft.messagebus.message import Message
 
 
 class CPSMatchLevel(Enum):
-        EXACT = 1
-        MULTI_KEY = 2
-        TITLE = 3
-        ARTIST = 4
-        CATEGORY = 5
-        GENERIC = 6
+    EXACT = 1
+    MULTI_KEY = 2
+    TITLE = 3
+    ARTIST = 4
+    CATEGORY = 5
+    GENERIC = 6
 
 
 class CommonPlaySkill(MycroftSkill, ABC):
     def __init__(self, name=None, bus=None):
         super().__init__(name, bus)
         self.audioservice = None
+        self.play_service_string = None
 
     def bind(self, bus):
         if bus:


### PR DESCRIPTION
The CommonPlaySkill base class provides an easy base class for any
skill wishing to use the "Common Play" framework.  This allows multiple
skills to jointly handle requests such as "play Janet Joplin",
"play my Sled Zepplin playlist", "play NPS news" or "play Strump's
speech to the UN".  Previously the "wildcard" intents needed to handle
this were basically impossible -- only one skill got a shot at handling
the request.  Now several skills to search their service to see if they
have anything that can service the request.  The service with which
reports the highest confidence gets invoked.

The CommonPlaySkill makes it easy to implement this.  Simply derive a
skill from CommonPlaySkill (instead of MycroftSkill) and override
the two required methods CPS__match_query_phrase() and CPS__start().
The skill can then use self.CPS__play(url) to begin playback, or invoke
a unique player to interact with a custom service.

## How to test
Use with a CommonPlay Skill, such as Pandora or Spotify

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
