### PR TITLE
Skilltester extension for Common Playback Skill functions

### DIFF
--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -58,6 +58,10 @@ DEFAULT_EVALUAITON_TIMEOUT = 30
 Configuration.get()['test_env'] = True
 
 
+class SkillTestError(Exception):
+    pass
+
+
 # Easy way to show colors on terminals
 class clr:
     PINK = '\033[95m'
@@ -300,7 +304,7 @@ class SkillTest(object):
                                                                    '=' * 15))
                 print(loader.load_log.pop(self.skill))
 
-            raise Exception('Skill couldn\'t be loaded')
+            raise SkillTestError('Skill couldn\'t be loaded')
 
         print("")
         print(color.HEADER + "="*20 + " RUNNING TEST " + "="*20 + color.RESET)

--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -39,6 +39,7 @@ import re
 import ast
 from os.path import join, isdir, basename
 from pyee import EventEmitter
+from numbers import Number
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import create_skill_descriptor, load_skill, \
     MycroftSkill, FallbackSkill
@@ -564,6 +565,18 @@ class EvaluationRule(object):
 
         if rule[0] == 'equal':
             if self._get_field_value(rule[1], msg) != rule[2]:
+                return False
+
+        if rule[0] == 'lt':
+            if not isinstance(self._get_field_value(rule[1], msg), Number):
+                return False
+            if self._get_field_value(rule[1], msg) >= rule[2]:
+                return False
+
+        if rule[0] == 'gt':
+            if not isinstance(self._get_field_value(rule[1], msg), Number):
+                return False
+            if self._get_field_value(rule[1], msg) <= rule[2]:
                 return False
 
         if rule[0] == 'notEqual':


### PR DESCRIPTION
## Description
Add support for common playback skill messages.

CPS_query:

new test json possibilities
play_query: Emits a message that can be catched by CPS_match_query_phrase()
play_query_match: Structure with info of the expected match
  "phrase": matched phrase
  "confidence_threshold": The minimum confidence the phrase should result in

Example:
```json
{
  "play_query": "the news",
  "play_query_match": {
    "phrase": "the news",
    "confidence_threshold":  0.8
  }
}
```json

"play_start": Emits message that can be caught by CPS_start using sub-fields.
  "phrase": matched phrase
  "callback_data": dict with info for the function

Example:
```json
{
  "play_start": {
    "phrase": "the news",
    "callback_data": {
    }
  },
  "expected_data": {"__type__": "mycroft.audio.service.play"}
}
```
## How to test
Try the changes with the *feature/common_play_tests* branch of the npr-news-skill.

## Contributor license agreement signed?
CLA [Yes]