### PR TITLE
Revert "Upgrade msm to 0.7.2"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pulsectl==17.7.4
 google-api-python-client==1.6.4
 fasteners==0.14.1
 
-msm==0.7.2
+msm==0.6.3
 msk==0.3.12
 adapt-parser==0.3.0
 padatious==0.4.5


### PR DESCRIPTION
Reverts MycroftAI/mycroft-core#1985

Pako 0.2.1 isn't compatible with python 3.4 reverting this until it can be made compatible.