### PR TITLE
Single viseme message

### DIFF
--- a/mycroft/enclosure/api.py
+++ b/mycroft/enclosure/api.py
@@ -199,8 +199,20 @@ class EnclosureAPI:
         self.bus.emit(Message("enclosure.mouth.smile"))
         self.display_manager.set_active(self.name)
 
+    def mouth_viseme_list(self, start, viseme_pairs):
+        """ Send mouth visemes as a list in a single message.
+
+            Arguments:
+                start (int):    Timestamp for start of speech
+                viseme_pairs:   Pairs of viseme id and cumulative end times
+        """
+        self.bus.emit(Message("enclosure.mouth.viseme_list",
+                              {"start": start, "visemes": viseme_pairs}))
+
     def mouth_viseme(self, code, time_until=0):
         """Display a viseme mouth shape for synched speech
+
+        TODO: Remove in 19.02
         Args:
             code (int):  0 = shape for sounds like 'y' or 'aa'
                          1 = shape for sounds like 'aw'

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -128,6 +128,10 @@ class PlaybackThread(Thread):
                 True if button has been pressed.
         """
         start = time()
+        if self.enclosure:
+            self.enclosure.mouth_viseme_list(start, pairs)
+
+        # TODO 19.02 Remove the one by one method below
         for code, duration in pairs:
             if self._clear_visimes:
                 self._clear_visimes = False


### PR DESCRIPTION
## Description
Send all the visemes in a single message letting the enclosure handle the timing internally. The old system sending each viseme individually is still in place.

## How to test
Ensure that the mark-1 still shows visemes as normal.

## Contributor license agreement signed?
CLA [ Yes ]
