### PR TITLE
Improve debug logging

### DIFF
--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -222,11 +222,8 @@ class LogMonitorThread(Thread):
 
                 # Check if file has been modified since last read
                 if not st_results.st_mtime == self.st_results.st_mtime:
-                    read_from = self.st_results.st_size
-                    self.st_results = st_results
-                    if st_results.st_size < read_from:
-                        st
                     self.read_file_from(self.st_results.st_size)
+                    self.st_results = st_results
 
                     set_screen_dirty()
             except OSError:
@@ -873,7 +870,7 @@ help_struct = [
       (":filter (clear|reset)", "reset filters"),
       (":filter (show|list)",   "display current filters"),
       (":find 'STR'",           "show logs containing 'str'"),
-      (":log level (debug|info|error)", "set logging level"),
+      (":log level (DEBUG|INFO|ERROR)", "set logging level"),
       (":log bus (on|off)",     "control logging of messagebus messages")
      ]
     ),
@@ -1052,7 +1049,7 @@ def _get_cmd_param(cmd, keyword):
     # Returns parameter to a command.  Will de-quote.
     # Ex: find 'abc def'   returns: abc def
     #    find abc def     returns: abc def
-    if type(keyword) is list:
+    if isinstance(keyword, list):
         for w in keyword:
             cmd = cmd.replace(w, "").strip()
     else:

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -432,8 +432,8 @@ def create_echo_function(name, whitelist=None):
                 # Respond to requests to adjust the logger settings
                 lvl = msg["data"].get("level", "").upper()
                 if lvl in ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]:
-                    LOG(name).info("Changing log level to: "+lvl)
-                    LOG(name).setLevel(lvl)
+                    LOG.level = lvl
+                    LOG(name).info("Changing log level to: {}".format(lvl))
 
                 # Allow enable/disable of messagebus traffic
                 log_bus = msg["data"].get("bus", None)

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -398,7 +398,6 @@ def wait_for_exit_signal():
         pass
 
 
-
 _log_all_bus_messages = False
 def create_echo_function(name, whitelist=None):
     """ Standard logging mechanism for Mycroft processes.
@@ -438,7 +437,7 @@ def create_echo_function(name, whitelist=None):
 
                 # Allow enable/disable of messagebus traffic
                 log_bus = msg["data"].get("bus", None)
-                if not log_bus is None:
+                if log_bus is not None:
                     LOG(name).info("Bus logging: "+str(log_bus))
                     _log_all_bus_messages = log_bus
             elif msg.get("type") == "registration":

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -400,6 +400,8 @@ def wait_for_exit_signal():
 
 
 _log_all_bus_messages = False
+
+
 def create_echo_function(name, whitelist=None):
     """ Standard logging mechanism for Mycroft processes.
 

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -28,6 +28,7 @@ import os.path
 import psutil
 from stat import S_ISREG, ST_MTIME, ST_MODE, ST_SIZE
 import requests
+import logging
 
 import signal as sig
 
@@ -434,6 +435,10 @@ def create_echo_function(name, whitelist=None):
                 if lvl in ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]:
                     LOG.level = lvl
                     LOG(name).info("Changing log level to: {}".format(lvl))
+                    try:
+                        logging.getLogger('urllib3').setLevel(lvl)
+                    except Exception:
+                        pass  # We don't really care about if this fails...
 
                 # Allow enable/disable of messagebus traffic
                 log_bus = msg["data"].get("bus", None)


### PR DESCRIPTION
Several changes to the logging using in all processes:
* Disable logging of bus messages by default (massively cleans up the logs)
* Add "mycroft.debug.log" bus message.  It supports the data={"bus": True/False} as well as
  data={"log": LEVEL}, where level is a Python logging level.

CLI now supports several commands:
* ```:log level XXX``` where XXX is the name of a standard Python level (e.g. 'debug')
* ```:log bus on``` or ```:log bus off```
* Removed the requirement for "log" in ```:clear log```.  ```:clear``` works now.
