### PR TITLE
Use builtin cd for venv-activate.sh

### DIFF
--- a/venv-activate.sh
+++ b/venv-activate.sh
@@ -55,7 +55,7 @@ function main() {
         # Prevent running in script then exiting immediately
         echo "ERROR: Invoke with 'source venv-activate.sh' or '. venv-activate.sh'"
     else
-        local SRC_DIR="$( cd "$( dirname "${BASH_SOURCE}" )" ; pwd -P )"
+        local SRC_DIR="$( builtin cd "$( dirname "${BASH_SOURCE}" )" ; pwd -P )"
         source ${SRC_DIR}/.venv/bin/activate
         
         # Provide an easier to find "mycroft-" prefixed command.


### PR DESCRIPTION
`builtin cd` is safer, as simple `cd` may fail when cd is aliased to something
that outputs to stdout in the local environment.

When doing some local testing and debugging I ran into an issues running venv-activate.sh since I have 'cd' aliased to pushd.