### PR TITLE
Add (|) syntax to dialog files

### DIFF
--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from os.path import join
 
 from mycroft.util import resolve_resource_file
+from mycroft.util.format import expand_options
 from mycroft.util.log import LOG
 
 
@@ -90,6 +91,7 @@ class MustacheDialogRenderer:
             line = template_functions[index % len(template_functions)]
         # Replace {key} in line with matching values from context
         line = line.format(**context)
+        line = random.choice(expand_options(line))
         return line
 
 

--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -22,6 +22,7 @@ from os.path import splitext, join
 import re
 
 from mycroft.messagebus.message import Message
+from mycroft.util.format import expand_options
 
 
 def load_vocab_from_file(path, vocab_type, bus):
@@ -39,7 +40,7 @@ def load_vocab_from_file(path, vocab_type, bus):
             for line in voc_file.readlines():
                 if line.startswith("#"):
                     continue
-                parts = line.strip().split("|")
+                parts = expand_options(line)
                 entity = parts[0]
                 bus.emit(Message("register_vocab", {
                     'start': entity, 'end': vocab_type

--- a/mycroft/util/format.py
+++ b/mycroft/util/format.py
@@ -32,6 +32,7 @@ from mycroft.util.lang.format_nl import pronounce_number_nl
 from mycroft.util.lang.format_nl import nice_number_nl
 
 from collections import namedtuple
+from padatious.util import expand_parentheses
 import json
 import os
 import datetime
@@ -512,3 +513,16 @@ def join_list(items, connector, sep=None, lang="en-us"):
         sep += " "
     return (sep.join(str(item) for item in items[:-1]) +
             " " + _translate_word(connector, lang) + " " + items[-1])
+
+
+def expand_options(parentheses_line: str) -> list:
+    """
+    Convert 'test (a|b)' -> ['test a', 'test b']
+    Args:
+        parentheses_line: Input line to expand
+    Returns:
+        List of expanded possibilities
+    """
+    # 'a(this|that)b' -> [['a', 'this', 'b'], ['a', 'that', 'b']]
+    options = expand_parentheses(re.split(r'([(|)])', parentheses_line))
+    return [re.sub(r'\s+', ' ', ' '.join(i)).strip() for i in options]


### PR DESCRIPTION
## Description
This PR allows dialog files to use the `(this|that)` syntax that has previously only been available in `.intent` files.

**Note:** This requires making the following changes to all `.voc` files:
```
a|b|c|d
```
->
```
(a|b|c|d)
```

## How to test
 - Make sure dialog files for previous skills work
 - Test a skill dialog with something like `This is (a (foo|bar) (test|))` and make sure it outputs a random choice of the options
 - Test adding skill vocab for something like `shut (it|) up`