### PR TITLE
Bugfix/speech stop

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -55,6 +55,7 @@ def handle_speak(event):
     else:
         ident = 'unknown'
 
+    start = time.time()  # Time of speech request
     with lock:
         stopwatch = Stopwatch()
         stopwatch.start()
@@ -74,19 +75,21 @@ def handle_speak(event):
         # so we likely will want to get rid of this when not running on Mimic
         if (config.get('enclosure', {}).get('platform') != "picroft" and
                 len(re.findall('<[^>]*>', utterance)) == 0):
-            start = time.time()
             chunks = re.split(r'(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?)\s',
                               utterance)
             for chunk in chunks:
+                # Check if somthing has aborted the speech
+                if (_last_stop_signal > start or
+                        check_for_signal('buttonPress')):
+                    # Clear any newly queued speech
+                    tts.playback.clear()
+                    break
                 try:
                     mute_and_speak(chunk, ident)
                 except KeyboardInterrupt:
                     raise
                 except Exception:
                     LOG.error('Error in mute_and_speak', exc_info=True)
-                if (_last_stop_signal > start or
-                        check_for_signal('buttonPress')):
-                    break
         else:
             mute_and_speak(utterance, ident)
 
@@ -143,8 +146,7 @@ def handle_stop(event):
     global _last_stop_signal
     if check_for_signal("isSpeaking", -1):
         _last_stop_signal = time.time()
-        tts.playback.clear_queue()
-        tts.playback.clear_visimes()
+        tts.playback.clear()  # Clear here to get instant stop
         bus.emit(Message("mycroft.stop.handled", {"by": "TTS"}))
 
 

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -143,6 +143,11 @@ class PlaybackThread(Thread):
     def clear_visimes(self):
         self._clear_visimes = True
 
+    def clear(self):
+        """ Clear all pending actions for the TTS playback thread. """
+        self.clear_queue()
+        self.clear_visimes()
+
     def blink(self, rate=1.0):
         """ Blink mycroft's eyes """
         if self.enclosure and random.random() < rate:

--- a/mycroft/tts/mimic2_tts.py
+++ b/mycroft/tts/mimic2_tts.py
@@ -29,6 +29,7 @@ import base64
 import os
 import hashlib
 import re
+import json
 
 
 max_sentence_size = 170
@@ -268,15 +269,13 @@ class Mimic2(TTS):
             LOG.exception("type error in mimic2_tts.py _normalized_numbers()")
         return sentence
 
-    def execute(self, sentence, ident=None):
+    def get_tts(self, sentence, wav_file):
         """request and play mimic2 wav audio
 
         Args:
             sentence (str): sentence to synthesize from mimic2
             ident (optional): Defaults to None.
         """
-        create_signal("isSpeaking")
-
         sentence = self._normalized_numbers(sentence)
 
         # Use the phonetic_spelling mechanism from the TTS base class
@@ -291,20 +290,48 @@ class Mimic2(TTS):
             for idx, req in enumerate(self._requests(chunks)):
                 results = req.result().json()
                 audio = base64.b64decode(results['audio_base64'])
-                vis = self.visime(results['visimes'])
-                key = str(hashlib.md5(
-                    chunks[idx].encode('utf-8', 'ignore')).hexdigest())
-                wav_file = os.path.join(
-                    get_cache_directory("tts"),
-                    key + '.' + self.audio_ext
-                )
+                vis = results['visimes']
                 with open(wav_file, 'wb') as f:
                     f.write(audio)
-                self.queue.put((self.audio_ext, wav_file, vis, ident))
         except (ReadTimeout, ConnectionError, ConnectTimeout, HTTPError):
             raise RemoteTTSTimeoutException(
                 "Mimic 2 remote server request timedout. falling back to mimic"
             )
+        return (wav_file, vis)
+
+    def save_phonemes(self, key, phonemes):
+        """
+            Cache phonemes
+
+            Args:
+                key:        Hash key for the sentence
+                phonemes:   phoneme string to save
+        """
+
+        cache_dir = get_cache_directory("tts")
+        pho_file = os.path.join(cache_dir, key + ".pho")
+        try:
+            with open(pho_file, "w") as cachefile:
+                cachefile.write(json.dumps(phonemes))
+        except Exception:
+            LOG.exception("Failed to write {} to cache".format(pho_file))
+
+    def load_phonemes(self, key):
+        """
+            Load phonemes from cache file.
+
+            Args:
+                Key:    Key identifying phoneme cache
+        """
+        pho_file = os.path.join(get_cache_directory("tts"), key + ".pho")
+        if os.path.exists(pho_file):
+            try:
+                with open(pho_file, "r") as cachefile:
+                    phonemes = json.load(cachefile)
+                return phonemes
+            except Exception as e:
+                LOG.error("Failed to read .PHO from cache ({})".format(e))
+        return None
 
 
 class Mimic2Validator(TTSValidator):


### PR DESCRIPTION
## Description
Improve the TTS stop mechanic

- Make the mimic2 TTS more similar to the other TTS engines (I think this fixes another bug with local caching)
- Make sure pending requests are also stopped
- Make sure that any TTS operation that was running when the stop signal arrived will be cleared

## How to test
A good skill to test with is the [fairytalez skill](https://github.com/andlo/fairytalez-skill) by @andlo 

## Contributor license agreement signed?
CLA [ Yes ]
