### PR TITLE
Remove inheritance from object

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -39,8 +39,8 @@ class InternetDown(RequestException):
     pass
 
 
-class Api(object):
-    """ Generic object to wrap web APIs """
+class Api:
+    """ Generic class to wrap web APIs """
     params_to_etag = {}
     etag_to_response = {}
 

--- a/mycroft/audio-accuracy-test/audio_accuracy_test.py
+++ b/mycroft/audio-accuracy-test/audio_accuracy_test.py
@@ -29,7 +29,7 @@ def to_percent(val):
     return "{0:.2f}".format(100.0 * val) + "%"
 
 
-class FileStream(object):
+class FileStream:
     MIN_S_TO_DEBUG = 5.0
 
     # How long between printing debug info to screen
@@ -81,7 +81,7 @@ class FileMockMicrophone(AudioSource):
         self.stream.close()
 
 
-class AudioTester(object):
+class AudioTester:
     def __init__(self, samp_rate):
         print()  # Pad debug messages
         self.ww_recognizer = RecognizerLoop().create_mycroft_recognizer(

--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -125,7 +125,7 @@ def load_services(config, bus, path=None):
     return service
 
 
-class AudioService(object):
+class AudioService:
     """ Audio Service class.
         Handles playback of audio and selecting proper backend for the uri
         to be played.

--- a/mycroft/audio/services/__init__.py
+++ b/mycroft/audio/services/__init__.py
@@ -15,7 +15,7 @@
 from abc import ABCMeta, abstractmethod
 
 
-class AudioBackend():
+class AudioBackend:
     """
         Base class for all audio backend implementations.
 

--- a/mycroft/audio/services/mopidy/mopidypost.py
+++ b/mycroft/audio/services/mopidy/mopidypost.py
@@ -23,7 +23,7 @@ MOPIDY_API = '/mopidy/rpc'
 _base_dict = {'jsonrpc': '2.0', 'id': 1, 'params': {}}
 
 
-class Mopidy(object):
+class Mopidy:
     def __init__(self, url):
         self.is_playing = False
         self.url = url + MOPIDY_API

--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -34,7 +34,7 @@ def DEBUG(str):
     # pass  # disable by default
 
 
-class Enclosure():
+class Enclosure:
 
     def __init__(self):
         # Establish Enclosure's websocket connection to the messagebus
@@ -189,7 +189,7 @@ gui_app_settings = {
 }
 
 
-class GUIConnection():
+class GUIConnection:
     """ A single GUIConnection exists per graphic interface.  This object
     maintains the socket used for communication and keeps the state of the
     Mycroft data in sync with the GUIs data.

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -43,7 +43,7 @@ class NoModelAvailable(Exception):
     pass
 
 
-class HotWordEngine(object):
+class HotWordEngine:
     def __init__(self, key_phrase="hey mycroft", config=None, lang="en-us"):
         self.key_phrase = str(key_phrase).lower()
         # rough estimate 1 phoneme per 2 chars
@@ -261,7 +261,7 @@ class SnowboyHotWord(HotWordEngine):
         return wake_word == 1
 
 
-class HotWordFactory(object):
+class HotWordFactory:
     CLASSES = {
         "pocketsphinx": PocketsphinxHotWord,
         "precise": PreciseHotword,

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -199,7 +199,7 @@ class AudioConsumer(Thread):
         self.emitter.emit("speak", payload)
 
 
-class RecognizerLoopState(object):
+class RecognizerLoopState:
     def __init__(self):
         self.running = False
         self.sleeping = False

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -43,7 +43,7 @@ from mycroft.util import (
 from mycroft.util.log import LOG
 
 
-class MutableStream(object):
+class MutableStream:
     def __init__(self, wrapped_stream, format, muted=False):
         assert wrapped_stream is not None
         self.wrapped_stream = wrapped_stream

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -174,7 +174,7 @@ class RemoteConf(LocalConf):
             self.load_local(cache)
 
 
-class Configuration(object):
+class Configuration:
     __config = {}  # Cached config
     __patch = {}  # Patch config that skills can update to override config
 

--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -27,7 +27,7 @@ __doc__ = """
 """
 
 
-class MustacheDialogRenderer(object):
+class MustacheDialogRenderer:
     """
     A dialog template renderer based on the mustache templating language.
     """
@@ -93,7 +93,7 @@ class MustacheDialogRenderer(object):
         return line
 
 
-class DialogLoader(object):
+class DialogLoader:
     """
     Loads a collection of dialog files into a renderer implementation.
     """

--- a/mycroft/enclosure/display_manager.py
+++ b/mycroft/enclosure/display_manager.py
@@ -113,7 +113,7 @@ def _read_data():
     return data
 
 
-class DisplayManager():
+class DisplayManager:
     """ The Display manager handles the basic state of the display,
     be it a mark-1 or a mark-2 or even a future Mark-3.
     """

--- a/mycroft/filesystem/__init__.py
+++ b/mycroft/filesystem/__init__.py
@@ -16,7 +16,7 @@ import os
 from os.path import join, expanduser, isdir
 
 
-class FileSystemAccess(object):
+class FileSystemAccess:
     """
     A class for providing access to the mycroft FS sandbox. Intended to be
     attached to skills at initialization time to provide a skill-specific

--- a/mycroft/identity/__init__.py
+++ b/mycroft/identity/__init__.py
@@ -22,7 +22,7 @@ from mycroft.util.combo_lock import ComboLock
 identity_lock = ComboLock('/tmp/identity-lock')
 
 
-class DeviceIdentity(object):
+class DeviceIdentity:
     def __init__(self, **kwargs):
         self.uuid = kwargs.get("uuid", "")
         self.access = kwargs.get("access", "")
@@ -36,7 +36,7 @@ class DeviceIdentity(object):
         return self.refresh != ""
 
 
-class IdentityManager(object):
+class IdentityManager:
     __identity = None
 
     @staticmethod

--- a/mycroft/lock/__init__.py
+++ b/mycroft/lock/__init__.py
@@ -24,7 +24,7 @@ import os  # Operating System functions
 from mycroft.util import LOG
 
 
-class Signal(object):  # python 3+ class Signal
+class Signal:  # python 3+ class Signal
 
     """
     Capture and replace a signal handler with a user supplied function.
@@ -87,7 +87,7 @@ class Signal(object):  # python 3+ class Signal
 #
 # Create, delete and manipulate a PID file for this service
 # ------------------------------------------------------------------------------
-class Lock(object):  # python 3+ 'class Lock'
+class Lock:  # python 3+ 'class Lock'
 
     """
     Create and maintains the PID lock file for this application process.

--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -28,7 +28,7 @@ from mycroft.util import validate_param, create_echo_function
 from mycroft.util.log import LOG
 
 
-class WebsocketClient(object):
+class WebsocketClient:
     def __init__(self, host=None, port=None, route=None, ssl=None):
 
         config = Configuration.get().get("websocket")

--- a/mycroft/messagebus/message.py
+++ b/mycroft/messagebus/message.py
@@ -17,7 +17,7 @@ import re
 from mycroft.util.parse import normalize
 
 
-class Message(object):
+class Message:
     """Holds and manipulates data sent over the websocket
 
         Message objects will be used to send information back and forth

--- a/mycroft/metrics/__init__.py
+++ b/mycroft/metrics/__init__.py
@@ -61,7 +61,7 @@ def report_timing(ident, system, timing, additional_data=None):
     report_metric('timing', report)
 
 
-class Stopwatch(object):
+class Stopwatch:
     """
         Simple time measuring class.
     """
@@ -110,7 +110,7 @@ class Stopwatch(object):
             return 'Not started'
 
 
-class MetricsAggregator(object):
+class MetricsAggregator:
     """
     MetricsAggregator is not threadsafe, and multiple clients writing the
     same metric "concurrently" may result in data loss.
@@ -167,7 +167,7 @@ class MetricsAggregator(object):
             threading.Thread(target=publish).start()
 
 
-class MetricsPublisher(object):
+class MetricsPublisher:
     def __init__(self, url=None, enabled=False):
         conf = Configuration().get()['server']
         self.url = url or conf['url']

--- a/mycroft/session/__init__.py
+++ b/mycroft/session/__init__.py
@@ -20,9 +20,9 @@ from mycroft.configuration import Configuration
 from mycroft.util.log import LOG
 
 
-class Session(object):
+class Session:
     """
-    An object representing a Mycroft Session Identifier
+    An class representing a Mycroft Session Identifier
     """
 
     def __init__(self, session_id, expiration_seconds=180):
@@ -50,10 +50,8 @@ class Session(object):
         return "{%s,%d}" % (str(self.session_id), self.touch_time)
 
 
-class SessionManager(object):
-    """
-    Keeps track of the current active session
-    """
+class SessionManager:
+    """ Keeps track of the current active session. """
     __current_session = None
     __lock = Lock()
 

--- a/mycroft/skills/audioservice.py
+++ b/mycroft/skills/audioservice.py
@@ -42,9 +42,9 @@ def ensure_uri(s):
         raise ValueError('Invalid track')
 
 
-class AudioService(object):
+class AudioService:
     """
-        AudioService object for interacting with the audio subsystem
+        AudioService class for interacting with the audio subsystem
 
         Arguments:
             bus: Mycroft messagebus connection

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -207,11 +207,11 @@ def intent_file_handler(intent_file):
     return real_decorator
 
 
-class SkillGUI(object):
+class SkillGUI:
     """
     SkillGUI - Interface to the Graphical User Interface
 
-    Values set in this object are synced to the GUI, accessible within QML
+    Values set in this class are synced to the GUI, accessible within QML
     via the built-in sessionData mechanism.  For example, in Python you can
     write in a skill:
         self.gui['temp'] = 33
@@ -342,7 +342,7 @@ class SkillGUI(object):
 #######################################################################
 # MycroftSkill base class
 #######################################################################
-class MycroftSkill(object):
+class MycroftSkill:
     """
     Abstract base class which provides common behaviour and parameters to all
     Skills implementation.

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -45,7 +45,7 @@ def workaround_one_of_context(best_intent):
     return best_intent
 
 
-class ContextManager(object):
+class ContextManager:
     """
     ContextManager
     Use to track context throughout the course of a conversational session.
@@ -149,7 +149,7 @@ class ContextManager(object):
         return result
 
 
-class IntentService(object):
+class IntentService:
     def __init__(self, bus):
         self.config = Configuration.get().get('context', {})
         self.engine = IntentDeterminationEngine()

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -23,7 +23,7 @@ from mycroft.configuration import Configuration
 from mycroft.util.log import LOG
 
 
-class STT(object):
+class STT:
     __metaclass__ = ABCMeta
 
     def __init__(self):
@@ -222,7 +222,7 @@ class GoVivaceSTT(TokenSTT):
         return response.json()["result"]["hypotheses"][0]["transcript"]
 
 
-class STTFactory(object):
+class STTFactory:
     CLASSES = {
         "mycroft": MycroftSTT,
         "google": GoogleSTT,

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -154,7 +154,7 @@ class PlaybackThread(Thread):
         self.clear_queue()
 
 
-class TTS(object):
+class TTS:
     """
     TTS abstract class to be implemented by all TTS engines.
 
@@ -384,7 +384,7 @@ class TTS(object):
         self.playback.join()
 
 
-class TTSValidator(object):
+class TTSValidator:
     """
     TTS Validator abstract class to be implemented by all TTS engines.
 
@@ -433,7 +433,7 @@ class TTSValidator(object):
         pass
 
 
-class TTSFactory(object):
+class TTSFactory:
     from mycroft.tts.espeak_tts import ESpeak
     from mycroft.tts.fa_tts import FATTS
     from mycroft.tts.google_tts import GoogleTTS

--- a/mycroft/util/combo_lock.py
+++ b/mycroft/util/combo_lock.py
@@ -18,7 +18,7 @@ from os.path import exists
 from os import chmod
 
 
-class ComboLock():
+class ComboLock:
     """ A combined process and thread lock.
 
     Arguments:

--- a/mycroft/version/__init__.py
+++ b/mycroft/version/__init__.py
@@ -34,7 +34,7 @@ CORE_VERSION_TUPLE = (CORE_VERSION_MAJOR,
 CORE_VERSION_STR = '.'.join(map(str, CORE_VERSION_TUPLE))
 
 
-class VersionManager(object):
+class VersionManager:
     @staticmethod
     def get():
         data_dir = expanduser(Configuration.get()['data_dir'])


### PR DESCRIPTION
## Description
Inheriting from object isn't necessary in python3. Removing it to keep the code cleaner and more consistent.

## How to test
Make sure tests passes and mycroft still functions

## Contributor license agreement signed?
CLA [ Yes ]
