### PR TITLE
Fix context handling in skill tester

### DIFF
--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -557,7 +557,7 @@ class EvaluationRule(object):
             ctx = test_case['changed_context']
             if isinstance(ctx, list):
                 for c in ctx:
-                    self.rule.append(['equal', 'context', str(c)])
+                    self.rule.append(['endsWith', 'context', str(c)])
             else:
                 self.rule.append(['equal', 'context', ctx])
 


### PR DESCRIPTION
## Description
Checking for context didn't work with some change made during the 18.08's lifetime (The context name gets slightly mangled). This fixes that issue.


## How to test
Run the test on carstena-the-cow-list skill and verify that it's working again.

## Contributor license agreement signed?
CLA [ Yes ]
