### PR TITLE
Add default values to Message attributes

### DIFF
--- a/mycroft/messagebus/message.py
+++ b/mycroft/messagebus/message.py
@@ -36,10 +36,9 @@ class Message:
         Message objects will be used to send information back and fourth
         bettween processes of mycroft service, voice, skill and cli
         """
-        data = data or {}
         self.type = type
-        self.data = data
-        self.context = context
+        self.data = data or {}
+        self.context = context or {}
 
     def serialize(self):
         """This returns a string of the message info.
@@ -73,7 +72,9 @@ class Message:
             value(str): This is the string received from the websocket
         """
         obj = json.loads(value)
-        return Message(obj.get('type'), obj.get('data'), obj.get('context'))
+        return Message(obj.get('type') or '',
+                       obj.get('data') or {},
+                       obj.get('context') or {})
 
     def reply(self, type, data=None, context=None):
         """Construct a reply message for a given message
@@ -98,7 +99,7 @@ class Message:
         data = data or {}
         context = context or {}
 
-        new_context = self.context if self.context else {}
+        new_context = self.context
         for key in context:
             new_context[key] = context[key]
         if 'target' in data:
@@ -138,7 +139,7 @@ class Message:
             Message: Message object to publish
         """
         context = context or {}
-        new_context = self.context.copy() if self.context else {}
+        new_context = self.context.copy()
         for key in context:
             new_context[key] = context[key]
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1644,7 +1644,7 @@ class FallbackSkill(MycroftSkill):
                                                  'exception': warning}))
 
             # Send timing metric
-            if message.context and message.context['ident']:
+            if message.context.get('ident'):
                 ident = message.context['ident']
                 report_timing(ident, 'fallback_handler', stopwatch,
                               {'handler': handler_name})

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -277,7 +277,7 @@ class IntentService:
 
         NOTE: This only applies to those with Opt In.
         """
-        ident = context['ident'] if context else None
+        ident = context['ident'] if 'ident' in context else None
         if intent:
             # Recreate skill name from skill id
             parts = intent.get('intent_type', '').split(':')


### PR DESCRIPTION
## Description
This ensures no attributes are None and simplifies some checks within the function
Otherwise, if, for instance, there were no 'data' field in a message, when deserializing, the caller would have to check for None

## How to test
Make sure the following works correctly:
```python
class FooMessage:
    def __init__(self, msg_type):
        self.msg_type = msg_type

    def serialize(self):
        return {'type': self.msg_type}  # Doesn't include 'data'
bus.on('test.message', lambda msg: print(msg.data.get('something', 'HELLO'))
bus.emit(FooMessage('test.message'))
```
