### PR TITLE
Add pause/resume to simple audio services

### DIFF
--- a/mycroft/audio/services/simple/__init__.py
+++ b/mycroft/audio/services/simple/__init__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import subprocess
+import signal
 from time import sleep
 
 from mycroft.audio.services import AudioBackend
@@ -46,13 +47,14 @@ class SimpleAudioService(AudioBackend):
 
     def __init__(self, config, bus, name='simple'):
 
-        super(SimpleAudioService, self).__init__(config, bus)
+        super().__init__(config, bus)
         self.config = config
         self.process = None
         self.bus = bus
         self.name = name
         self._stop_signal = False
         self._is_playing = False
+        self._paused = False
         self.tracks = []
         self.index = 0
         self.supports_mime_hints = True
@@ -78,6 +80,7 @@ class SimpleAudioService(AudioBackend):
         LOG.info('SimpleAudioService._play')
         repeat = message.data.get('repeat', False)
         self._is_playing = True
+        self._paused = False
         if isinstance(self.tracks[self.index], list):
             track = self.tracks[self.index][0]
             mime = self.tracks[self.index][1]
@@ -114,6 +117,7 @@ class SimpleAudioService(AudioBackend):
             self.process.terminate()
             self.process = None
             self._is_playing = False
+            self._paused = False
             return
 
         self.index += 1
@@ -125,6 +129,7 @@ class SimpleAudioService(AudioBackend):
                                   {'repeat': repeat}))
         else:
             self._is_playing = False
+            self._paused = False
 
     def play(self, repeat=False):
         LOG.info('Call SimpleAudioServicePlay')
@@ -139,10 +144,16 @@ class SimpleAudioService(AudioBackend):
         self._stop_signal = False
 
     def pause(self):
-        pass
+        if self.process and not self._paused:
+            # Suspend the playback process
+            self._paused = True
+            self.process.send_signal(signal.SIGSTOP)
 
     def resume(self):
-        pass
+        if self.process and self._paused:
+            # Resume the playback process
+            self.process.send_signal(signal.SIGCONT)
+            self._paused = False
 
     def next(self):
         # Terminate process to continue to next
@@ -152,10 +163,10 @@ class SimpleAudioService(AudioBackend):
         pass
 
     def lower_volume(self):
-        pass
+        self.pause()  # poor-man's ducking
 
     def restore_volume(self):
-        pass
+        self.resume()  # poor-man's unducking
 
 
 def load_service(base_config, bus):


### PR DESCRIPTION
This adds a very simple mechanism for pausing and resuming audio streams
that are actively playing.  The process is suspended and resumed when
requested.

This also uses that same method to implement lower_volume()/restore_volume() for simple "ducking" of audio.

## How to test
* "Hey Mycroft, play the news"
* Via cli: pause
    Should stop news playback
* Via cli: resume
    Should resume news playback
* With voice try shouting "Hey Mycroft" several times.
    Should pause audio while listening for a command, then resume after listening.