### PR TITLE
Try updating the system on boot when not paired

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -77,6 +77,19 @@ def _starting_up():
     check_connection()
 
 
+def try_update_system(platform):
+    bus.emit(Message('system.update'))
+    msg = Message('system.update', {
+        'paired': is_paired(),
+        'platform': platform
+    })
+    resp = bus.wait_for_response(msg, 'system.update.processing')
+
+    if resp and (resp.data or {}).get('processing', True):
+        bus.wait_for_response(Message('system.update.waiting'),
+                              'system.update.complete', 1000)
+
+
 def check_connection():
     """
         Check for network connection. If not paired trigger pairing.
@@ -96,6 +109,9 @@ def check_connection():
         if platform in ['mycroft_mark_1', 'picroft']:
             bus.emit(Message("system.ntp.sync"))
             time.sleep(15)  # TODO: Generate/listen for a message response...
+
+        if not is_paired():
+            try_update_system(platform)
 
         # Check if the time skewed significantly.  If so, reboot
         skew = abs((time.monotonic() - start_ticks) -


### PR DESCRIPTION
## Description
This sends a new system.update.check message when the device is booted and not paired
Note: It is not sent every boot because the command could upgrade across major versions which the user could not want.

[Relevant mycroft-wifi-setup PR](https://github.com/MycroftAI/mycroft-wifi-setup/pull/33).

## How to test
 - Test that on desktop, the boot process is unaltered
 - Test that on a normal mark 1 the boot process us unaltered
 - [Optionally] Test that on an unpaired mark 1 that a system.update message is sent
