### PR TITLE
date and time - for tonight, weekdays

### DIFF
--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -741,7 +741,7 @@ def extract_datetime_en(string, dateNow, default_time):
     timeQualifier = ""
 
     timeQualifiersAM = ['morning']
-    timeQualifiersPM = ['afternoon', 'evening', 'night'] # 'tonight' not required here
+    timeQualifiersPM = ['afternoon', 'evening', 'night']
     timeQualifiersList = set(timeQualifiersAM + timeQualifiersPM)
     markers = ['at', 'in', 'on', 'by', 'this', 'around', 'for', 'of', "within"]
     days = ['monday', 'tuesday', 'wednesday',
@@ -1172,7 +1172,7 @@ def extract_datetime_en(string, dateNow, default_time):
                         remainder == "weekdays" or
                         wordNext == "weekdays" or
                         wordNextNext == "weekdays"):
-                    # we set strHH here to make sure isTime == True
+                    # Set strHH so that isTime == True
                     # when am or pm is not specified
                     strHH = strNum
                     used = 1

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -741,7 +741,7 @@ def extract_datetime_en(string, dateNow, default_time):
     timeQualifier = ""
 
     timeQualifiersAM = ['morning']
-    timeQualifiersPM = ['afternoon', 'evening', 'tonight', 'night']
+    timeQualifiersPM = ['afternoon', 'evening', 'night'] # 'tonight' not required here
     timeQualifiersList = set(timeQualifiersAM + timeQualifiersPM)
     markers = ['at', 'in', 'on', 'by', 'this', 'around', 'for', 'of', "within"]
     days = ['monday', 'tuesday', 'wednesday',
@@ -813,6 +813,9 @@ def extract_datetime_en(string, dateNow, default_time):
             timeQualifier = word
         # parse today, tomorrow, day after tomorrow
         elif word == "today" and not fromFlag:
+            dayOffset = 0
+            used += 1
+        elif word == "tonight" and not fromFlag:
             dayOffset = 0
             used += 1
         elif word == "tomorrow" and not fromFlag:
@@ -1164,6 +1167,14 @@ def extract_datetime_en(string, dateNow, default_time):
                         wordNext == "a.m."):
                     strHH = strNum
                     remainder = "am"
+                    used = 1
+                elif (
+                        remainder == "weekdays" or
+                        wordNext == "weekdays" or
+                        wordNextNext == "weekdays"):
+                    # we set strHH here to make sure isTime == True
+                    # when am or pm is not specified
+                    strHH = strNum
                     used = 1
                 else:
                     if (

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -749,6 +749,8 @@ def extract_datetime_en(string, dateNow, default_time):
     months = ['january', 'february', 'march', 'april', 'may', 'june',
               'july', 'august', 'september', 'october', 'november',
               'december']
+    recur_markers = days + [d+'s' for d in days] + ['weekend', 'weekday',
+                                                    'weekends', 'weekdays']
     monthsShort = ['jan', 'feb', 'mar', 'apr', 'may', 'june', 'july', 'aug',
                    'sept', 'oct', 'nov', 'dec']
     year_multiples = ["decade", "century", "millennium"]
@@ -1169,9 +1171,10 @@ def extract_datetime_en(string, dateNow, default_time):
                     remainder = "am"
                     used = 1
                 elif (
-                        remainder == "weekdays" or
-                        wordNext == "weekdays" or
-                        wordNextNext == "weekdays"):
+                        remainder in recur_markers or
+                        wordNext in recur_markers or
+                        wordNextNext in recur_markers):
+                    # Ex: "7 on mondays" or "3 this friday"
                     # Set strHH so that isTime == True
                     # when am or pm is not specified
                     strHH = strNum

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -455,6 +455,19 @@ class TestNormalize(unittest.TestCase):
                     "2017-07-08 10:00:00", "remind me to call mom")
         testExtract("remind me to call mom at 10am next saturday",
                     "2017-07-08 10:00:00", "remind me to call mom")
+        # Below two tests, ensure that time is picked even if no am/pm is specified
+        # in case of weekdays/tonight
+        testExtract("set alarm for 9 on weekdays",
+                    "2017-06-27 21:00:00", "set alarm weekdays")
+        testExtract("for 8 tonight",
+                    "2017-06-27 20:00:00", "")
+        testExtract("for 8:30pm tonight",
+                    "2017-06-27 20:3:00", "")
+        # Tests a specified time with : & without am/pm
+        testExtract("remind me about the game tonight at 11:30",
+                    "2017-06-27 23:30:00", "remind me about game")
+        testExtract("set alarm at 7:30 on weekdays",
+                    "2017-06-27 19:30:00", "set alarm on weekdays")
 
     def test_extract_ambiguous_time_en(self):
         morning = datetime(2017, 6, 27, 8, 1, 2)

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -455,7 +455,8 @@ class TestNormalize(unittest.TestCase):
                     "2017-07-08 10:00:00", "remind me to call mom")
         testExtract("remind me to call mom at 10am next saturday",
                     "2017-07-08 10:00:00", "remind me to call mom")
-        # Below two tests, ensure that time is picked even if no am/pm is specified
+        # Below two tests, ensure that time is picked
+        # even if no am/pm is specified
         # in case of weekdays/tonight
         testExtract("set alarm for 9 on weekdays",
                     "2017-06-27 21:00:00", "set alarm weekdays")
@@ -463,7 +464,7 @@ class TestNormalize(unittest.TestCase):
                     "2017-06-27 20:00:00", "")
         testExtract("for 8:30pm tonight",
                     "2017-06-27 20:30:00", "")
-        # Tests a specified time with : & without am/pm
+        # Tests a time with ':' & without am/pm
         testExtract("remind me about the game tonight at 11:30",
                     "2017-06-27 23:30:00", "remind me about game")
         testExtract("set alarm at 7:30 on weekdays",

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -462,7 +462,7 @@ class TestNormalize(unittest.TestCase):
         testExtract("for 8 tonight",
                     "2017-06-27 20:00:00", "")
         testExtract("for 8:30pm tonight",
-                    "2017-06-27 20:3:00", "")
+                    "2017-06-27 20:30:00", "")
         # Tests a specified time with : & without am/pm
         testExtract("remind me about the game tonight at 11:30",
                     "2017-06-27 23:30:00", "remind me about game")


### PR DESCRIPTION
## Description
Not picking the time in case of tonight/weekdays when am/pm is not specified
examples 

- "set an alarm at 7 tonight"

- "set an alarm at 9 on weekdays"

## How to test

Test cases 

- set alarm at 7:30 on weekdays
- set an alarm tonight at 9

More test cases have been added to  test_extractdatetime_en in unittests\util\test_parse.py

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
