### PR TITLE
Let skill tester expand dialogs

### DIFF
--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -289,12 +289,13 @@ class SkillTest(object):
         self.failure_msg = None
 
     def run(self, loader):
-        """
-            Run a test for a skill. The skill, test_case_file and emitter is
-            already set up in the __init__ method
+        """ Execute the test
 
-            Args:
-                loader:  A list of loaded skills
+        Run a test for a skill. The skill, test_case_file and emitter is
+        already set up in the __init__ method
+
+        Args:
+            bool: Test results -- only True if all passed
         """
         s = [s for s in loader.skills if s and s.root_dir == self.skill]
         if s:
@@ -442,12 +443,12 @@ HIDDEN_MESSAGES = ['skill.converse.request', 'skill.converse.response']
 def load_dialog_list(skill, dialog):
     """ Load dialog from files into a single list.
 
-        Arguments:
-            skill (MycroftSkill): skill to load dialog from
-            dialog (list): List of dialogs to load
+    Args:
+        skill (MycroftSkill): skill to load dialog from
+        dialog (list): Dialog names (str) to load
 
-        Returns:
-            List of expanded dialog strings
+    Returns:
+        list: Expanded dialog strings
     """
     dialogs = []
     try:
@@ -481,9 +482,9 @@ class EvaluationRule(object):
     def __init__(self, test_case, skill=None):
         """ Convert test_case read from file to internal rule format
 
-            Args:
-                test_case:  The loaded test case
-                skill:      optional skill to test, used to fetch dialogs
+        Args:
+            test_case:  The loaded test case
+            skill:      optional skill to test, used to fetch dialogs
         """
         self.rule = []
 
@@ -569,13 +570,13 @@ class EvaluationRule(object):
     def evaluate(self, msg):
         """ Main entry for evaluating a message against the rules.
 
-            The rules are prepared in the __init__
-            This method is usually called several times with different
-            messages using the same rule set. Each call contributing
-            to fulfilling all the rules
+        The rules are prepared in the __init__
+        This method is usually called several times with different
+        messages using the same rule set. Each call contributing
+        to fulfilling all the rules
 
-            Args:
-                msg:  The message event to evaluate
+        Args:
+            msg:  The message event to evaluate
         """
         if msg.get('__type__', '') not in HIDDEN_MESSAGES:
             print("\nEvaluating message: ", msg)
@@ -598,14 +599,14 @@ class EvaluationRule(object):
     def _partial_evaluate(self, rule, msg):
         """ Evaluate the message against a part of the rules
 
-            Recursive over rules
+        Recursive over rules
 
-            Args:
-                rule:  A rule or a part of the rules to be broken down further
-                msg:   The message event being evaluated
+        Args:
+            rule:  A rule or a part of the rules to be broken down further
+            msg:   The message event being evaluated
 
-            Returns:
-                 Bool: True if a partial evaluation succeeded
+        Returns:
+            Bool: True if a partial evaluation succeeded
         """
         if 'succeeded' in rule:  # Rule has already succeeded, test not needed
             return True
@@ -661,8 +662,8 @@ class EvaluationRule(object):
     def get_failure(self):
         """ Get the first rule which has not succeeded
 
-            Returns:
-                str: The failed rule
+        Returns:
+            str: The failed rule
         """
         for x in self.rule:
             if x[-1] != 'succeeded':
@@ -672,7 +673,7 @@ class EvaluationRule(object):
     def all_succeeded(self):
         """ Test if all rules succeeded
 
-            Returns:
-                bool: True if all rules succeeded
+        Returns:
+            bool: True if all rules succeeded
         """
         return len([x for x in self.rule if x[-1] != 'succeeded']) == 0


### PR DESCRIPTION
## Description
The skill tester need to expand the dialogs in the same way as the dialog renderer to be able to correctly assert the expected_dialog criteria.

## How to test
Test a skill which uses both single dialog file and multiple dialog files in expected_dialog such as the weather skill.

## Contributor license agreement signed?
CLA [ Yes ]
