### PR TITLE
Store config in more human readable form

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -121,7 +121,7 @@ class LocalConf(dict):
         """
         path = path or self.path
         with open(path, 'w') as f:
-            json.dump(self, f)
+            json.dump(self, f, indent=2)
 
     def merge(self, conf):
         merge_dict(self, conf)


### PR DESCRIPTION
## Description
Adds 2 spaces of indentation making the config much more easily readable.

## How to test
1. Either manually store a configuration change or rename the `~/.mycroft/mycroft.conf` and it should be recreated by the version checker skill.
2. Check that the file uses indentation.

## Contributor license agreement signed?
CLA [ Yes ]
