### PR TITLE
Pause at semicolon

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -75,7 +75,7 @@ def handle_speak(event):
         # so we likely will want to get rid of this when not running on Mimic
         if (config.get('enclosure', {}).get('platform') != "picroft" and
                 len(re.findall('<[^>]*>', utterance)) == 0):
-            chunks = re.split(r'(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\?)\s',
+            chunks = re.split(r'(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\;|\?)\s',
                               utterance)
             for chunk in chunks:
                 # Check if somthing has aborted the speech


### PR DESCRIPTION
Split at semicolon and speak each chunk of data, similar to a period.

## Description
Support TTS engines using semicolon to separate letters, when a Spell-Skill is invoked.
Mycroft core now splits the word on a period ('.') or a semicolon (';').
More details of the issue can be found [here](https://community.mycroft.ai/t/mycroft-mispronounces-the-letter-m-when-spelling-a-word-unless-it-is-the-last-letter-of-the-word/5331/24)

## How to test

* ssh to Mark1
* run 'mycroft-cli-client'
* say M. O. N. D. A. Y -> Mycroft spells it as before
* say M; O; N; D; A; Y -> Mycroft now spells just like the above case (Previously there was no pause on semicolon)


## Contributor license agreement signed?
CLA [ yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
