### PR TITLE
Send skill page info for all skills

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -61,13 +61,40 @@
 import json
 import hashlib
 import os
+import time
+import copy
 from threading import Timer
 from os.path import isfile, join, expanduser
 from requests.exceptions import RequestException
+from msm import MycroftSkillsManager, SkillEntry
 
 from mycroft.api import DeviceApi, is_paired
 from mycroft.util.log import LOG
 from mycroft.configuration import ConfigurationManager
+
+
+msm = None
+msm_creation_time = 0
+
+
+# This is the base needed for sending a blank settings meta entry
+# To this a "title" and "icon_img" entry is added.
+BLANK_META = {
+    "name": "No-skill",
+    "skillMetadata": {
+        "sections": [
+            {
+                "name": "",
+                "fields": [
+                    {
+                        "type": "label",
+                        "label": ""
+                    }
+                ]
+            }
+        ]
+    }
+}
 
 
 class SkillSettings(dict):
@@ -80,6 +107,13 @@ class SkillSettings(dict):
     """
 
     def __init__(self, directory, name):
+        # Update the msm object if it's more than an hour old
+        global msm
+        global msm_creation_time
+        if msm is None or time.time() - msm_creation_time > 60 * 60:
+            msm_creation_time = time.time()
+            msm = MycroftSkillsManager()
+
         super(SkillSettings, self).__init__()
         # when skills try to instantiate settings
         # in __init__, it can erase the settings saved
@@ -93,6 +127,11 @@ class SkillSettings(dict):
         # set file paths
         self._settings_path = join(directory, 'settings.json')
         self._meta_path = join(directory, 'settingsmeta.json')
+
+        # Get information from skills-meta.json entry for skill
+        s = SkillEntry.from_folder(directory, msm)
+        self._meta_info = s.meta_info
+
         self.is_alive = True
         self.loaded_hash = hash(json.dumps(self, sort_keys=True))
         self._complete_intialization = False
@@ -101,11 +140,17 @@ class SkillSettings(dict):
         self._user_identity = None
         self.changed_callback = None
         self._poll_timer = None
+        self._blank_poll_timer = None
         self._is_alive = True
 
         # if settingsmeta exist
         if isfile(self._meta_path):
             self._poll_skill_settings()
+        # if not disallowed by user upload an entry for all skills installed
+        elif self.config['skills']['upload_skill_manifest']:
+            self._blank_poll_timer = Timer(1, self._init_blank_meta)
+            self._blank_poll_timer.daemon = True
+            self._blank_poll_timer.start()
 
     def __hash__(self):
         """ Simple object unique hash. """
@@ -121,6 +166,8 @@ class SkillSettings(dict):
         self._is_alive = False
         if self._poll_timer:
             self._poll_timer.cancel()
+        if self._blank_poll_timer:
+            self._blank_poll_timer.cancel()
 
     def set_changed_callback(self, callback):
         """ Set callback to perform when server settings have changed.
@@ -195,18 +242,36 @@ class SkillSettings(dict):
             return super(SkillSettings, self).__setitem__(key, value)
 
     def _load_settings_meta(self):
-        """ Loads settings metadata from skills path. """
+        """ Load settings metadata from the skill folder.
+
+        If no settingsmeta exists a basic settingsmeta will be created
+        containing a basic identifier.
+
+        Returns:
+            (dict) settings meta
+        """
         if isfile(self._meta_path):
             try:
                 with open(self._meta_path, encoding='utf-8') as f:
                     data = json.load(f)
-                return data
             except Exception as e:
-                LOG.error("Failed to load setting file: "+self._meta_path)
+                LOG.error("Failed to load setting file: " + self._meta_path)
                 LOG.error(repr(e))
                 return None
         else:
-            return None
+            data = copy.copy(BLANK_META)
+            data['name'] = self._meta_info.get('title', self.name)
+
+        # Add Information extracted from the skills-meta.json entry for the
+        # skill.
+        data['title'] = self._meta_info.get('title', self.name)
+        # If icon-info is available add that to the call
+        if self._meta_info.get('icon_img'):
+            data['icon_img'] = self._meta_info['icon_img']
+        elif self._meta_info.get('icon'):
+            data['icon'] = self._meta_info['icon']
+
+        return data
 
     def _send_settings_meta(self, settings_meta):
         """ Send settingsmeta.json to the server.
@@ -379,6 +444,18 @@ class SkillSettings(dict):
         else:
             settings_meta = self._load_settings_meta()
             self._upload_meta(settings_meta, hashed_meta)
+
+    def _init_blank_meta(self):
+        """ Send blank settingsmeta to remote. """
+        try:
+            if not is_paired() and self.is_alive:
+                self._blank_poll_timer = Timer(60, self._init_blank_meta)
+                self._blank_poll_timer.daemon = True
+                self._blank_poll_timer.start()
+            else:
+                self.initialize_remote_settings()
+        except Exception as e:
+            LOG.exception('Failed to send blank meta: {}'.format(repr(e)))
 
     def _poll_skill_settings(self):
         """ If identifier exists for this skill poll to backend to

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -64,7 +64,7 @@ import os
 import time
 import copy
 from threading import Timer
-from os.path import isfile, join, expanduser
+from os.path import isfile, join, expanduser, abspath, dirname
 from requests.exceptions import RequestException
 from msm import MycroftSkillsManager, SkillEntry
 
@@ -147,7 +147,9 @@ class SkillSettings(dict):
         if isfile(self._meta_path):
             self._poll_skill_settings()
         # if not disallowed by user upload an entry for all skills installed
-        elif self.config['skills']['upload_skill_manifest']:
+        # also skip anything located in the skills directory (padatious)
+        elif (self.config['skills']['upload_skill_manifest'] and
+                not abspath(directory) == abspath(dirname(__file__))):
             self._blank_poll_timer = Timer(1, self._init_blank_meta)
             self._blank_poll_timer.daemon = True
             self._blank_poll_timer.start()

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pulsectl==17.7.4
 google-api-python-client==1.6.4
 fasteners==0.14.1
 
-msm==0.7.3
+msm==0.7.4
 msk==0.3.12
 adapt-parser==0.3.2
 padatious==0.4.6


### PR DESCRIPTION

## Description
- Create BLANK template for skills without settingsmeta.json
- Add title and icon from msm entry to all settingsmeta uploads

This Requires [msm PR #33](https://github.com/MycroftAI/mycroft-skills-manager/pull/33) and an update for Tartarus to accept the the "icon_img" entry.

## How to test
Check that Mycroft starts and that the skill page gets populated with a bunch of blank skill entries.

## Contributor license agreement signed?
CLA [ Yes ]
