### PR TITLE
Add basic barge-in functionality

### DIFF
--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -29,6 +29,7 @@ from mycroft.util.log import LOG
 bus = None  # Mycroft messagebus connection
 lock = Lock()
 loop = None
+config = None
 
 
 def handle_record_begin():
@@ -115,15 +116,17 @@ def handle_audio_start(event):
     """
         Mute recognizer loop
     """
-    loop.mute()
+    if config.get("listener").get("mute_during_output"):
+        loop.mute()
 
 
 def handle_audio_end(event):
     """
-        Request unmute, if more sources has requested the mic to be muted
+        Request unmute, if more sources have requested the mic to be muted
         it will remain muted.
     """
-    loop.unmute()  # restore
+    if config.get("listener").get("mute_during_output"):
+        loop.unmute()  # restore
 
 
 def handle_stop(event):
@@ -142,10 +145,12 @@ def handle_open():
 def main():
     global bus
     global loop
+    global config
     reset_sigint_handler()
     PIDLock("voice")
     bus = WebsocketClient()  # Mycroft messagebus, see mycroft.messagebus
     Configuration.init(bus)
+    config = Configuration.get()
 
     # Register handlers on internal RecognizerLoop bus
     loop = RecognizerLoop()

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -308,7 +308,7 @@ class RecognizerLoop(EventEmitter):
 
     def force_unmute(self):
         """
-            Completely unmute mic dispite the number of calls to mute
+            Completely unmute mic regardless of the number of calls to mute
         """
         self.mute_calls = 0
         self.unmute()

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -157,6 +157,18 @@
       "disable": false,
       "url": "https://training.mycroft.ai/precise/upload"
     },
+
+    // Stop listing to the microphone during playback to prevent accidental triggering
+    // This is enabled by default, but instances with good microphone noise cancellation
+    // can disable this to listen all the time, allowing 'barge in' functionality.
+    "mute_during_output" : true,
+
+    // How much (if at all) to 'duck' the speaker output during listening.  A
+    // setting of 0.0 will not duck at all.  A 1.0 will completely mute output
+    // while in a listening state.  Values in between will lower the volume
+    // partially (this is optional behavior, depending on the enclosure).
+    "duck_while_listening" : 0.3,
+
     // In milliseconds
     "phoneme_duration": 120,
     "multiplier": 1.0,
@@ -292,7 +304,10 @@
     "extended_delay": 60
   },
   "VolumeSkill": {
+    // default_level can be 0 (off) to 10 (max)
     "default_level": 6,
+
+    // Volumes are 0-100
     "min_volume": 0,
     "max_volume": 100
   },


### PR DESCRIPTION
The ability to "barge-in" has been lacking from Mycroft Core.  The Mark 1
microphone was unable to support this due to physical limitations, but the
Mark II and other implementations with more advanced mic tech which can
hear over themselves are able to continuously listen.

To enable this while retaining backwards compatibility with simpler mic.py
systems, there are now two mycroft.conf values:

{
   "listener": {
        "mute_during_output" : true,
        "duck_while_listening" : 0.3
   }
}

The above values are defaults, and implementers will likely override them
using the /etc/mycroft/mycroft.conf file when appropriate.

The duck_while_listening setting is currently handled in Mycroft's
skill-volume.  The mute_during_output is handled within mycroft-core itself.

## How to test
Add ```"mute_during_ouptut" : false``` to /etc/mycroft/mycroft.conf.  System should allow listening even while speaking.  

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
