### PR TITLE
Set a default locale when running dev_setup.sh

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -15,6 +15,9 @@
 # limitations under the License.
 ##########################################################################
 
+# Set a default locale to handle output from commands reliably
+export LANG=C
+
 # exit on any error
 set -Ee
 


### PR DESCRIPTION
## Description
System Localisation could break the maximum-used-cores calculation when mimic is built. This sets it to a default (C) locale ensuring a reliable run. Fixes #2037 as suggested by @MaWoe.

## How to test
Run dev_setup.sh and make sure it completes correctly. Look especially at the maximum number of cores for mimic.

## Contributor license agreement signed?
CLA [ Yes ]
