### PR TITLE
Tweak English extract_datetime() parsing

### DIFF
--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -634,7 +634,6 @@ def extract_duration_en(text):
                     not consumed in the parsing. The first value will
                     be None if no duration is found. The text returned
                     will have whitespace stripped from the ends.
-
     """
     if not text:
         return None
@@ -1276,7 +1275,8 @@ def extract_datetime_en(string, dateNow, default_time):
                     ((not daySpecified) or dayOffset < 1)):
                 # ambiguous time, detect whether they mean this evening or
                 # the next morning based on whether it has already passed
-                if dateNow.hour < HH:
+                if dateNow.hour < HH or (dateNow.hour == HH and
+                                         dateNow.minute < MM):
                     pass  # No modification needed
                 elif dateNow.hour < HH + 12:
                     HH += 12


### PR DESCRIPTION
Ambiguous times previously used a generally unexpected rule about
when to jump 12 hours when parsing times.  Now it follows the rule:
If a time is spoken without am/pm indicator, assume the next time
that hasn't passed was intended.

For example:
  "at 7 o'clock"
Would mean 7:00am if spoken at 6:59am, but would mean 7:00pm
if spoken at 7:01am.

NOTE: This behavior is distinctly different for 19.02.

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
