### PR TITLE
Remove pyyaml as a dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ SpeechRecognition==3.8.1
 tornado==4.5.3
 websocket-client==0.32.0
 requests-futures==0.9.5
-pyyaml==3.13
 pyalsaaudio==0.8.2
 xmlrunner==1.7.7
 pyserial==3.0


### PR DESCRIPTION
==== Fixed Issues ====
CVE-2017-18342
https://nvd.nist.gov/vuln/detail/CVE-2017-18342
high severity
Vulnerable versions: < 4.2b1
Patched version: 4.2b1
In PyYAML before 4.1, the yaml.load() API could execute arbitrary code.
In other words, yaml.safe_load is not used.

====  Tech Notes ====
Full build done from `dev` branch after removing `pyyaml` as a dep. All OK. 
![screenshot from 2019-01-08 02-49-41](https://user-images.githubusercontent.com/114158/50777912-e3836180-12f0-11e9-8f92-164e4b4f99a4.png)


====  Documentation Notes ====
NONE - description of a new feature or notes on behavior changes

==== Localization Notes ====
NONE - point to new strings, language specific functions, etc.

==== Environment Notes ====
NONE - new package requirements, new files being written to disk, etc.

==== Protocol Notes ====
NONE - message types added or changed, new signals, APIs, etc.

## Description
(Description of what the PR does, such as fixes # {issue number})

## How to test
(Description of how to validate or test this PR)

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
