### PR TITLE
Minor update to dialog

### DIFF
--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -48,8 +48,9 @@ class MustacheDialogRenderer(object):
         with open(filename, 'r') as f:
             for line in f:
                 template_text = line.strip()
-                # Skip all lines starting with '#'
-                if not template_text.startswith('#'):
+                # Skip all lines starting with '#' and all empty lines
+                if (not template_text.startswith('#') and
+                        template_text != ''):
                     if template_name not in self.templates:
                         self.templates[template_name] = []
 

--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -87,10 +87,10 @@ class MustacheDialogRenderer(object):
 
         template_functions = self.templates.get(template_name)
         if index is None:
-            index = random.randrange(len(template_functions))
+            line = random.choice(template_functions)
         else:
-            index %= len(template_functions)
-        line = template_functions[index]
+            line = template_functions[index % len(template_functions)]
+        # Replace {key} in line with matching values from context
         line = line.format(**context)
         return line
 

--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 #
 import random
-from io import open
-
 import os
 import re
 from pathlib import Path


### PR DESCRIPTION
## Description
- Skip empty lines
- Use `choice()` instead of `randrange()` when getting a random line from the dialog
- skip importing `open` from `io` since that's not needed for python3

## How to test
Run mycroft make sure dialogs load as expected

## Contributor license agreement signed?
CLA [ Yes ]
