### PR TITLE
Bugfix/audioservice invalid utterance

### DIFF
--- a/mycroft/skills/audioservice.py
+++ b/mycroft/skills/audioservice.py
@@ -77,7 +77,7 @@ class AudioService(object):
         self.bus.emit(Message('mycroft.audio.service.queue',
                               data={'tracks': tracks}))
 
-    def play(self, tracks=None, utterance='', repeat=None):
+    def play(self, tracks=None, utterance=None, repeat=None):
         """ Start playback.
 
             Args:
@@ -90,6 +90,7 @@ class AudioService(object):
         """
         repeat = repeat or False
         tracks = tracks or []
+        utterance = utterance or ''
         if isinstance(tracks, (str, tuple)):
             tracks = [tracks]
         elif not isinstance(tracks, list):

--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -122,7 +122,8 @@ class CommonPlaySkill(MycroftSkill, ABC):
         """
         # Inject the user's utterance in case the audio backend wants to
         # interpret it.  E.g. "play some rock at full volume on the stereo"
-        kwargs['utterance'] = self.play_service_string
+        if 'utterance' not in kwargs:
+            kwargs['utterance'] = self.play_service_string
         self.audioservice.play(*args, **kwargs)
 
     def stop(self):


### PR DESCRIPTION
## Description
The CommonPlaybackSkill may send None as an utterance when invoking the audioservice.play() method. This fix makes sure that None is handled in a sane way.

Additionally the CPS_play method has been altered to not add an utterance if the skill tries to add one.

## How to test
Try invoking the NPR_news skill with "what's the news" and make sure it works.

## Contributor license agreement signed?
CLA [Yes]
