### PR TITLE
Fix dialog check in skill tester

### DIFF
--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -549,6 +549,9 @@ class EvaluationRule(object):
                 dialogs = load_dialog_list(skill, dialog)
                 # Allow custom fields to be anything
                 d = [re.sub(r'{.*?\}', r'.*', t) for t in dialogs]
+                # Merge consequtive .*'s into a single .*
+                d = [re.sub(r'\.\*( \.\*)+', r'.*', t) for t in d]
+
                 # Create rule allowing any of the sentences for that dialog
                 rules = [['match', 'utterance', r] for r in d]
                 self.rule.append(['or'] + rules)


### PR DESCRIPTION
## Description
This handles a slight change due to the updated dialog handling where empty dialog keys are now completely removed. This requires a slight change in how the regex to match them are generated.

Merge consecutive .*'s into a single .*

The process for "{{modifier}} {{precip}} is expected on {{day}}" will first
replace the {{}} by .* as previously:

".* .* is expected on .*"

then a second pass is made replacing any consecutive .* resulting in

".* is expected on .*"

## How to test
The testcase that indicated this issue was the weather-skill's 002.when-will-it-rain-next.json where there were two key words next to each other in the corresponding dialog.

## Contributor license agreement signed?
CLA [ Yes ]
