### PR TITLE
CLI: Use language set in mycroft configuration

### DIFF
--- a/mycroft/client/text/__main__.py
+++ b/mycroft/client/text/__main__.py
@@ -19,7 +19,7 @@ import curses
 from mycroft.util import get_ipc_directory
 from .text_client import (
         load_settings, save_settings, simple_cli, gui_main,
-        start_log_monitor, start_mic_monitor, connect_to_messagebus
+        start_log_monitor, start_mic_monitor, connect_to_mycroft
     )
 
 sys.stdout = io.StringIO()
@@ -47,7 +47,7 @@ def main():
     # Monitor IPC file containing microphone level info
     start_mic_monitor(os.path.join(get_ipc_directory(), "mic_level"))
 
-    connect_to_messagebus()
+    connect_to_mycroft()
     if '--simple' in sys.argv:
         sys.stdout = sys.__stdout__
         sys.stderr = sys.__stderr__

--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -31,6 +31,7 @@ from threading import Thread, Lock
 from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
+from mycroft.configuration import Configuration
 
 import locale
 # Curses uses LC_ALL to determine how to display chars set it to system
@@ -40,6 +41,7 @@ preferred_encoding = locale.getpreferredencoding()
 
 bSimple = False
 bus = None  # Mycroft messagebus connection
+config = {}  # Will be populated by the Mycroft configuration
 event_thread = None
 history = []
 chat = []   # chat history, oldest at the lowest index
@@ -125,6 +127,25 @@ def handleNonAscii(text):
 # Settings
 
 config_file = os.path.join(os.path.expanduser("~"), ".mycroft_cli.conf")
+
+
+def load_mycroft_config(bus):
+    """ Load the mycroft config and connect it to updates over the messagebus.
+    """
+    Configuration.init(bus)
+    return Configuration.get()
+
+
+def connect_to_mycroft():
+    """ Connect to the mycroft messagebus and load and register config
+        on the bus.
+
+        Sets the bus and config global variables
+    """
+    global bus
+    global config
+    bus = connect_to_messagebus()
+    config = load_mycroft_config(bus)
 
 
 def load_settings():
@@ -396,8 +417,12 @@ def handle_utterance(event):
     set_screen_dirty()
 
 
-def connect():
-    # Once the websocket has connected, just watch it for speak events
+def connect(bus):
+    """ Run the mycroft messagebus referenced by bus.
+
+        Arguments:
+            bus:    Mycroft messagebus instance
+    """
     bus.run_forever()
 
 
@@ -1128,6 +1153,7 @@ def gui_main(stdscr):
     global history
     global screen_lock
     global show_gui
+    global config
 
     scr = stdscr
     init_screen()
@@ -1258,7 +1284,7 @@ def gui_main(stdscr):
                     # Treat this as an utterance
                     bus.emit(Message("recognizer_loop:utterance",
                                      {'utterances': [line.strip()],
-                                      'lang': 'en-us'}))
+                                      'lang': config.get('lang', 'en-us')}))
                 hist_idx = -1
                 line = ""
             elif code == 16 or code == 545:  # Ctrl+P or Ctrl+Left (Previous)
@@ -1355,9 +1381,14 @@ def simple_cli():
 
 
 def connect_to_messagebus():
-    global bus
+    """ Connect to the mycroft messagebus and launch a thread handling the
+        connection.
+
+        Returns: WebsocketClient
+    """
     bus = WebsocketClient()  # Mycroft messagebus connection
 
-    event_thread = Thread(target=connect)
+    event_thread = Thread(target=connect, args=[bus])
     event_thread.setDaemon(True)
     event_thread.start()
+    return bus


### PR DESCRIPTION
## Description
Slight refactoring to accommodate for this in a nice way. Created
function connect_to_mycroft() handling fetching the config and
connecting to the mycroft messagebus since these are related and the
order is important to maintain for it to work.

Resolves #1917 

## How to test
Set language to a non-english and check that the `recognizer_loop:utterance` message data contains the correct lang code.

## Contributor license agreement signed?
CLA [ Yes ]
