### PR TITLE
Install pep8 check as pre-commit hook

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -239,7 +239,6 @@ fi" > ~/.profile_mycroft
 fi
 
 
-
 function os_is() {
     [[ $(grep "^ID=" /etc/os-release | awk -F'=' '/^ID/ {print $2}' | sed 's/\"//g') == $1 ]]
 }
@@ -352,6 +351,16 @@ fi
 # Start the virtual environment
 source "${VIRTUALENV_ROOT}/bin/activate"
 cd "${TOP}"
+
+# Install pep8 pre-commit hook
+HOOK_FILE="./.git/hooks/pre-commit"
+if [ ! -f ${HOOK_FILE} ] || grep -q "MYCROFT DEV SETUP" ${HOOK_FILE} ; then
+    echo "Installing PEP8 check as precommit-hook"
+    echo "#! $( which python )" > ${HOOK_FILE}
+    echo "# MYCROFT DEV SETUP" >> ${HOOK_FILE}
+    cat ./scripts/pre-commit >> ${HOOK_FILE}
+    chmod +x ${HOOK_FILE}
+fi
 
 PYTHON=$( python -c "import sys;print('python{}.{}'.format(sys.version_info[0], sys.version_info[1]))" )
 

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -229,6 +229,17 @@ fi" > ~/.profile_mycroft
         echo "to /opt/mycroft/skills."
     fi
 
+    # Add PEP8 pre-commit hook
+    sleep 0.5
+    echo "
+(Devloper) Do you want to automatically check code-style when submitting code.
+If unsure answer yes.
+"
+    if get_YN ; then
+        echo -e "Will install PEP8 pre-commit hook..."
+        INSTALL_PRECOMMIT_HOOK=true
+    fi
+
     # Save options
     echo '{"use_branch": "'${branch}'", "auto_update": '${autoupdate}'}' > .dev_opts.json
 
@@ -353,13 +364,15 @@ source "${VIRTUALENV_ROOT}/bin/activate"
 cd "${TOP}"
 
 # Install pep8 pre-commit hook
-HOOK_FILE="./.git/hooks/pre-commit"
-if [ ! -f ${HOOK_FILE} ] || grep -q "MYCROFT DEV SETUP" ${HOOK_FILE} ; then
-    echo "Installing PEP8 check as precommit-hook"
-    echo "#! $( which python )" > ${HOOK_FILE}
-    echo "# MYCROFT DEV SETUP" >> ${HOOK_FILE}
-    cat ./scripts/pre-commit >> ${HOOK_FILE}
-    chmod +x ${HOOK_FILE}
+if [ -z ${INSTALL_PRECOMMIT_HOOK} ] ; then
+    HOOK_FILE="./.git/hooks/pre-commit"
+    if [ ! -f ${HOOK_FILE} ] || grep -q "MYCROFT DEV SETUP" ${HOOK_FILE} ; then
+        echo "Installing PEP8 check as precommit-hook"
+        echo "#! $( which python )" > ${HOOK_FILE}
+        echo "# MYCROFT DEV SETUP" >> ${HOOK_FILE}
+        cat ./scripts/pre-commit >> ${HOOK_FILE}
+        chmod +x ${HOOK_FILE}
+    fi
 fi
 
 PYTHON=$( python -c "import sys;print('python{}.{}'.format(sys.version_info[0], sys.version_info[1]))" )

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -1,0 +1,63 @@
+"""
+Forked from https://gist.github.com/810399
+INSTALLED BY MYCROFT DEV SETUP
+"""
+from __future__ import with_statement, print_function
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# don't fill in both of these
+select_codes = []
+ignore_codes = ["E121", "E122", "E123", "E124", "E125", "E126", "E127", "E128",
+                "E129", "E501", "E722", "E226"]
+# Add things like "--max-line-length=120" below
+overrides = []
+
+
+def system(*args, **kwargs):
+    kwargs.setdefault('stdout', subprocess.PIPE)
+    proc = subprocess.Popen(args, **kwargs)
+    out, err = proc.communicate()
+    return out
+
+
+def main():
+    modified = re.compile('^[AM]+\s+(?P<name>.*\.py$)', re.MULTILINE)
+    files = system('git', 'status', '--porcelain').decode("utf-8")
+    files = modified.findall(files)
+
+    tempdir = tempfile.mkdtemp()
+    for name in files:
+        filename = os.path.join(tempdir, name)
+        filepath = os.path.dirname(filename)
+
+        if not os.path.exists(filepath):
+            os.makedirs(filepath)
+        with open(filename, 'w') as f:
+            system('git', 'show', ':' + name, stdout=f)
+
+    args = ['pep8']
+    if select_codes and ignore_codes:
+        print(u'Error: select and ignore codes are mutually exclusive')
+        sys.exit(1)
+    elif select_codes:
+        args.extend(('--select', ','.join(select_codes)))
+    elif ignore_codes:
+        args.extend(('--ignore', ','.join(ignore_codes)))
+    args.extend(overrides)
+    args.append('.')
+    output = system(*args, cwd=tempdir)
+    shutil.rmtree(tempdir)
+    if output:
+        print(u'PEP8 style violations have been detected.  Please fix them\n'
+              'or force the commit with "git commit --no-verify".\n')
+        print(output.decode("utf-8"),)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION


## Description
If no pre-commit hook exists the scripts/pre-commit will be installed as a pre-commit hook checking for PEP8 issues when making a commit. It will also allow overwriting the pre-commit hook installed by previous dev_setups.

## How to test
run dev_setup.sh

edit a python file and add a pep8 incompatible line
```python
bad=equal#BAD COMMENT
```
or similar.

Commit the file and you should see:
```
15:07 $ git commit mycroft/__init__.py 
PEP8 style violations have been detected.  Please fix them
or force the commit with "git commit --no-verify".

./mycroft/__init__.py:26:4: E225 missing whitespace around operator
./mycroft/__init__.py:26:10: E261 at least two spaces before inline comment
./mycroft/__init__.py:26:10: E262 inline comment should start with '# '
```
## Contributor license agreement signed?
CLA [ Yes ]
