### PR TITLE
dialog: Open template file as utf8 encoded

### DIFF
--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -43,7 +43,7 @@ class MustacheDialogRenderer:
             template_name (str): a unique identifier for a group of templates
             filename (str): a fully qualified filename of a mustache template.
         """
-        with open(filename, 'r') as f:
+        with open(filename, 'r', encoding='utf8') as f:
             for line in f:
                 template_text = line.strip()
                 # Skip all lines starting with '#' and all empty lines


### PR DESCRIPTION
## Description
To avoid UnicodeDecodeError's when opening files tell Python that we
want to open the file as a utf8 encoded file.

## How to test
Load skills in mycroft

## Contributor license agreement signed?
CLA [ Yes ]
