### PR TITLE
Add python 3.7 python version to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: python
+dist: xenial
+
 before_install:
  - sudo apt-get update -qq
  - sudo apt-get install -qq mpg123 portaudio19-dev libglib2.0-dev swig bison libtool autoconf libglib2.0-dev libicu-dev libfann-dev realpath
+ - sudo apt-get install -y gcc-4.8 g++-4.8
+ - export CC="gcc-4.8"
 python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 # don't rebuild pocketsphinx for every build
 cache: pocketsphinx-python
 # command to install dependencies


### PR DESCRIPTION
## Description
- Switch to Xenial so python 3.7 is available
- Install and use gcc-4.8 to make the mimic build faster

## How to test
Check Travis result and make sure all python versions passes the tests.

## Contributor license agreement signed?
CLA [ Yes ]
