### PR TITLE
add changes to work with gui

### DIFF
--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -242,19 +242,38 @@ class GUIConnection(object):
         self.callback_disconnect(self.id)
 
     def set(self, namespace, name, value):
+        skillIdList = []
+        # hack to send active skills list before
+        if namespace in skillIdList:
+            print("skill already in skillIdList")
+        else:
+            skillIdList.append({'skill_id': str(namespace)})
+        sendlst = {"type": "mycroft.session.list.insert", 
+                    "namespace": "mycroft.system.active_skills",
+                    "position": 0,
+                    "data": skillIdList}
+        self.socket.send(sendlst)
+        # eoh
         if not namespace in self.datastore:
             self.datastore[namespace] = {}
         if self.datastore[namespace].get(name) != value:
             msg = { "type": "mycroft.session.set",
-                    "namespace": namespace,
+                    "namespace": str(namespace),
                     "data": { name: value}}
             self.socket.send(msg)
             self.datastore[namespace][name] = value
 
     def show(self, namespace, page):
+        # Hack to send gui urls in correct format, currently only sends single page of active skill
+        active_pages = []
+        if page in active_pages:
+            print("page already in active_pages")
+        else:
+            active_pages.append(page)
+        #eoh
         self.socket.send({"type": "mycroft.gui.show",
                           "namespace": namespace,
-                          "gui_url": page})
+                          "gui_urls": active_pages})
         self.current_namespace = namespace
         self.current_page = page
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -246,7 +246,7 @@ class SkillGUI(object):
         """
 
         self.page = name
-
+        self.skill.log.debug(name)
         # Communicate with the enclosure process
 
         # First sync any data...
@@ -256,10 +256,11 @@ class SkillGUI(object):
         # TODO: Minimize by tracking data that has already been synched?
 
         # Convert page to full reference
-        page = self.skill.find_resource(self.page)
+        # use find_qml_resource instead of find_resource as find_resource was failing and not looking into the correct path
+        page = self.skill.find_qml_resource(self.page)
         if page:
-            page_url = "file://" + page
-
+            page_url = "file://" + str(page)
+            print(page_url)
             # Then request display of the correct page
             self.skill.bus.emit(Message("gui.page.show",
                                         {"page": page_url,
@@ -727,11 +728,20 @@ class MycroftSkill(object):
         # New scheme:  search for res_name under the 'locale' folder
         root_path = join(self.root_dir, 'locale', self.lang)
         for path, _, files in os.walk(root_path):
+            self.skill.log.debug(files)
             if res_name in files:
                 return join(path, res_name)
 
         # Not found
         return None
+
+    def find_qml_resource(self, res_name):
+        ui_folder = self.root_dir + "/ui"
+        for path, dirs, files in os.walk(ui_folder):
+            if res_name in files:
+                return join(ui_folder + "/" + res_name)
+            else:
+                return None
 
     def translate_namedvalues(self, name, delim=None):
         """ Load translation dict containing names and values.


### PR DESCRIPTION
## Description: 
Changes made to feature/gui branch to work with mycroft-gui:
-- This shouldn't really be merged except for testing and needs way better implementation

#### In skills/core.py 
- find resource did not have the correct path to qml files required to be sent, temp fix was to create find_qml_resource to run os.walk on the correct path where the qml UI is expected to exist.
#### In client/enclosure/base.py:
- As per the protocol specs list of active skills is required to be sent before mycroft.session.set message call, the active skills list needs to implement correct position of active skills in the list and if existing avoid duplicates, refer to autotest in mycroft-gui https://github.com/MycroftAI/mycroft-gui/blob/master/autotests/servertest.cpp#L174
- gui_url was changed to gui_urls to provide a list of active pages in skill, required to be a list of pages even if there is just a single page. also most likely need to avoid adding duplicates of an existing page in the list