### PR TITLE
text_client.py: Don't throw exception on missing conf

### DIFF
--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -169,7 +169,6 @@ def load_settings():
             show_meter = config["show_meter"]
     except Exception as e:
         LOG.info("Ignoring failed load of settings file")
-        LOG.exception(e)
 
 
 def save_settings():


### PR DESCRIPTION
## Description
If we are missing the ".mycroft_cli.conf" file we print a message to the
user informing them that we are ignoring the missing file, but then
throw an exception. Remove the exception throwing and instead allow the
user to continue without the file, as we tell them we are doing.

## How to test
Run CLI without ".mycroft_cli.conf" file.

## Contributor license agreement signed?
CLA [ Yes ]