### PR TITLE
Update MycroftSkill api documentation

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,8 +3,8 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python2 -msphinx
-SPHINXPROJ    = Padatious
+SPHINXBUILD   = python -msphinx
+SPHINXPROJ    = mycroft-core
 SOURCEDIR     = .
 BUILDDIR      = _build
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,10 +1,10 @@
 # API documentation
 
-The scripts in this folder builds the api documentation for mycroft core.
+The scripts in this folder build the API documentation for `mycroft-core`.
 
 ##
 
-Activate the mycroft venv
+Activate the mycroft `venv`
 
 ```
 source ../venv-activate.sh

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,23 @@
+# API documentation
+
+The scripts in this folder builds the api documentation for mycroft core.
+
+##
+
+Activate the mycroft venv
+
+```
+source ../venv-activate.sh
+```
+
+Install the documentation requirements
+
+```
+pip install -r requirements
+```
+
+Create the documentation
+
+```
+make html
+```

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -43,7 +43,7 @@ with open(os.path.join(os.path.dirname(os.path.dirname(
                                flags=re.MULTILINE))
 
 # Dependencies with different module names
-autodoc_mock_imports += [
+autodoc_mock_imports = list(autodoc_mock_imports) + [
     'adapt',
     'alsaaudio',
     'dateutil',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,6 +22,16 @@ import sys
 import re
 import os
 
+import sphinx_rtd_theme
+from sphinx.ext.autodoc import (
+    ClassLevelDocumenter, InstanceAttributeDocumenter)
+
+
+def iad_add_directive_header(self, sig):
+    ClassLevelDocumenter.add_directive_header(self, sig)
+
+
+InstanceAttributeDocumenter.add_directive_header = iad_add_directive_header
 
 sys.path.insert(0, os.path.abspath('../'))
 
@@ -73,7 +83,6 @@ pygments_style = 'sphinx'
 
 todo_include_todos = False
 
-import sphinx_rtd_theme
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 html_theme_options = {

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,2 @@
-six
+sphinx>= 1.8.1
+sphinx_rtd_theme>=0.4.2

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -225,14 +225,18 @@ class MycroftSkill(object):
         self._bus = None
         self._enclosure = None
         self.bind(bus)
+        #: Mycroft global configuration. (dict)
         self.config_core = Configuration.get()
         self.config = self.config_core.get(self.name) or {}
         self.dialog_renderer = None
-        self.root_dir = None
+        self.root_dir = None  #: skill root directory
+
+        #: Filesystem access to skill specific folder.
+        #: See mycroft.filesystem for details.
         self.file_system = FileSystemAccess(join('skills', self.name))
         self.registered_intents = []
-        self.log = LOG.create_logger(self.name)
-        self.reload_skill = True  # allow reloading
+        self.log = LOG.create_logger(self.name)  #: Skill logger instance
+        self.reload_skill = True  #: allow reloading (default True)
         self.events = []
         self.scheduled_repeats = []
         self.skill_id = ''  # will be set from the path, so guaranteed unique


### PR DESCRIPTION
## Description
* Add some interesting MycroftSkill members to the api documentation
  * file_system
  * log
  * root_dir
  * reload_skill
- Update doc config to work with python3
- Add brief readme explaining how to build the docs locally

Should resolve #1522 

## How to test
Check the test branch on [readthedocs](https://mycroft-core.readthedocs.io/en/feature-mycroft-skill-member-docs/)

## Contributor license agreement signed?
CLA [Yes]