### PR TITLE
Issues-1982 - Add IAM authentication for Watson TTS

### DIFF
--- a/mycroft/tts/ibm_tts.py
+++ b/mycroft/tts/ibm_tts.py
@@ -55,10 +55,11 @@ class WatsonTTSValidator(TTSValidator):
         config = Configuration.get().get("tts", {}).get("watson", {})
         user = config.get("user") or config.get("username")
         password = config.get("password")
-        if user and password:
+        apikey = config.get("apikey")
+        if user and password or apikey:
             return
         else:
-            raise ValueError('user and/or password for IBM tts is not defined')
+            raise ValueError('user/pass or apikey for IBM tts is not defined')
 
     def get_tts_class(self):
         return WatsonTTS

--- a/mycroft/tts/ibm_tts.py
+++ b/mycroft/tts/ibm_tts.py
@@ -29,7 +29,11 @@ class WatsonTTS(RemoteTTS):
         self.type = "wav"
         user = self.config.get("user") or self.config.get("username")
         password = self.config.get("password")
-        self.auth = HTTPBasicAuth(user, password)
+        api_key = self.config.get("apikey")
+        if api_key is None:
+            self.auth = HTTPBasicAuth(user, password)
+        else:
+            self.auth = HTTPBasicAuth("apikey", api_key)
 
     def build_request_params(self, sentence):
         params = self.PARAMS.copy()


### PR DESCRIPTION
## Description
Add compatibility for Watson Text To Speech: IAM authentication #1982

## How to test
- You might need a IBM Cloud Account
- Create a Watson Text To Speech Instance
- Copy your apikey to mycroft.conf
```json
  "tts": {
    "module": "watson",
    "watson": {
       "voice":"es-LA_SofiaVoice",       
       "apikey": "sdsakdljasklkasnxslahdjasnd55s6dsakdsakjdhas"
     }
  }
```
## Contributor license agreement signed?
CLA [X] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
