### PR TITLE
Play on local audiobackends before trying remotes

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -23,6 +23,8 @@ from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
 
+from .services import RemoteAudioBackend
+
 try:
     import pulsectl
 except ImportError:
@@ -161,7 +163,12 @@ class AudioService:
             subsystem.
         """
 
-        self.service = load_services(self.config, self.bus)
+        services = load_services(self.config, self.bus)
+        # Sort services so local services are checked first
+        local = [s for s in services if not isinstance(s, RemoteAudioBackend)]
+        remote = [s for s in services if isinstance(s, RemoteAudioBackend)]
+        self.service = local + remote
+
         # Register end of track callback
         for s in self.service:
             s.set_track_start_callback(self.track_start)

--- a/mycroft/audio/services/__init__.py
+++ b/mycroft/audio/services/__init__.py
@@ -150,3 +150,12 @@ class AudioBackend:
     def shutdown(self):
         """ perform clean shutdown """
         self.stop()
+
+
+class RemoteAudioBackend(AudioBackend):
+    """ Class used to identify remote audio backends.
+
+        These may be things like Chromecasts, mopidy servers, etc.
+
+    """
+    pass

--- a/mycroft/audio/services/__init__.py
+++ b/mycroft/audio/services/__init__.py
@@ -21,7 +21,7 @@ class AudioBackend:
 
         Args:
             config: configuration dict for the instance
-            bus:    mycroft messagebus emitter
+            bus:    Mycroft messagebus emitter
     """
     __metaclass__ = ABCMeta
 
@@ -118,9 +118,9 @@ class AudioBackend:
     @abstractmethod
     def seek_forward(self, seconds=1):
         """
-        skip X seconds
+            Skip X seconds
 
-          Args:
+            Args:
                 seconds (int): number of seconds to seek, if negative rewind
         """
         pass
@@ -128,9 +128,9 @@ class AudioBackend:
     @abstractmethod
     def seek_backward(self, seconds=1):
         """
-        rewind X seconds
+            Rewind X seconds
 
-          Args:
+            Args:
                 seconds (int): number of seconds to seek, if negative rewind
         """
         pass
@@ -148,14 +148,13 @@ class AudioBackend:
         return ret
 
     def shutdown(self):
-        """ perform clean shutdown """
+        """ Perform clean shutdown """
         self.stop()
 
 
 class RemoteAudioBackend(AudioBackend):
-    """ Class used to identify remote audio backends.
+    """ Base class for remote audio backends.
 
         These may be things like Chromecasts, mopidy servers, etc.
-
     """
     pass

--- a/mycroft/audio/services/chromecast/__init__.py
+++ b/mycroft/audio/services/chromecast/__init__.py
@@ -17,12 +17,12 @@ from mimetypes import guess_type
 
 import pychromecast
 
-from mycroft.audio.services import AudioBackend
+from mycroft.audio.services import RemoteAudioBackend
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
 
 
-class ChromecastService(AudioBackend):
+class ChromecastService(RemoteAudioBackend):
     """
         Audio backend for playback on chromecast. Using the default media
         playback controller included in pychromecast.

--- a/mycroft/audio/services/mopidy/__init__.py
+++ b/mycroft/audio/services/mopidy/__init__.py
@@ -17,7 +17,7 @@ import time
 
 from os.path import dirname, abspath
 
-from mycroft.audio.services import AudioBackend
+from mycroft.audio.services import RemoteAudioBackend
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
 
@@ -26,7 +26,7 @@ sys.path.append(abspath(dirname(__file__)))
 Mopidy = __import__('mopidypost').Mopidy
 
 
-class MopidyService(AudioBackend):
+class MopidyService(RemoteAudioBackend):
     def _connect(self, message):
         """
             Callback method to connect to mopidy if server is not available


### PR DESCRIPTION
## Description
Sorts the audio backends putting backends inheriting from RemoteAudioBackend at the end.

- Adds RemoteAudioBackend class, which is used to differentiate between
Remotes and local audio backends
- When searching for audio backends the backends are storted to first
check local ones and secondly remote ones

## Contributor license agreement signed?
CLA [ Yes ]
