### PR TITLE
bugfix/issue-1913 fixed bug with new flag

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -38,24 +38,24 @@
 # </endRant>
 ######################################################
 
-# exit on any error
-set -Ee
+
 
 cd $(dirname $0)
 TOP=$( pwd -L )
 
 function show_help() {
-    echo "dev_setup.sh: Mycroft development environment setup"
-    echo "Usage: dev_setup.sh [options]"
-    echo
-    echo "Options:"
-    echo "    -r, --allow-root  Allow to be run as root (e.g. sudo)"
-    echo "    -fm               Force mimic build"
-    echo "    -h, --help        Show this message"
-    echo
-    echo "This will prepare your environment for running the mycroft-core"
-    echo "services. Normally this should be run as a normal user,"
-    echo "not as root/sudo."
+    echo "dev_setup.sh: Mycroft development environment setup
+Usage: dev_setup.sh [options]
+
+Options:
+    -r, --allow-root  Allow to be run as root (e.g. sudo)
+    -fm               Force mimic build
+    -h, --help        Show this message
+    -n, --no-error    Do not exit on error (use this flag with caution, usually not necessary)
+
+This will prepare your environment for running the mycroft-core
+services. Normally this should be run as a normal user,
+not as root/sudo."
 }
 
 opt_forcemimicbuild=false
@@ -73,6 +73,10 @@ for var in "$@" ; do
 
     if [[ ${var} == "-fm" ]] ; then
         opt_forcemimicbuild=true
+    fi
+    fi [[ ${var} != "-n" ]] || [[ ${var} != "--no-error" ]] ; then
+    	# exit on any error
+	set -Ee
     fi
 done
 

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -37,7 +37,7 @@
 # (as much as possible).
 # </endRant>
 ######################################################
-
+#exit on any error
 set -Ee
 
 cd $(dirname $0)

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -38,7 +38,7 @@
 # </endRant>
 ######################################################
 
-
+set -Ee
 
 cd $(dirname $0)
 TOP=$( pwd -L )
@@ -74,9 +74,9 @@ for var in "$@" ; do
     if [[ ${var} == "-fm" ]] ; then
         opt_forcemimicbuild=true
     fi
-    fi [[ ${var} != "-n" ]] || [[ ${var} != "--no-error" ]] ; then
+    if [[ ${var} == "-n" ]] || [[ ${var} == "--no-error" ]] ; then
     	# exit on any error
-	set -Ee
+	set +Ee
     fi
 done
 


### PR DESCRIPTION
moved the `set -Ee` to run when a flag _IS NOT_ thrown on lines 77-80
Also improved print out in function show_help() to take a little less time and take up a little less space by using only one `echo` command, should work the exact same otherwise.

## Description
issue-1913, added flags so that `dev_setup.sh` will not exit on an error. Flags only take effect if explicitly called.

This flag is meant to be used it `apt` or some other package manager is throwing an error but otherwise is working perfectly fine.

## How to test
run `dev_setup.sh -n` and compare with normal usage of the file.

## Contributor license agreement signed?
Yes
