### PR TITLE
Handle failing refresh tokens

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -87,6 +87,12 @@ class Api(object):
                 })
                 IdentityManager.save(data, lock=False)
                 LOG.debug('Saved credentials')
+            except HTTPError as e:
+                if e.response.status_code == 401:
+                    LOG.error('Could not refresh token, invalid refresh code.')
+                else:
+                    raise
+
             finally:
                 identity_lock.release()
         else:  # Someone is updating the identity wait for release


### PR DESCRIPTION
## Description
Catch the HTTPError caused by the server returning a 401 status code when an expired refresh code is used to refresh the token.

## How to test
- Create an invalid identity.json such as
```json
{"uuid": "6ce818b1-b98c-4ae6-8efc-f48cde60bdbb", "expires_at": 1536967067.7580438, "refresh": "AMmc.lITOEZagOK.iupL4Pw5QuKPV4mPgDSsTwdeo4TOqdf0QZY6fNKeyo1PbcvsAXbHuAZmdXHDb5t3eegPk/", "access": "yr62HkPWcEvfDBCgdzPnRcS4EeIsZNJVHpRj.SR0eRcIhM.Q9t1z3Z8R51koy9MInWGIrsjHUuuK0N9As9zLn/"}
```

- Make sure the pairing is triggered correctly.

## Contributor license agreement signed?
CLA [ Yes ]
