### PR TITLE
Clean up some exception handling in settings code

### DIFF
--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -164,7 +164,7 @@ class WebsocketClient:
             else:
                 LOG.debug("Not able to find '"+str(event_name)+"'")
             self.emitter.remove_listener(event_name, func)
-        except ValueError as e:
+        except ValueError:
             LOG.warning('Failed to remove event {}: {}'.format(event_name,
                                                                str(func)))
             for line in traceback.format_stack():

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -516,7 +516,7 @@ class SkillSettings(dict):
         path = \
             "/" + self._device_identity + "/userSkill?identifier=" + identifier
         try:
-            user_skill = self.api.request({ "method": "GET", "path": path })
+            user_skill = self.api.request({"method": "GET", "path": path})
         except RequestException:
             # Some kind of Timeout, connection HTTPError, etc.
             user_skill = None

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -387,8 +387,6 @@ class SkillSettings(dict):
                 pass
             elif not self._complete_intialization:
                 self.initialize_remote_settings()
-                if not self._complete_intialization:
-                    return  # unable to do remote sync
             else:
                 self.update_remote()
 
@@ -396,8 +394,9 @@ class SkillSettings(dict):
             LOG.exception('Failed to fetch skill settings: {}'.format(repr(e)))
         finally:
             # Call callback for updated settings
-            if self.changed_callback and hash(str(self)) != original:
-                self.changed_callback()
+            if self._complete_intialization:
+                if self.changed_callback and hash(str(self)) != original:
+                    self.changed_callback()
 
         if self._poll_timer:
             self._poll_timer.cancel()

--- a/mycroft/tts/mimic2_tts.py
+++ b/mycroft/tts/mimic2_tts.py
@@ -295,7 +295,7 @@ class Mimic2(TTS):
                     f.write(audio)
         except (ReadTimeout, ConnectionError, ConnectTimeout, HTTPError):
             raise RemoteTTSTimeoutException(
-                "Mimic 2 server request timed out. Falling back to mimic" )
+                "Mimic 2 server request timed out. Falling back to mimic")
         return (wav_file, vis)
 
     def save_phonemes(self, key, phonemes):

--- a/mycroft/tts/mimic2_tts.py
+++ b/mycroft/tts/mimic2_tts.py
@@ -295,8 +295,7 @@ class Mimic2(TTS):
                     f.write(audio)
         except (ReadTimeout, ConnectionError, ConnectTimeout, HTTPError):
             raise RemoteTTSTimeoutException(
-                "Mimic 2 remote server request timedout. falling back to mimic"
-            )
+                "Mimic 2 server request timed out. Falling back to mimic" )
         return (wav_file, vis)
 
     def save_phonemes(self, key, phonemes):


### PR DESCRIPTION
The settings code worked, but was noisy and generally messy about
a few exceptional but common situations:
* When the .mycroft/skills/<SkillName> folder didn't already exist
* When network timeouts and such occcurred

I also slipped in a couple trivial code cleanups for an unused variable
and a log message.

## Description
(Description of what the PR does, such as fixes # {issue number})

## How to test
This mainly happens when running a fresh install of Mycroft

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
