### PR TITLE
include skill_id in response

### DIFF
--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -254,8 +254,9 @@ class MockSkillsLoader(object):
             'intent_failure',
             FallbackSkill.make_intent_failure_handler(self.emitter))
 
-        def make_response(_):
-            data = dict(result=False)
+        def make_response(message):
+            skill_id = message.data.get('skill_id', '')
+            data = dict(result=False, skill_id=skill_id)
             self.emitter.emit(Message('skill.converse.response', data))
         self.emitter.on('skill.converse.request', make_response)
 


### PR DESCRIPTION
## Description
Changes in the intent_service makes it now require the skill_id field to exist in the response, this updates the skill testers dummy converse response to respond with the requested skill_id.

## How to test
Run `python -m test.integrationtests.skills.runner /opt/mycroft/skills/mycroft-joke` and check that the test passes.

## Contributor license agreement signed?
CLA [ Yes ]
