### PR TITLE
Load .voc and .rx as utf-8

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -189,7 +189,7 @@ class SkillSettings(dict):
         """ Loads settings metadata from skills path. """
         if isfile(self._meta_path):
             try:
-                with open(self._meta_path) as f:
+                with open(self._meta_path, encoding='utf-8') as f:
                     data = json.load(f)
                 return data
             except Exception as e:

--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -35,7 +35,7 @@ def load_vocab_from_file(path, vocab_type, bus):
         skill_id(str):  skill id
     """
     if path.endswith('.voc'):
-        with open(path, 'r') as voc_file:
+        with open(path, 'r', encoding='utf8') as voc_file:
             for line in voc_file.readlines():
                 if line.startswith("#"):
                     continue
@@ -59,7 +59,7 @@ def load_regex_from_file(path, bus, skill_id):
         bus:        Mycroft messagebus connection
     """
     if path.endswith('.rx'):
-        with open(path, 'r') as reg_file:
+        with open(path, 'r', encoding='utf8') as reg_file:
             for line in reg_file.readlines():
                 if line.startswith("#"):
                     continue


### PR DESCRIPTION
## Description
This is parts of the @alistair23's PR #1960 related to the voc and rx files. I'm leaving out the changes for the settings files until I'm sure of the root cause of the issue.

To the original PR it adds the loading of the settings meta file.

## How to test
Run Mycroft and ensure that skills are loading as expected.

## Contributor license agreement signed?
CLA [ Yes ]
