### PR TITLE
Fix registering fallback

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1621,7 +1621,7 @@ class FallbackSkill(MycroftSkill):
             return False
 
         self.instance_fallback_handlers.append(wrapper)
-        self._register_fallback(handler, priority)
+        self._register_fallback(wrapper, priority)
 
     @classmethod
     def remove_fallback(cls, handler_to_del):


### PR DESCRIPTION
## Description
The wrong method was referenced when registering fallback handler, instead of the wrapped function call the original method was registered. This led to not being able to unregister fallbacks.

## How to test
Use the simple fallback skill below

```python
from mycroft.skills.core import FallbackSkill


class FallbackTest(FallbackSkill):
    def initialize(self):
        self.register_fallback(self.handle_fallback, 2)

    def handle_fallback(self, message):
        utterance = message.data['utterance']
        self.log.info("FALLBACKING!")
        return False

def create_skill():
    return FallbackTest()
```

Use `touch` to make mycroft reload it and see that in the dev branch are multiple prints of *FALLBACKING!*

Switch to the PR branch and restart the skills process and check that only a single line of text is shown after triggering reload of the skill.

## Contributor license agreement signed?
CLA [ Yes ]
