### PR TITLE
Tweaks to start/stop scripts

### DIFF
--- a/bin/mycroft-help
+++ b/bin/mycroft-help
@@ -25,6 +25,8 @@ echo "Mycroft-specific commands you can use from the Linux command prompt:"
 echo "  mycroft-cli-client       command line client, useful for debugging"
 echo "  mycroft-msm              Mycroft Skills Manager, to manage your Skills"
 echo "  mycroft-msk              Mycroft Skills Kit, create and share Skills"
+echo "  mycroft-start            Launch/restart Mycroft services"
+echo "  mycroft-stop             Stop Mycroft services"
 echo
 echo "Scripting Utilities:"
 echo "  mycroft-speak <phr>      have Mycroft speak a phrase to the user"

--- a/bin/mycroft-start
+++ b/bin/mycroft-start
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SOURCE="${BASH_SOURCE[0]}"
+cd -P "$( dirname "$SOURCE" )"/..
+DIR="$( pwd )"
+
+. "$DIR/start-mycroft.sh" $@

--- a/bin/mycroft-stop
+++ b/bin/mycroft-stop
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SOURCE="${BASH_SOURCE[0]}"
+cd -P "$( dirname "$SOURCE" )"/..
+DIR="$( pwd )"
+
+. "$DIR/stop-mycroft.sh" $@

--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -24,13 +24,11 @@ VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${DIR}/.venv"}
 
 function help() {
     echo "${script}:  Mycroft command/service launcher"
-    echo "usage: ${script} [command] [params]"
+    echo "usage: ${script} [COMMAND] [restart] [params]"
     echo
-    echo "Services:"
+    echo "Services COMMANDs:"
     echo "  all                      runs core services: bus, audio, skills, voice"
     echo "  debug                    runs core services, then starts the CLI"
-    echo
-    echo "Services:"
     echo "  audio                    the audio playback service"
     echo "  bus                      the messagebus service"
     echo "  skills                   the skill service"
@@ -38,18 +36,22 @@ function help() {
     # echo "  wifi                     wifi setup service"
     echo "  enclosure                mark_1 enclosure service"
     echo
-    echo "Tools:"
+    echo "Tool COMMANDs:"
     echo "  cli                      the Command Line Interface"
     echo "  unittest                 run mycroft-core unit tests (requires pytest)"
     echo "  skillstest               run the skill autotests for all skills (requires pytest)"
     echo
-    echo "Utils:"
+    echo "Util COMMANDs:"
     echo "  audiotest                attempt simple audio validation"
     echo "  audioaccuracytest        more complex audio validation"
     echo "  sdkdoc                   generate sdk documentation"
     echo
+    echo "Options:"
+    echo "  restart                  (optional) Force the service to restart if running"
+    echo
     echo "Examples:"
     echo "  ${script} all"
+    echo "  ${script} all restart"
     echo "  ${script} cli"
     echo "  ${script} unittest"
 
@@ -102,6 +104,7 @@ function launch-process() {
 }
 
 function require-process() {
+    # Launch process if not found
     name-to-script-path ${1}
     if ! pgrep -f "python3 -m ${_module}" > /dev/null ; then
         # Start required process
@@ -115,8 +118,13 @@ function launch-background() {
     # Check if given module is running and start (or restart if running)
     name-to-script-path ${1}
     if pgrep -f "python3 -m ${_module}" > /dev/null ; then
-        echo "Restarting: ${1}"
-        "${DIR}/stop-mycroft.sh" ${1}
+        if ($_force_restart) ; then
+            echo "Restarting: ${1}"
+            "${DIR}/stop-mycroft.sh" ${1}
+        else
+            # Already running, no need to restart
+            return
+        fi
     else
         echo "Starting background service $1"
     fi
@@ -138,15 +146,7 @@ function launch-all() {
     launch-background skills
     launch-background audio
     launch-background voice
-
-    # Determine platform type
-    if [[ -r /etc/mycroft/mycroft.conf ]] ; then
-        mycroft_platform=$( jq -r ".enclosure.platform" < /etc/mycroft/mycroft.conf )
-        if [[ $mycroft_platform = "mycroft_mark_1" ]] ; then
-            # running on a Mark 1, start enclosure service
-            launch-background enclosure
-        fi
-    fi
+    launch-background enclosure
 }
 
 function check-dependencies() {
@@ -177,7 +177,16 @@ function check-dependencies() {
 }
 
 _opt=$1
+_force_restart=false
 shift
+if [[ "${1}" == "restart" ]] || [[ "${_opt}" == "restart" ]] ; then
+    _force_restart=true
+    if [[ "${_opt}" == "restart" ]] ; then
+        # Support "start-mycroft.sh restart all" as well as "start-mycroft.sh all restart"
+        _opt=$1
+    fi
+    shift
+fi
 _params=$@
 
 check-dependencies


### PR DESCRIPTION
Several minor changes:
* Add mycroft-start and mycroft-stop, which can be used as commands anywhere
  if the user has added this to the PATH.  They are shortcuts to the
  start-mycroft.sh and stop-mycroft.sh scripts.
* Add to the mycroft-help command reference
* Add "reset" parameter for start-mycroft.sh, which forces a service restart.
  If a service is currently running, it will not restart by default anymore.
* Make the 'enclosure' service part of 'all' regardless of platform.  This
  makes sense not that it can handle a remote GUI connection.
* BUG: mycroft-stop would sometimes show odd messages if the skill process
  had active child processes.
