### PR TITLE
Upgrade pyyaml to address CVE-2017-18342

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ SpeechRecognition==3.8.1
 tornado==4.5.3
 websocket-client==0.32.0
 requests-futures==0.9.5
-pyyaml==3.13
+pyyaml==4.2b1
 pyalsaaudio==0.8.2
 xmlrunner==1.7.7
 pyserial==3.0


### PR DESCRIPTION
CVE-2017-18342 
https://nvd.nist.gov/vuln/detail/CVE-2017-18342
high severity
Vulnerable versions: < 4.2b1
Patched version: 4.2b1
In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In other words, yaml.safe_load is not used.

