### PR TITLE
Handle floats when checking year pronounciation

### DIFF
--- a/mycroft/util/lang/format_en.py
+++ b/mycroft/util/lang/format_en.py
@@ -224,7 +224,7 @@ def nice_number_en(number, speech, denominators):
 
 def pronounce_number_en(num, places=2, short_scale=True, scientific=False):
     """
-    Convert a number to it's spoken equivalent
+    Convert a number to its spoken equivalent
 
     For example, '5.2' would return 'five point two'
 

--- a/mycroft/util/lang/format_en.py
+++ b/mycroft/util/lang/format_en.py
@@ -271,7 +271,7 @@ def pronounce_number_en(num, places=2, short_scale=True, scientific=False):
         # deal with 4 digits
         # usually if it's a 4 digit num it should be said like a date
         # i.e. 1972 => nineteen seventy two
-        if len(str(num)) == 4:
+        if len(str(num)) == 4 and isinstance(num, int):
             _num = str(num)
             # deal with 1000, 2000, 2001, 2100, 3123, etc
             # is skipped as the rest of the


### PR DESCRIPTION
## Description
This fixes an invalid error message when a float between 10 and 99 with exactly 1 decimal is passed to `prounce_number`. For example `pronounce_number(10.0)`.

## How to test
Make sure `pronounce_number(10.0)` and similar works as expected. 

## Contributor license agreement signed?
CLA [ Yes ]
