### PR TITLE
Activate/deactivate visemes on command

### DIFF
--- a/mycroft/client/enclosure/mark1/mouth.py
+++ b/mycroft/client/enclosure/mark1/mouth.py
@@ -42,6 +42,16 @@ class EnclosureMouth:
         self.bus.on('enclosure.mouth.display_image', self.display_image)
         self.bus.on('enclosure.weather.display', self.display_weather)
         self.bus.on('mycroft.stop', self.clear_visemes)
+        self.bus.on('enclosure.mouth.events.activate',
+                    self._activate_visemes)
+        self.bus.on('enclosure.mouth.events.deactivate',
+                    self._deactivate_visemes)
+
+    def _activate_visemes(self, event=None):
+        self.bus.on('enclosure.mouth.viseme_list', self.viseme_list)
+
+    def _deactivate_visemes(self, event=None):
+        self.bus.remove('enclosure.mouth.viseme_list', self.viseme_list)
 
     def reset(self, event=None):
         self.writer.write("mouth.reset")


### PR DESCRIPTION
## Description
When showing text the visemes would overwrite it. This inhibits the visemes when mouth events are turned off and reenables them when activated.

## How to test
On a mark-1 in the pairing skill ensure that the pairing code isn't immediately overwritten by the mouth visemes

## Contributor license agreement signed?
CLA [ Yes ]
