### PR TITLE
Hide deprecated warning in certain cases

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -501,11 +501,11 @@ class MycroftSkill:
         TODO: Remove in 19.08
         """
         stack = simple_trace(traceback.format_stack())
-        if (not " _register_decorated" in stack and
-            not "register_resting_screen" in stack):
-                LOG.warning('self.config is deprecated.  Switch to using '
-                                'self.setting["whatever"] within your skill.')
-                LOG.warning(stack)
+        if (" _register_decorated" not in stack and
+                "register_resting_screen" not in stack):
+            LOG.warning('self.config is deprecated.  Switch to using '
+                        'self.setting["whatever"] within your skill.')
+            LOG.warning(stack)
         return self._config
 
     @property

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -500,8 +500,12 @@ class MycroftSkill:
         """ Provide deprecation warning when accessing config.
         TODO: Remove in 19.08
         """
-        self.log.warning('self.config is deprecated.  Switch to using '
-                         'self.setting["whatever"] within your skill.')
+        stack = simple_trace(traceback.format_stack())
+        if (not " _register_decorated" in stack and
+            not "register_resting_screen" in stack):
+                LOG.warning('self.config is deprecated.  Switch to using '
+                                'self.setting["whatever"] within your skill.')
+                LOG.warning(stack)
         return self._config
 
     @property


### PR DESCRIPTION
The deprecation warning was firing off at the load of every skill when
the decorators are being iterated through by internal code (which
includes the self.config with an @property).  Add check for these
special cases to not show a warning.

## How to test
Reboot or ```sudo service mycroft-skills restart```.  Watch the logs sparkle!
