### PR TITLE
Ignore the 'skills' symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ dev.env
 *.swp
 *~
 mimic
-./skills
+/skills
 pocketsphinx-python
 *.egg-info/
 build


### PR DESCRIPTION
The .gitignore wasn't ignoring the symlink that would be created in
dev_setup.sh to point to /opt/mycroft/skills.  The gitignore treats
what looks like an absolute path "/skills" as relative to the
repo.

## How to test
A ```git status``` before this change lists the 'skills' directory as an untracked file.  With this change it shouldn't appear in that last.
