### PR TITLE
Feature/skill manager error checks

### DIFF
--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -427,10 +427,14 @@ class SkillManager(Thread):
             skill_paths = glob(join(self.msm.skills_dir, '*/'))
             still_loading = False
             for skill_path in skill_paths:
-                still_loading = (
-                        self._load_or_reload_skill(skill_path) or
-                        still_loading
-                )
+                try:
+                    still_loading = (
+                            self._load_or_reload_skill(skill_path) or
+                            still_loading
+                    )
+                except Exception as e:
+                    LOG.error('(Re)loading of {} failed ({})'.format(
+                        skill_path, repr(e)))
             if not has_loaded and not still_loading and len(skill_paths) > 0:
                 has_loaded = True
                 self.bus.emit(Message('mycroft.skills.initialized'))

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -101,7 +101,9 @@ class SkillManager(Thread):
         self.update_interval = Configuration.get()['skills']['update_interval']
         self.update_interval = int(self.update_interval * 60 * MINUTES)
         self.dot_msm = join(self.msm.skills_dir, '.msm')
-        if exists(self.dot_msm):
+        # Update immediately if the .msm or installed skills file is missing
+        # otherwise according to timestamp on .msm
+        if exists(self.dot_msm) and exists(self.installed_skills_file):
             self.next_download = os.path.getmtime(self.dot_msm) + \
                                  self.update_interval
         else:

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -135,6 +135,10 @@ class SkillManager(Thread):
         repo_config = msm_config['repo']
         data_dir = expanduser(config['data_dir'])
         skills_dir = join(data_dir, msm_config['directory'])
+        # Try to create the skills directory if it doesn't exist
+        if not exists(skills_dir):
+            os.makedirs(skills_dir)
+
         repo_cache = join(data_dir, repo_config['cache'])
         platform = config['enclosure'].get('platform', 'default')
         return MycroftSkillsManager(

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -389,15 +389,19 @@ class SkillManager(Thread):
     def load_priority(self):
         skills = {skill.name: skill for skill in self.msm.list()}
         for skill_name in PRIORITY_SKILLS:
-            skill = skills[skill_name]
-            if not skill.is_local:
-                try:
-                    skill.install()
-                except Exception:
-                    LOG.exception('Downloading priority skill:' + skill.name)
-                    if not skill.is_local:
-                        continue
-            self._load_or_reload_skill(skill.path)
+            skill = skills.get(skill_name)
+            if skill:
+                if not skill.is_local:
+                    try:
+                        skill.install()
+                    except Exception:
+                        LOG.exception('Downloading priority skill: '
+                                      '{} failed'.format(skill.name))
+                        if not skill.is_local:
+                            continue
+                self._load_or_reload_skill(skill.path)
+            else:
+                LOG.error('Priority skill {} can\'t be found')
 
     def remove_git_locks(self):
         """If git gets killed from an abrupt shutdown it leaves lock files"""

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -280,12 +280,15 @@ class SkillManager(Thread):
             data = {'utterance': dialog.get("skills updated")}
             self.bus.emit(Message("speak", data))
 
+        # Schedule retry in 5 minutes on failure, after 10 shorter periods
+        # Go back to 60 minutes wait
         if default_skill_errored and self.num_install_retries < 10:
             self.num_install_retries += 1
             self.next_download = time.time() + 5 * MINUTES
             return False
         self.num_install_retries = 0
 
+        # Update timestamp on .msm file to be used when system is restarted
         with open(self.dot_msm, 'a'):
             os.utime(self.dot_msm, None)
         self.next_download = time.time() + self.update_interval
@@ -320,10 +323,7 @@ class SkillManager(Thread):
         """
         skill_path = skill_path.rstrip('/')
         skill = self.loaded_skills.setdefault(skill_path, {})
-        skill.update({
-            "id": basename(skill_path),
-            "path": skill_path
-        })
+        skill.update({"id": basename(skill_path), "path": skill_path})
 
         # check if folder is a skill (must have __init__.py)
         if not MainModule + ".py" in os.listdir(skill_path):

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -1,0 +1,69 @@
+import unittest
+import mock
+import tempfile
+from os.path import exists, join
+from shutil import rmtree
+from test.util import base_config
+
+from mycroft.configuration import Configuration
+from mycroft.skills.skill_manager import SkillManager
+
+BASE_CONF = base_config()
+BASE_CONF['data_dir'] = tempfile.mkdtemp()
+BASE_CONF['skills'] = {
+    'msm': {
+        'directory': 'skills',
+        'versioned': True,
+        'repo': {
+            'cache': '.skills-repo',
+            'url': 'https://github.com/MycroftAI/mycroft-skills',
+            'branch': '18.08'
+        }
+    },
+    'update_interval': 3600,
+    'auto_update': False,
+    'blacklisted_skills': [],
+    'priority_skills': ["mycroft-pairing"]
+}
+
+
+class MockEmitter(object):
+    def __init__(self):
+        self.reset()
+
+    def emit(self, message):
+        self.types.append(message.type)
+        self.results.append(message.data)
+
+    def get_types(self):
+        return self.types
+
+    def get_results(self):
+        return self.results
+
+    def on(self, event, f):
+        pass
+
+    def reset(self):
+        self.types = []
+        self.results = []
+
+
+class MycroftSkillTest(unittest.TestCase):
+    emitter = MockEmitter()
+
+    def setUp(self):
+        self.emitter.reset()
+        self.temp_dir = tempfile.mkdtemp()
+
+    @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
+    def test_create_manager(self):
+        """ Verify that the skill manager and msm loads as expected and
+            that the skills dir is created as needed.
+        """
+        SkillManager(self.emitter)
+        self.assertTrue(exists(join(BASE_CONF['data_dir'], 'skills')))
+
+    @classmethod
+    def tearDownClass(cls):
+        rmtree(BASE_CONF['data_dir'])


### PR DESCRIPTION
## Description
- Don't allow the skill manager thread to exit if an unexpected exception occurs. (One case is installing and then **directly** removing a skill)
- Try to create necessary directories for skills if missing
- In case of a missing internet connection and missing .skills-repo try to recover gracefully
- Don't crash on missing priority skills

## How to test
- Make sure the skills are loaded correctly.
- Remove the .skills-repo and make sure the skills still load
- Remove the .skills-repo disconnect from the internet, look for an error message explaining that skills can't be started yet. Reconnect to the internet and check that skills are loaded within a minute or so.
- Configure a non-existing skill as a priority skill and make sure all skills are loaded as intended.

## Contributor license agreement signed?
CLA [ Yes ]
