### PR TITLE
Add option to skip mimic build in dev_setup.sh

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -50,6 +50,7 @@ Usage: dev_setup.sh [options]
 Options:
     -r, --allow-root  Allow to be run as root (e.g. sudo)
     -fm               Force mimic build
+    -sm               Skip mimic build
     -h, --help        Show this message
     -n, --no-error    Do not exit on error (use this flag with caution, usually not necessary)
 
@@ -60,6 +61,7 @@ not as root/sudo."
 
 opt_forcemimicbuild=false
 opt_allowroot=false
+opt_skipmimicbuild=false
 
 for var in "$@" ; do
     if [[ ${var} == "-h" ]] || [[ ${var} == "--help" ]] ; then
@@ -77,6 +79,9 @@ for var in "$@" ; do
     if [[ ${var} == "-n" ]] || [[ ${var} == "--no-error" ]] ; then
     	# exit on any error
 	set +Ee
+    fi
+    if [[ ${var} == "-sm" ]] ; then
+        opt_skipmimicbuild=true
     fi
 done
 
@@ -208,7 +213,11 @@ else
     fi
 
     if [ "$has_mimic" == "" ]; then
-        build_mimic="y"
+        if [[ ${opt_skipmimicbuild} == true ]] ; then
+            build_mimic="n"
+        else
+            build_mimic="y"
+        fi
     fi
 fi
 


### PR DESCRIPTION
Add a -sm "Skip mimic" option to dev_setup.sh which
will always prevent the download and compile of
the original Mimic.  By default, we still want to
do this all the time, but there are situations where
it is convenient to skip this time-consuming step.

## How to test
Run dev_setup.sh on a clean install and add the -sm flag.  E.g. ```./dev_setup.sh -sm```

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
