### PR TITLE
Bugfix/mimic2 negative numbers

### DIFF
--- a/mycroft/tts/mimic2_tts.py
+++ b/mycroft/tts/mimic2_tts.py
@@ -257,7 +257,7 @@ class Mimic2(TTS):
             stf: normalized sentences to speak
         """
         try:
-            numbers = re.findall(r'\d+', sentence)
+            numbers = re.findall(r'-?\d+', sentence)
             normalized_num = [
                 (num, pronounce_number(int(num)))
                 for num in numbers

--- a/mycroft/util/lang/format_en.py
+++ b/mycroft/util/lang/format_en.py
@@ -242,9 +242,13 @@ def pronounce_number_en(num, places=2, short_scale=True, scientific=False):
         n, power = number.replace("+", "").split("E")
         power = int(power)
         if power != 0:
-            return pronounce_number_en(float(n), places, short_scale, False) \
-                   + " times ten to the power of " + \
-                   pronounce_number_en(power, places, short_scale, False)
+            # This handles negatives of powers separately from the normal
+            # handling since each call disables the scientific flag
+            return '{}{} times ten to the power of {}{}'.format(
+                'negative ' if float(n) < 0 else '',
+                pronounce_number_en(abs(float(n)), places, short_scale, False),
+                'negative ' if power < 0 else '',
+                pronounce_number_en(abs(power), places, short_scale, False))
     if short_scale:
         number_names = NUM_STRING_EN.copy()
         number_names.update(SHORT_SCALE_EN)
@@ -264,7 +268,7 @@ def pronounce_number_en(num, places=2, short_scale=True, scientific=False):
     # deal with negatives
     result = ""
     if num < 0:
-        result = "negative "
+        result = "negative " if scientific else "minus "
     num = abs(num)
 
     try:

--- a/test/unittests/util/test_format.py
+++ b/test/unittests/util/test_format.py
@@ -105,13 +105,13 @@ class TestPronounceNumber(unittest.TestCase):
         self.assertEqual(pronounce_number(33), "thirty three")
 
     def test_convert_negative_int(self):
-        self.assertEqual(pronounce_number(-1), "negative one")
-        self.assertEqual(pronounce_number(-10), "negative ten")
-        self.assertEqual(pronounce_number(-15), "negative fifteen")
-        self.assertEqual(pronounce_number(-20), "negative twenty")
-        self.assertEqual(pronounce_number(-27), "negative twenty seven")
-        self.assertEqual(pronounce_number(-30), "negative thirty")
-        self.assertEqual(pronounce_number(-33), "negative thirty three")
+        self.assertEqual(pronounce_number(-1), "minus one")
+        self.assertEqual(pronounce_number(-10), "minus ten")
+        self.assertEqual(pronounce_number(-15), "minus fifteen")
+        self.assertEqual(pronounce_number(-20), "minus twenty")
+        self.assertEqual(pronounce_number(-27), "minus twenty seven")
+        self.assertEqual(pronounce_number(-30), "minus thirty")
+        self.assertEqual(pronounce_number(-33), "minus thirty three")
 
     def test_convert_decimals(self):
         self.assertEqual(pronounce_number(1.234),
@@ -129,19 +129,19 @@ class TestPronounceNumber(unittest.TestCase):
         self.assertEqual(pronounce_number(21.234, places=5),
                          "twenty one point two three four")
         self.assertEqual(pronounce_number(-1.234),
-                         "negative one point two three")
+                         "minus one point two three")
         self.assertEqual(pronounce_number(-21.234),
-                         "negative twenty one point two three")
+                         "minus twenty one point two three")
         self.assertEqual(pronounce_number(-21.234, places=1),
-                         "negative twenty one point two")
+                         "minus twenty one point two")
         self.assertEqual(pronounce_number(-21.234, places=0),
-                         "negative twenty one")
+                         "minus twenty one")
         self.assertEqual(pronounce_number(-21.234, places=3),
-                         "negative twenty one point two three four")
+                         "minus twenty one point two three four")
         self.assertEqual(pronounce_number(-21.234, places=4),
-                         "negative twenty one point two three four")
+                         "minus twenty one point two three four")
         self.assertEqual(pronounce_number(-21.234, places=5),
-                         "negative twenty one point two three four")
+                         "minus twenty one point two three four")
 
     def test_convert_hundreds(self):
         self.assertEqual(pronounce_number(100), "one hundred")


### PR DESCRIPTION
## Description
Mimic2 filtered away negative signs when pronouncing numbers, this updates the regex.

In addition the pronounce_number function was modified to use the format "minus XXX" instead of "negative XXX" after discussion on the chat (The reasoning being that in normal speech it's more common). If this isn't desired just cherry-pick the first commit handling the issue in the mimic2-tts class.

This resolves #1926.

## How to test
Make sure American Male is used and use the speak skill to speak something like "-123"

## Contributor license agreement signed?
CLA [ Yes ]
