### PR TITLE
bugfix/utterance remainder, only replace complete words

### DIFF
--- a/mycroft/messagebus/message.py
+++ b/mycroft/messagebus/message.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import json
+import re
 from mycroft.util.parse import normalize
 
 
@@ -160,5 +161,6 @@ class Message(object):
         utt = normalize(self.data.get("utterance", ""))
         if utt and "__tags__" in self.data:
             for token in self.data["__tags__"]:
-                utt = utt.replace(token.get("key", ""), "")
+                # Substitute only whole words matching the token
+                utt = re.sub(r'\b' + token.get("key", "") + r"\b", "", utt)
         return normalize(utt)


### PR DESCRIPTION
## Description

“Turn the room light on in 30 seconds” will return a remainder of “Turn in 30 secds”

utterance remainder now is parsed word by word instead of just replacing the keywords in the string

[bug originally reported here](https://community.mycroft.ai/t/intent-builder-vocab-files-extracting-from-remainder-portion-of-utterance/5115)

## How to test

make an intent with following required keywords

state.voc -> on / off
action.voc -> turn / switch
object.voc -> light / bulb / plug

say “Turn the room light on in 30 seconds” 

check utterance remainder, notice "on" will no longer be wrongly replaced in "seconds"

## Contributor license agreement signed?
CLA [yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
