### PR TITLE
Remove depth=1, which breaks the dev_setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Mycroft is a hackable open source voice assistant.
 
 First, get the code on your system!  The simplest method is via git ([git installation instructions](https://gist.github.com/derhuerst/1b15ff4652a867391f03)):
 - `cd ~/`
-- `git clone --depth=1 https://github.com/MycroftAI/mycroft-core.git`
+- `git clone https://github.com/MycroftAI/mycroft-core.git`
 - `cd mycroft-core`
 - `bash dev_setup.sh`
 
@@ -37,11 +37,6 @@ This script sets up dependencies and a [virtualenv][about-virtualenv].  If runni
 [about-virtualenv]:https://virtualenv.pypa.io/en/stable/
 
 NOTE: The default branch for this repository is 'dev', which should be considered a work-in-progress. If you want to clone a more stable version, switch over to the 'master' branch.
-NOTE: If you are willing to contribute to this project, clone the entire repository by 
-- `git clone  https://github.com/MycroftAI/mycroft-core.git`
- instead of 
-- `git clone --depth=1 https://github.com/MycroftAI/mycroft-core.git`
-which is said above.
 
 # Running Mycroft
 


### PR DESCRIPTION
Fixes problem described in #1946.  With depth=1, you can't switch branches, thus can't get to master.

## How to test
Install from scratch, select 'master' when running dev_setup.sh

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
