### PR TITLE
Handle invalid json when loading log level

### DIFF
--- a/mycroft/util/log.py
+++ b/mycroft/util/log.py
@@ -65,8 +65,11 @@ class LOG:
         confs = [SYSTEM_CONFIG, USER_CONFIG]
         config = {}
         for conf in confs:
-            merge_dict(config,
-                       load_commented_json(conf) if isfile(conf) else {})
+            try:
+                merge_dict(config,
+                           load_commented_json(conf) if isfile(conf) else {})
+            except Exception as e:
+                print('couldn\'t load {}: {}'.format(conf, str(e)))
 
         cls.level = logging.getLevelName(config.get('log_level', 'DEBUG'))
         fmt = '%(asctime)s.%(msecs)03d - ' \


### PR DESCRIPTION
## Description
Just ignore invalid log files, if a config file contains errors all processess that use logs will fail.

This was reported by paul_panther on Mattermost with the traceback:

```
...
  File "/opt/venvs/mycroft-core/lib/python3.4/site-packages/mycroft/util/signal.py", line 22, in <module>
    from mycroft.util.log import LOG
  File "/opt/venvs/mycroft-core/lib/python3.4/site-packages/mycroft/util/log.py", line 116, in <module>
    LOG.init()
  File "/opt/venvs/mycroft-core/lib/python3.4/site-packages/mycroft/util/log.py", line 69, in init
    load_commented_json(conf) if isfile(conf) else {})
  File "/opt/venvs/mycroft-core/lib/python3.4/site-packages/mycroft/util/json_helper.py", line 55, in load_commented_json
    return json.loads(uncomment_json(contents))
  File "/usr/lib/python3.4/json/__init__.py", line 318, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.4/json/decoder.py", line 346, in decode
    raise ValueError(errmsg("Extra data", s, end, len(s)))
ValueError: Extra data: line 1 column 36 - line 1 column 128 (char 35 - 127)
```

## How to test
Add some bad json into your mycroft.conf and check that processes launch as expected

## Contributor license agreement signed?
CLA [ Yes ]
