### PR TITLE
Document "save_utterance" option

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -188,7 +188,12 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         self.energy_ratio = listener_config.get('energy_ratio')
         # check the config for the flag to save wake words.
 
-        self.save_utterances = listener_config.get('record_utterances', False)
+        if 'record_utterances' in listener_config:
+            # TODO: 19.08 remove this backwards compatibility
+            self.save_utterances = listener_config.get('record_utterances')
+        else:
+            self.save_utterances = listener_config.get('save_utterances',
+                                                       False)
         self.upload_lock = Lock()
         self.filenames_to_upload = []
         self.mic_level_file = os.path.join(get_ipc_directory(), "mic_level")

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -158,6 +158,12 @@
       "url": "https://training.mycroft.ai/precise/upload"
     },
 
+    // Override to save each sound which triggers the wake word engine -- by
+    // default they are only kept briefly in-memory.  This can be useful for
+    // for debugging or other custom purposes.  Recordings are saved to:
+    //   /tmp/mycroft_utterance<TIMESTAMP>.wav
+    // "save_utterance": false,
+  
     // Override as SYSTEM or USER to select a specific microphone input instead of
     // the PortAudio default input.
     //   "device_name": "somename",  // can be regex pattern or substring

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -152,17 +152,16 @@
     "sample_rate": 16000,
     "channels": 1,
     "record_wake_words": false,
-    "record_utterances": false,
+    // Override to save each sentence sent to STT -- by default they are only
+    // kept briefly in-memory.  This can be useful for for debugging or other
+    // custom purposes.  Recordings are saved to:
+    // /tmp/mycroft_utterance<TIMESTAMP>.wav
+    "save_utterances": false,
     "wake_word_upload": {
       "disable": false,
       "url": "https://training.mycroft.ai/precise/upload"
     },
 
-    // Override to save each sound which triggers the wake word engine -- by
-    // default they are only kept briefly in-memory.  This can be useful for
-    // for debugging or other custom purposes.  Recordings are saved to:
-    //   /tmp/mycroft_utterance<TIMESTAMP>.wav
-    // "save_utterance": false,
   
     // Override as SYSTEM or USER to select a specific microphone input instead of
     // the PortAudio default input.


### PR DESCRIPTION
The Listener has an option to save the sound that was recognized as a wake-word.   This isn't new functionality, but was previously undocumented.

## How to test
None needed, comments only

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
