### PR TITLE
dev_setup: Exit if pip installation fails.

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -287,6 +287,8 @@ function install_venv() {
     # about this version.  Update whenever a new version is released and
     # verified functional.
     curl https://bootstrap.pypa.io/3.3/get-pip.py | "${VIRTUALENV_ROOT}/bin/python" - 'pip==18.0.0'
+    # Function status depending on if pip exists
+    [ -x "${VIRTUALENV_ROOT}/bin/pip" ]
 }
 
 install_deps
@@ -323,7 +325,10 @@ else
 fi
 
 if [ ! -x "${VIRTUALENV_ROOT}/bin/activate" ] ; then
-    install_venv
+    if ! install_venv ; then
+        echo "Failed to set up virtualenv for mycroft, exiting setup."
+        exit 1
+    fi
 fi
 
 # Start the virtual environment


### PR DESCRIPTION
## Description
Running the get-pip-script will return a status Ok even if the command fails due to network error causing an install without pip. The system pip will then be used to install packages resulting in a faulty venv.

This adds a simple check that pip exists in the virtualenv after the setup and if not fails the build. This could be a possible cause for #1929 

## How to test
 
## Contributor license agreement signed?
CLA [ Yes ]
