### PR TITLE
Improve setup and start-mycroft scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
+.dev_opts.json
 .idea
 *.pyc
 *.swp
 *~
 mimic
+skills
 pocketsphinx-python
 *.egg-info/
 build

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -189,6 +189,7 @@ fi" > ~/.profile_mycroft
 
     # Create a link to the 'skills' folder.
     sleep 0.5
+    echo
     echo "The standard location for Mycroft skills is under /opt/mycroft/skills."
     if [[ ! -d /opt/mycroft/skills ]] ; then
         echo "This script will create that folder for you.  This requires sudo"

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -179,8 +179,8 @@ Would you like this to be added to your PATH in the .profile?"
         echo "
 # WARNING: This file may be replaced in future, do not customize.
 # set path so it includes Mycroft utilities
-if [ -d \""${TOP}"/bin\" ] ; then
-    PATH=\"\$PATH:"${TOP}"/bin\"
+if [ -d \"${TOP}/bin\" ] ; then
+    PATH=\"\$PATH:${TOP}/bin\"
 fi" > ~/.profile_mycroft
         echo -e "Type ${CYAN}mycroft-help${RESET} to see available commands."
     else


### PR DESCRIPTION
Improved the dev_setup.sh in several ways:
* Add 'wizard' that walks new users through setup
  - Option to put the mycroft-core/bin folder in the path
  - Option to change to 'master' instead of 'dev' branch.  This is
    usually desirable for users who only run Mycroft, not developers.
  - Option to auto-update when running Mycroft
  - Add soft link <mycroft-core>/skills to the /opt/mycroft/skills
    directory

Improve the start-mycroft.sh script
* Unify some duplicated code under init-once() function
* Add support for "auto-update", which attempts a git pull at startup
* Add require-process() function which doesn't restart already
  running services
* Add require-process for messagebus and skills services when running
  the CLI
* Tweak the --help message

====  Documentation Notes ====
This significantly changes the setup and normal operation

## How to test
Run dev_setup.sh

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
