### PR TITLE
Stop hotword engines when reloading

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -61,6 +61,14 @@ class HotWordEngine(object):
     def update(self, chunk):
         pass
 
+    def stop(self):
+        """ Perform any actions needed to shut down the hot word engine.
+
+            This may include things such as unload loaded data or shutdown
+            external processess.
+        """
+        pass
+
 
 class PocketsphinxHotWord(HotWordEngine):
     def __init__(self, key_phrase="hey mycroft", config=None, lang="en-us"):
@@ -221,6 +229,10 @@ class PreciseHotword(HotWordEngine):
             self.has_found = False
             return True
         return False
+
+    def stop(self):
+        if self.runner:
+            self.runner.stop()
 
 
 class SnowboyHotWord(HotWordEngine):

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -344,6 +344,7 @@ class RecognizerLoop(EventEmitter):
             Reload configuration and restart consumer and producer
         """
         self.stop()
+        self.wakeword_recognizer.stop()
         # load config
         self._load_config()
         # restart


### PR DESCRIPTION
## Description
To shutdown precise on reload the following is added:
- Add overridable stop() method to HotwordEngine Class
- Add stop implementation to precise shutting down the runner
- Call wakeword_recognizer.stop() before reloading the listener configuration

Resolves #1564.

## How to test
- run `ps aux | grep precise` to list running processess
- do a configuration change on mycroft home
- wait a minute for the change to be applied
- run `ps aux | grep precise` again and check that the number of processess doesn't increase.

## Contributor license agreement signed?
CLA [ Yes ]
