### PR TITLE
grammatical gender support

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -474,10 +474,10 @@ class MycroftSkill(object):
         """
         gender = self.config.get("grammatical_gender")
         if not gender:
-            tts_config = self.config["tts"]
+            tts_config = self.config.get("tts", {})
             gender = tts_config.get("gender")
             if not gender:
-                tts_module = tts_config["module"]
+                tts_module = tts_config.get("module", "mimic")
                 gender = tts_config.get(tts_module, {}).get("gender")
         return gender
 
@@ -1098,8 +1098,8 @@ class MycroftSkill(object):
         """
         data = data or {}
         if self.grammatical_gender is not None:
-            if resolve_resource_file(key + "." + self.grammatical_gender +
-                                     ".dialog"):
+            gender_file = key + "." + self.grammatical_gender + ".dialog"
+            if resolve_resource_file(gender_file):
                 key = key + "." + self.grammatical_gender
         self.speak(self.dialog_renderer.render(key, data),
                    expect_response, wait)

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -462,6 +462,25 @@ class MycroftSkill(object):
             line = on_fail_fn(response)
             self.speak(line, expect_response=True)
 
+    @property
+    def grammatical_gender(self):
+        """
+        mycroft's gender
+
+        if not configured extrapolate from TTS config
+
+        Returns:
+              string:  'male', 'female' or None
+        """
+        gender = self.config.get("grammatical_gender")
+        if not gender:
+            tts_config = self.config["tts"]
+            gender = tts_config.get("gender")
+            if not gender:
+                tts_module = tts_config["module"]
+                gender = tts_config.get(tts_module, {}).get("gender")
+        return gender
+
     def ask_yesno(self, prompt, data=None):
         """ Read prompt and wait for a yes/no answer
 
@@ -1078,6 +1097,10 @@ class MycroftSkill(object):
                                         is being spoken.
         """
         data = data or {}
+        if self.grammatical_gender is not None:
+            if resolve_resource_file(key + "." + self.grammatical_gender +
+                                     ".dialog"):
+                key = key + "." + self.grammatical_gender
         self.speak(self.dialog_renderer.render(key, data),
                    expect_response, wait)
 


### PR DESCRIPTION
## Description

adds a solution for first half of #1865 , mostly an idea up for discussion but usable already

in some languages the speaker gender matters when generating dialog, this PR adds a new property to the base skill class "grammatical_gender"

gender can be configured and does not necessarily need to match the voice, this means it is inclusive and also allows male sounding voices that identify as female or the other way around

if provided in config, the selected gender will be used, else it will be extrapolated from the TTS config if a gender parameter exists there

this PR assumes skills that want to account for gender will have a dialog structure like:

- file_name.dialog <- default, gender neutral
- file_name.gender.dialog <- if gender is configured and file exists use this one instead

## How to test

- in a skill check self.grammatical_gender
- create my_dialog.female.dialog, my_dialog.male.dialog, my_dialog.dialog
- check that different dialog files are used according to gender

responsive voice TTS has a gender parameter if you want to test TTS gender, for "global" gender change your config and add

`"grammatical_gender": "male"`

## Contributor license agreement signed?
CLA [yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
