### PR TITLE
fix converse

### DIFF
--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -227,7 +227,8 @@ class IntentService(object):
 
     def handle_converse_error(self, message):
         skill_id = message.data["skill_id"]
-        self.remove_active_skill(skill_id)
+        if message.data["error"] == "skill id does not exist":
+            self.remove_active_skill(skill_id)
         if skill_id == self.converse_skill_id:
             self.converse_result = False
             self.waiting_for_converse = False

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -223,6 +223,7 @@ class IntentService(object):
             t = time.time() - start_time
             time.sleep(0.1)
         self.waiting_for_converse = False
+        self.converse_skill_id = ""
         return self.converse_result
 
     def handle_converse_error(self, message):

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -174,6 +174,7 @@ class IntentService(object):
         self.bus.on('clear_context', self.handle_clear_context)
         # Converse method
         self.bus.on('skill.converse.response', self.handle_converse_response)
+        self.bus.on('skill.converse.error', self.handle_converse_error)
         self.bus.on('mycroft.speech.recognition.unknown', self.reset_converse)
         self.bus.on('mycroft.skills.loaded', self.update_skill_name_dict)
 
@@ -182,6 +183,9 @@ class IntentService(object):
         self.bus.on('active_skill_request', add_active_skill_handler)
         self.active_skills = []  # [skill_id , timestamp]
         self.converse_timeout = 5  # minutes to prune active_skills
+        self.waiting_for_converse = False
+        self.converse_result = False
+        self.converse_skill_id = ""
 
     def update_skill_name_dict(self, message):
         """
@@ -208,25 +212,31 @@ class IntentService(object):
             self.do_converse(None, skill[0], lang)
 
     def do_converse(self, utterances, skill_id, lang):
-        self.waiting = True
-        self.result = False
+        self.waiting_for_converse = True
+        self.converse_result = False
+        self.converse_skill_id = skill_id
         self.bus.emit(Message("skill.converse.request", {
             "skill_id": skill_id, "utterances": utterances, "lang": lang}))
         start_time = time.time()
         t = 0
-        while self.waiting and t < 5:
+        while self.waiting_for_converse and t < 5:
             t = time.time() - start_time
             time.sleep(0.1)
-        self.waiting = False
-        return self.result
+        self.waiting_for_converse = False
+        return self.converse_result
+
+    def handle_converse_error(self, message):
+        skill_id = message.data["skill_id"]
+        self.remove_active_skill(skill_id)
+        if skill_id == self.converse_skill_id:
+            self.converse_result = False
+            self.waiting_for_converse = False
 
     def handle_converse_response(self, message):
-        # id = message.data["skill_id"]
-        # no need to crosscheck id because waiting before new request is made
-        # no other skill will make this request is safe assumption
-        result = message.data["result"]
-        self.result = result
-        self.waiting = False
+        skill_id = message.data["skill_id"]
+        if skill_id == self.converse_skill_id:
+            self.converse_result = message.data.get("result", False)
+            self.waiting_for_converse = False
 
     def remove_active_skill(self, skill_id):
         for skill in self.active_skills:

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -534,8 +534,7 @@ class SkillManager(Thread):
 
         # loop trough skills list and call converse for skill with skill_id
         for skill in self.loaded_skills:
-            if (self.loaded_skills[skill]["instance"] and
-                    self.loaded_skills[skill]["id"] == skill_id):
+            if self.loaded_skills[skill]["id"] == skill_id:
                 try:
                     instance = self.loaded_skills[skill]["instance"]
                 except BaseException:

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -544,8 +544,6 @@ class SkillManager(Thread):
                                                  "error": "converse requested"
                                                           " but skill not "
                                                           "loaded"}))
-                    self.bus.emit(message.reply("skill.converse.response", {
-                        "skill_id": skill_id, "result": False}))
                     return
                 try:
                     result = instance.converse(utterances, lang)
@@ -557,12 +555,8 @@ class SkillManager(Thread):
                                                 {"skill_id": skill_id,
                                                  "error": "exception in "
                                                           "converse method"}))
-                    self.bus.emit(message.reply("skill.converse.response", {
-                        "skill_id": skill_id, "result": False}))
                     return
 
         self.bus.emit(message.reply("skill.converse.error",
                                     {"skill_id": skill_id,
                                      "error": "skill id does not exist"}))
-        self.bus.emit(message.reply("skill.converse.response",
-                                    {"skill_id": skill_id, "result": False}))

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -539,8 +539,13 @@ class SkillManager(Thread):
                     instance = self.loaded_skills[skill]["instance"]
                 except BaseException:
                     LOG.error("converse requested but skill not loaded")
+                    self.bus.emit(message.reply("skill.converse.error",
+                                                {"skill_id": skill_id,
+                                                 "error": "converse requested"
+                                                          " but skill not "
+                                                          "loaded"}))
                     self.bus.emit(message.reply("skill.converse.response", {
-                        "skill_id": 0, "result": False}))
+                        "skill_id": skill_id, "result": False}))
                     return
                 try:
                     result = instance.converse(utterances, lang)
@@ -548,7 +553,16 @@ class SkillManager(Thread):
                         "skill_id": skill_id, "result": result}))
                     return
                 except BaseException:
-                    LOG.exception(
-                        "Error in converse method for skill " + str(skill_id))
+                    self.bus.emit(message.reply("skill.converse.error",
+                                                {"skill_id": skill_id,
+                                                 "error": "exception in "
+                                                          "converse method"}))
+                    self.bus.emit(message.reply("skill.converse.response", {
+                        "skill_id": skill_id, "result": False}))
+                    return
+
+        self.bus.emit(message.reply("skill.converse.error",
+                                    {"skill_id": skill_id,
+                                     "error": "skill id does not exist"}))
         self.bus.emit(message.reply("skill.converse.response",
-                                    {"skill_id": 0, "result": False}))
+                                    {"skill_id": skill_id, "result": False}))

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -535,10 +535,8 @@ class SkillManager(Thread):
         # loop trough skills list and call converse for skill with skill_id
         for skill in self.loaded_skills:
             if self.loaded_skills[skill]["id"] == skill_id:
-                try:
-                    instance = self.loaded_skills[skill]["instance"]
-                except BaseException:
-                    LOG.error("converse requested but skill not loaded")
+                instance = self.loaded_skills[skill].get("instance")
+                if instance is None:
                     self.bus.emit(message.reply("skill.converse.error",
                                                 {"skill_id": skill_id,
                                                  "error": "converse requested"


### PR DESCRIPTION
## Description

during converse request if a skill failed to load a KeyError would happen silently, this would cause latency (5 seconds until converse timeout) and converse method general failure

to reproduce:
- create a bad skill (needs to be loaded first so its checked first in the converse loop)
- trigger hello world (to activate converse)
- trigger hello world again and check latency and lack of converse.response bus message

## How to test
check everything is working as supposed and that you can't replicate behaviour with PR merged

## Contributor license agreement signed?
CLA [ yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
