### PR TITLE
Support selecting microphone by name

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -158,6 +158,12 @@
       "url": "https://training.mycroft.ai/precise/upload"
     },
 
+    // Override as SYSTEM or USER to select a specific microphone input instead of
+    // the PortAudio default input.
+    //   "device_name": "somename",  // can be regex pattern or substring
+    //       or
+    //   "device_index": 12,
+
     // Stop listing to the microphone during playback to prevent accidental triggering
     // This is enabled by default, but instances with good microphone noise cancellation
     // can disable this to listen all the time, allowing 'barge in' functionality.

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -16,6 +16,8 @@ from __future__ import absolute_import
 import re
 import socket
 import subprocess
+import pyaudio
+
 from os.path import join, expanduser
 
 from threading import Thread
@@ -159,6 +161,27 @@ def record(file_path, duration, rate, channels):
     else:
         return subprocess.Popen(
             ["arecord", "-r", str(rate), "-c", str(channels), file_path])
+
+
+def find_input_device(device_name):
+    """ Find audio input device by name.
+
+        Arguments:
+            device_name: device name or regex pattern to match
+
+        Returns: device_index (int) or None if device wasn't found
+    """
+    LOG.info('Searching for input device: {}'.format(device_name))
+    LOG.debug('Devices: ')
+    pa = pyaudio.PyAudio()
+    pattern = re.compile(device_name)
+    for device_index in range(pa.get_device_count()):
+        dev = pa.get_device_info_by_index(device_index)
+        LOG.debug('   {}'.format(dev['name']))
+        if dev['maxInputChannels'] > 0 and pattern.match(dev['name']):
+            LOG.debug('    ^-- matched')
+            return device_index
+    return None
 
 
 def get_http(uri):


### PR DESCRIPTION
Normally Mycroft will use the default PortAudio input device as the
microphone input for the user.  However in some cases there is reason
to specify a different input.

The "device_index" under the "listener" section in mycroft.conf has
always allowed a user to select the microphone explicitly.  But on
some systems the indices can change from reboot to reboot.  So this
adds the "device_name" setting.  If it exists (and the "device_index"
has not been specified explicitly), a regex match will be run against
the PortAudio device names.

When "device_name" is used, the voice.log will contain a listing of
the devices as they are tested.  This can be used to debug if a
name isn't matching as expected.

EXAMPLES:
/etc/mycroft/mycroft.conf
```json
{
    "listener": {
        "device_name": "aawsrc"
    }
}
```
Would find a match against "aawsrc" or "aawsrcplug".  To force a specific
match, you can use a regex such as "aawsrc$".

/etc/mycroft/mycroft.conf
```json
{
    "listener": {
        "device_index": 2
    }
}
```
The PortAudio device index specified will be used.

Names and indexes for PortAudio are difficult to guess.  Under Linux they are based on the ALSA asound.conf entry names, but might be different in other OSes.  The simplest way to
view them is either enter a value for "device_name" and look at the names
which appear in the log when starting Mycroft, or to run a simple program
such as:
```python
import pyaudio

pa = pyaudio.PyAudio()
for i in range(pa.get_device_count()):
    dev = pa.get_device_info_by_index(i)
    print((i, dev['name'], dev['maxInputChannels']))
```
