### PR TITLE
Wait for ntp sync complete message

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -94,8 +94,8 @@ def check_connection():
         config = Configuration.get()
         platform = config['enclosure'].get("platform", "unknown")
         if platform in ['mycroft_mark_1', 'picroft']:
-            bus.emit(Message("system.ntp.sync"))
-            time.sleep(15)  # TODO: Generate/listen for a message response...
+            bus.wait_for_response(Message('system.ntp.sync'),
+                                  'system.ntp.sync.complete', 15)
 
         # Check if the time skewed significantly.  If so, reboot
         skew = abs((time.monotonic() - start_ticks) -


### PR DESCRIPTION
## Description
We can easily wait for the message, even if it doesn't exist. I figured we can introduce this as long as there are no regressions, and then when we update the admin service for boot changes, we can also add this message. [Relevant mycroft-wifi-setup commit in PR](https://github.com/MycroftAI/mycroft-wifi-setup/pull/33/commits/5d9f71df52330f2699a7a44bc9084545b785d502).

## How to test
Start a device and make sure it still goes through the ntp sync like normal.