### PR TITLE
Support params for mycroft-mic-test

### DIFF
--- a/bin/mycroft-mic-test
+++ b/bin/mycroft-mic-test
@@ -33,9 +33,6 @@ fi
 
 # Launch the standard audiotest
 "$DIR/../start-mycroft.sh" audiotest $@
-# Necessary for now, audiotest returns while still playing in background
-# TODO: Remove once audiotest has been corrected to wait on playback
-sleep 10
 
 
 if [ $restart -eq 1 ]

--- a/bin/mycroft-mic-test
+++ b/bin/mycroft-mic-test
@@ -32,7 +32,7 @@ fi
 
 
 # Launch the standard audiotest
-"$DIR/../start-mycroft.sh" audiotest
+"$DIR/../start-mycroft.sh" audiotest $@
 # Necessary for now, audiotest returns while still playing in background
 # TODO: Remove once audiotest has been corrected to wait on playback
 sleep 10


### PR DESCRIPTION
The audiotest utility supports parameters (e.g. -l), but the
mycroft-mic-test shortcut didn't allow parameters to be passed along.

## How to test
Use a parameter for mycroft-mic-test, such as:
```mycroft-mic-test -l```

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
