### PR TITLE
Change default lang to None, not English

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -26,6 +26,7 @@ from mycroft.util import (
     create_echo_function, create_daemon, wait_for_exit_signal
 )
 from mycroft.util.log import LOG
+from mycroft.util.lang import set_active_lang
 
 from .skill_manager import SkillManager, MsmException
 from .core import FallbackSkill
@@ -186,6 +187,9 @@ def main():
     # Connect this Skill management process to the Mycroft Messagebus
     bus = WebsocketClient()
     Configuration.init(bus)
+    config = Configuration.get()
+    # Set the active lang to match the configured one
+    set_active_lang(config.get('lang', 'en-us'))
 
     bus.on('message', create_echo_function('SKILLS'))
     # Startup will be called after the connection with the Messagebus is done

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -584,7 +584,7 @@ class MycroftSkill:
         """
         return None
 
-    def converse(self, utterances, lang="en-us"):
+    def converse(self, utterances, lang=None):
         """ Handle conversation.
 
         This method gets a peek at utterances before the normal intent
@@ -595,7 +595,7 @@ class MycroftSkill:
 
         Args:
             utterances (list): The utterances from the user
-            lang:       language the utterance is in
+            lang:       language the utterance is in, None for default
 
         Returns:
             bool: True if an utterance was handled, otherwise False
@@ -610,7 +610,7 @@ class MycroftSkill:
         """
         event = Event()
 
-        def converse(utterances, lang="en-us"):
+        def converse(utterances, lang=None):
             converse.response = utterances[0] if utterances else None
             event.set()
             return True

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -20,6 +20,7 @@ from adapt.intent import IntentBuilder
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import open_intent_envelope
+from mycroft.util.lang import set_active_lang
 from mycroft.util.log import LOG
 from mycroft.util.parse import normalize
 from mycroft.metrics import report_timing, Stopwatch
@@ -208,6 +209,7 @@ class IntentService:
     def reset_converse(self, message):
         """Let skills know there was a problem with speech recognition"""
         lang = message.data.get('lang', "en-us")
+        set_active_lang(lang)
         for skill in self.active_skills:
             self.do_converse(None, skill[0], lang)
 
@@ -309,6 +311,7 @@ class IntentService:
         try:
             # Get language of the utterance
             lang = message.data.get('lang', "en-us")
+            set_active_lang(lang)
             utterances = message.data.get('utterances', '')
 
             stopwatch = Stopwatch()

--- a/mycroft/util/format.py
+++ b/mycroft/util/format.py
@@ -539,7 +539,7 @@ def join_list(items, connector, sep=None, lang=None):
     else:
         sep += " "
     return (sep.join(str(item) for item in items[:-1]) +
-            " " + _translate_word(connector, get_full_lang_code(lang)) +
+            " " + _translate_word(connector, lang) +
             " " + items[-1])
 
 

--- a/mycroft/util/format.py
+++ b/mycroft/util/format.py
@@ -15,6 +15,8 @@
 
 from os.path import join
 
+from mycroft.util.lang import get_full_lang_code, get_primary_lang_code
+
 from mycroft.util.lang.format_en import *
 from mycroft.util.lang.format_pt import *
 from mycroft.util.lang.format_it import *
@@ -57,7 +59,9 @@ def _translate_word(name, lang):
     """
     from mycroft.util import resolve_resource_file
 
-    filename = resolve_resource_file(join("text", lang, name+".word"))
+    lang_code = get_full_lang_code(lang)
+
+    filename = resolve_resource_file(join("text", lang_code, name+".word"))
     if filename:
         # open the file
         try:
@@ -86,11 +90,13 @@ class DateTimeFormat:
     def cache(self, lang):
         if lang not in self.lang_config:
             try:
+                # Attempt to load the language-specific formatting data
                 with open(self.config_path + '/' + lang + '/date_time.json',
                           'r') as lang_config_file:
                     self.lang_config[lang] = json.loads(
                         lang_config_file.read())
             except FileNotFoundError:
+                # Fallback to English formatting
                 with open(self.config_path + '/en-us/date_time.json',
                           'r') as lang_config_file:
                     self.lang_config[lang] = json.loads(
@@ -237,7 +243,7 @@ date_time_format = DateTimeFormat(
     os.path.dirname(os.path.abspath(__file__)) + '/../res/text')
 
 
-def nice_number(number, lang="en-us", speech=True, denominators=None):
+def nice_number(number, lang=None, speech=True, denominators=None):
     """Format a float to human readable functions
 
     This function formats a float to human understandable functions. Like
@@ -251,26 +257,26 @@ def nice_number(number, lang="en-us", speech=True, denominators=None):
         (str): The formatted string.
     """
     # Convert to spoken representation in appropriate language
-    lang_lower = str(lang).lower()
-    if lang_lower.startswith("en"):
+    lang_code = get_primary_lang_code(lang)
+    if lang_code == "en":
         return nice_number_en(number, speech, denominators)
-    elif lang_lower.startswith("es"):
+    elif lang_code == "es":
         return nice_number_es(number, speech, denominators)
-    elif lang_lower.startswith("pt"):
+    elif lang_code == "pt":
         return nice_number_pt(number, speech, denominators)
-    elif lang_lower.startswith("it"):
+    elif lang_code == "it":
         return nice_number_it(number, speech, denominators)
-    elif lang_lower.startswith("fr"):
+    elif lang_code == "fr":
         return nice_number_fr(number, speech, denominators)
-    elif lang_lower.startswith("sv"):
+    elif lang_code == "sv":
         return nice_number_sv(number, speech, denominators)
-    elif lang_lower.startswith("de"):
+    elif lang_code == "de":
         return nice_number_de(number, speech, denominators)
-    elif lang_lower.startswith("hu"):
+    elif lang_code == "hu":
         return nice_number_hu(number, speech, denominators)
-    elif lang_lower.startswith("nl"):
+    elif lang_code == "nl":
         return nice_number_nl(number, speech, denominators)
-    elif lang_lower.startswith("da"):
+    elif lang_code == "da":
         return nice_number_da(number, speech, denominators)
 
     # Default to the raw number for unsupported languages,
@@ -278,7 +284,7 @@ def nice_number(number, lang="en-us", speech=True, denominators=None):
     return str(number)
 
 
-def nice_time(dt, lang="en-us", speech=True, use_24hour=False,
+def nice_time(dt, lang=None, speech=True, use_24hour=False,
               use_ampm=False):
     """
     Format a time to a comfortable human format
@@ -295,29 +301,29 @@ def nice_time(dt, lang="en-us", speech=True, use_24hour=False,
     Returns:
         (str): The formatted time string
     """
-    lang_lower = str(lang).lower()
-    if lang_lower.startswith("en"):
+    lang_code = get_primary_lang_code(lang)
+    if lang_code == "en":
         return nice_time_en(dt, speech, use_24hour, use_ampm)
-    elif lang_lower.startswith("es"):
+    elif lang_code == "es":
         return nice_time_es(dt, speech, use_24hour, use_ampm)
-    elif lang_lower.startswith("it"):
+    elif lang_code == "it":
         return nice_time_it(dt, speech, use_24hour, use_ampm)
-    elif lang_lower.startswith("fr"):
+    elif lang_code == "fr":
         return nice_time_fr(dt, speech, use_24hour, use_ampm)
-    elif lang_lower.startswith("de"):
+    elif lang_code == "de":
         return nice_time_de(dt, speech, use_24hour, use_ampm)
-    elif lang_lower.startswith("hu"):
+    elif lang_code == "hu":
         return nice_time_hu(dt, speech, use_24hour, use_ampm)
-    elif lang_lower.startswith("nl"):
+    elif lang_code == "nl":
         return nice_time_nl(dt, speech, use_24hour, use_ampm)
-    elif lang_lower.startswith("da"):
+    elif lang_code == "da":
         return nice_time_da(dt, speech, use_24hour, use_ampm)
 
     # TODO: Other languages
     return str(dt)
 
 
-def pronounce_number(number, lang="en-us", places=2, short_scale=True,
+def pronounce_number(number, lang=None, places=2, short_scale=True,
                      scientific=False):
     """
     Convert a number to it's spoken equivalent
@@ -332,33 +338,33 @@ def pronounce_number(number, lang="en-us", places=2, short_scale=True,
     Returns:
         (str): The pronounced number
     """
-    lang_lower = str(lang).lower()
-    if lang_lower.startswith("en"):
+    lang_code = get_primary_lang_code(lang)
+    if lang_code == "en":
         return pronounce_number_en(number, places=places,
                                    short_scale=short_scale,
                                    scientific=scientific)
-    elif lang_lower.startswith("it"):
+    elif lang_code == "it":
         return pronounce_number_it(number, places=places,
                                    short_scale=short_scale,
                                    scientific=scientific)
-    elif lang_lower.startswith("es"):
+    elif lang_code == "es":
         return pronounce_number_es(number, places=places)
-    elif lang_lower.startswith("fr"):
+    elif lang_code == "fr":
         return pronounce_number_fr(number, places=places)
-    elif lang_lower.startswith("de"):
+    elif lang_code == "de":
         return pronounce_number_de(number, places=places)
-    elif lang_lower.startswith("hu"):
+    elif lang_code == "hu":
         return pronounce_number_hu(number, places=places)
-    elif lang_lower.startswith("nl"):
+    elif lang_code == "nl":
         return pronounce_number_nl(number, places=places)
-    elif lang_lower.startswith("da"):
+    elif lang_code == "da":
         return pronounce_number_da(number, places=places)
 
     # Default to just returning the numeric value
     return str(number)
 
 
-def nice_date(dt, lang='en-us', now=None):
+def nice_date(dt, lang=None, now=None):
     """
     Format a datetime to a pronounceable date
 
@@ -374,13 +380,13 @@ def nice_date(dt, lang='en-us', now=None):
     Returns:
         (str): The formatted date string
     """
+    full_code = get_full_lang_code(lang)
+    date_time_format.cache(full_code)
 
-    date_time_format.cache(lang)
-
-    return date_time_format.date_format(dt, lang, now)
+    return date_time_format.date_format(dt, full_code, now)
 
 
-def nice_date_time(dt, lang='en-us', now=None, use_24hour=False,
+def nice_date_time(dt, lang=None, now=None, use_24hour=False,
                    use_ampm=False):
     """
         Format a datetime to a pronounceable date and time
@@ -402,13 +408,14 @@ def nice_date_time(dt, lang='en-us', now=None, use_24hour=False,
             (str): The formatted date time string
     """
 
-    date_time_format.cache(lang)
+    full_code = get_full_lang_code(lang)
+    date_time_format.cache(full_code)
 
-    return date_time_format.date_time_format(dt, lang, now, use_24hour,
+    return date_time_format.date_time_format(dt, full_code, now, use_24hour,
                                              use_ampm)
 
 
-def nice_year(dt, lang='en-us', bc=False):
+def nice_year(dt, lang=None, bc=False):
     """
         Format a datetime to a pronounceable year
 
@@ -424,12 +431,13 @@ def nice_year(dt, lang='en-us', bc=False):
             (str): The formatted year string
     """
 
-    date_time_format.cache(lang)
+    full_code = get_full_lang_code(lang)
+    date_time_format.cache(full_code)
 
-    return date_time_format.year_format(dt, lang, bc)
+    return date_time_format.year_format(dt, full_code, bc)
 
 
-def nice_duration(duration, lang="en-us", speech=True):
+def nice_duration(duration, lang=None, speech=True):
     """ Convert duration in seconds to a nice spoken timespan
 
     Examples:
@@ -438,6 +446,7 @@ def nice_duration(duration, lang="en-us", speech=True):
 
     Args:
         duration: time, in seconds
+        lang (str, optional): a BCP-47 language code, None for default
         speech (bool): format for speech (True) or display (False)
     Returns:
         str: timespan as a string
@@ -505,7 +514,7 @@ def nice_duration(duration, lang="en-us", speech=True):
     return out
 
 
-def join_list(items, connector, sep=None, lang="en-us"):
+def join_list(items, connector, sep=None, lang=None):
     """ Join a list into a phrase using the given connector word
 
     Examples:
@@ -530,7 +539,8 @@ def join_list(items, connector, sep=None, lang="en-us"):
     else:
         sep += " "
     return (sep.join(str(item) for item in items[:-1]) +
-            " " + _translate_word(connector, lang) + " " + items[-1])
+            " " + _translate_word(connector, get_full_lang_code(lang)) +
+            " " + items[-1])
 
 
 def expand_options(parentheses_line: str) -> list:

--- a/mycroft/util/lang/__init__.py
+++ b/mycroft/util/lang/__init__.py
@@ -12,3 +12,59 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+__active_lang = "en-us"  # English is the default active language
+# TODO: Should this really be stored in the user config file?
+
+
+def get_active_lang():
+    """ Get the active full language code (BCP-47)
+
+    Returns:
+        str: A BCP-47 language code, e.g. ("en-us", or "pt-pt")
+    """
+    return __active_lang
+
+
+def set_active_lang(lang_code):
+    """ Set the active BCP-47 language code to be used in formatting/parsing
+
+    Args:
+        lang (str): BCP-47 language code, e.g. "en-us" or "es-mx"
+    """
+    global __active_lang
+    if __active_lang != lang_code:
+        # TODO: Validate lang codes?
+        __active_lang = lang_code
+
+
+def get_primary_lang_code(lang=None):
+    """ Get the primary language code
+
+    Args:
+        lang (str, optional): A BCP-47 language code, or None for default
+
+    Returns:
+        str: A primary language family, such as "en", "de" or "pt"
+    """
+    # split on the hyphen and only return the primary-language code
+    # NOTE: This is typically a two character code.  The standard allows
+    #       1, 2, 3 and 4 character codes.  In the future we can consider
+    #       mapping from the 3 to 2 character codes, for example.  But for
+    #       now we can just be careful in use.
+    return get_full_lang_code(lang).split("-")[0]
+
+
+def get_full_lang_code(lang=None):
+    """ Get the full language code
+
+    Args:
+        lang (str, optional): A BCP-47 language code, or None for default
+
+    Returns:
+        str: A full language code, such as "en-us" or "de-de"
+    """
+    if not lang:
+        lang = __active_lang
+
+    return lang or "en-us"

--- a/mycroft/util/lang/parse_it.py
+++ b/mycroft/util/lang/parse_it.py
@@ -1289,7 +1289,7 @@ def get_gender_it(word, raw_string=""):
     TODO: check if useful
     """
 
-    gender = False
+    gender = None
     words = raw_string.split(' ')
     for idx, w in enumerate(words):
         if w == word and idx != 0:

--- a/mycroft/util/lang/parse_pt.py
+++ b/mycroft/util/lang/parse_pt.py
@@ -1185,7 +1185,7 @@ def pt_pruning(text, symbols=True, accents=True, agressive=True):
 
 def get_gender_pt(word, raw_string=""):
     word = word.rstrip("s")
-    gender = False
+    gender = None
     words = raw_string.split(" ")
     for idx, w in enumerate(words):
         if w == word and idx != 0:

--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -16,6 +16,7 @@
 #
 from difflib import SequenceMatcher
 from mycroft.util.time import now_local
+from mycroft.util.lang import get_primary_lang_code
 
 from mycroft.util.lang.parse_en import *
 from mycroft.util.lang.parse_pt import *
@@ -93,7 +94,7 @@ def match_one(query, choices):
         return best
 
 
-def extract_numbers(text, short_scale=True, ordinals=False, lang="en-us"):
+def extract_numbers(text, short_scale=True, ordinals=False, lang=None):
     """
         Takes in a string and extracts a list of numbers.
 
@@ -104,24 +105,25 @@ def extract_numbers(text, short_scale=True, ordinals=False, lang="en-us"):
             is now common in most English speaking countries.
             See https://en.wikipedia.org/wiki/Names_of_large_numbers
         ordinals (bool): consider ordinal numbers, e.g. third=3 instead of 1/3
-        lang (str): the BCP-47 code for the language to use
+        lang (str): the BCP-47 code for the language to use, None uses default
     Returns:
-        list: list of extracted numbers as floats
+        list: list of extracted numbers as floats, or empty list if none found
     """
-    if lang.startswith("en"):
+    lang_code = get_primary_lang_code(lang)
+    if lang_code == "en":
         return extract_numbers_en(text, short_scale, ordinals)
-    elif lang.startswith("de"):
+    elif lang_code == "de":
         return extract_numbers_de(text, short_scale, ordinals)
-    elif lang.startswith("fr"):
+    elif lang_code == "fr":
         return extract_numbers_fr(text, short_scale, ordinals)
-    elif lang.startswith("it"):
+    elif lang_code == "it":
         return extract_numbers_it(text, short_scale, ordinals)
-    elif lang.startswith("da"):
+    elif lang_code == "da":
         return extract_numbers_da(text, short_scale, ordinals)
     return []
 
 
-def extract_number(text, short_scale=True, ordinals=False, lang="en-us"):
+def extract_number(text, short_scale=True, ordinals=False, lang=None):
     """Takes in a string and extracts a number.
 
     Args:
@@ -131,29 +133,29 @@ def extract_number(text, short_scale=True, ordinals=False, lang="en-us"):
             is now common in most English speaking countries.
             See https://en.wikipedia.org/wiki/Names_of_large_numbers
         ordinals (bool): consider ordinal numbers, e.g. third=3 instead of 1/3
-        lang (str): the BCP-47 code for the language to use
+        lang (str): the BCP-47 code for the language to use, None uses default
     Returns:
         (int, float or False): The number extracted or False if the input
                                text contains no numbers
     """
-    lang_lower = str(lang).lower()
-    if lang_lower.startswith("en"):
+    lang_code = get_primary_lang_code(lang)
+    if lang_code == "en":
         return extractnumber_en(text, short_scale=short_scale,
                                 ordinals=ordinals)
-    elif lang_lower.startswith("es"):
+    elif lang_code == "es":
         return extractnumber_es(text)
-    elif lang_lower.startswith("pt"):
+    elif lang_code == "pt":
         return extractnumber_pt(text)
-    elif lang_lower.startswith("it"):
+    elif lang_code == "it":
         return extractnumber_it(text, short_scale=short_scale,
                                 ordinals=ordinals)
-    elif lang_lower.startswith("fr"):
+    elif lang_code == "fr":
         return extractnumber_fr(text)
-    elif lang_lower.startswith("sv"):
+    elif lang_code == "sv":
         return extractnumber_sv(text)
-    elif lang_lower.startswith("de"):
+    elif lang_code == "de":
         return extractnumber_de(text)
-    elif lang_lower.startswith("da"):
+    elif lang_code == "da":
         return extractnumber_da(text)
     # TODO: extractnumber_xx for other languages
     _log_unsupported_language(lang_lower,
@@ -161,7 +163,7 @@ def extract_number(text, short_scale=True, ordinals=False, lang="en-us"):
     return text
 
 
-def extract_duration(text, lang="en-us"):
+def extract_duration(text, lang=None):
     """ Convert an english phrase into a number of seconds
 
     Convert things like:
@@ -178,7 +180,7 @@ def extract_duration(text, lang="en-us"):
 
     Args:
         text (str): string containing a duration
-        lang (str): the BCP-47 code for the language to use
+        lang (str): the BCP-47 code for the language to use, None uses default
 
     Returns:
         (timedelta, str):
@@ -187,17 +189,17 @@ def extract_duration(text, lang="en-us"):
                     be None if no duration is found. The text returned
                     will have whitespace stripped from the ends.
     """
-    lang_lower = str(lang).lower()
+    lang_code = get_primary_lang_code(lang)
 
-    if lang_lower.startswith("en"):
+    if lang_code == "en":
         return extract_duration_en(text)
 
     # TODO: extract_duration for other languages
-    _log_unsupported_language(lang_lower, ['en'])
+    _log_unsupported_language(lang_code, ['en'])
     return None
 
 
-def extract_datetime(text, anchorDate=None, lang="en-us", default_time=None):
+def extract_datetime(text, anchorDate=None, lang=None, default_time=None):
     """
     Extracts date and time information from a sentence.  Parses many of the
     common ways that humans express dates and times, including relative dates
@@ -215,7 +217,7 @@ def extract_datetime(text, anchorDate=None, lang="en-us", default_time=None):
         anchorDate (:obj:`datetime`, optional): the date to be used for
             relative dating (for example, what does "tomorrow" mean?).
             Defaults to the current local date/time.
-        lang (string): the BCP-47 code for the language to use
+        lang (str): the BCP-47 code for the language to use, None uses default
         default_time (datetime.time): time to use if none was found in
             the input string.
 
@@ -249,79 +251,94 @@ def extract_datetime(text, anchorDate=None, lang="en-us", default_time=None):
         None
     """
 
-    lang_lower = str(lang).lower()
+    lang_code = get_primary_lang_code(lang)
 
     if not anchorDate:
         anchorDate = now_local()
 
-    if lang_lower.startswith("en"):
+    if lang_code == "en":
         return extract_datetime_en(text, anchorDate, default_time)
-    elif lang_lower.startswith("es"):
+    elif lang_code == "es":
         return extract_datetime_es(text, anchorDate, default_time)
-    elif lang_lower.startswith("pt"):
+    elif lang_code == "pt":
         return extract_datetime_pt(text, anchorDate, default_time)
-    elif lang_lower.startswith("it"):
+    elif lang_code == "it":
         return extract_datetime_it(text, anchorDate, default_time)
-    elif lang_lower.startswith("fr"):
+    elif lang_code == "fr":
         return extract_datetime_fr(text, anchorDate, default_time)
-    elif lang_lower.startswith("sv"):
+    elif lang_code == "sv":
         return extract_datetime_sv(text, anchorDate, default_time)
-    elif lang_lower.startswith("de"):
+    elif lang_code == "de":
         return extract_datetime_de(text, anchorDate, default_time)
-    elif lang_lower.startswith("da"):
+    elif lang_code == "da":
         return extract_datetime_da(text, anchorDate, default_time)
     # TODO: extract_datetime for other languages
-    _log_unsupported_language(lang_lower,
+    _log_unsupported_language(lang_code,
                               ['en', 'es', 'pt', 'it', 'fr', 'sv', 'de', 'da'])
     return text
-    # ==============================================================
 
 
-def normalize(text, lang="en-us", remove_articles=True):
+def normalize(text, lang=None, remove_articles=True):
     """Prepare a string for parsing
 
     This function prepares the given text for parsing by making
     numbers consistent, getting rid of contractions, etc.
+
     Args:
         text (str): the string to normalize
-        lang (str): the code for the language text is in
+        lang (str): the BCP-47 code for the language to use, None uses default
         remove_articles (bool): whether to remove articles (like 'a', or
                                 'the'). True by default.
+
     Returns:
         (str): The normalized string.
     """
 
-    lang_lower = str(lang).lower()
-    if lang_lower.startswith("en"):
+    lang_code = get_primary_lang_code(lang)
+
+    if lang_code == "en":
         return normalize_en(text, remove_articles)
-    elif lang_lower.startswith("es"):
+    elif lang_code == "es":
         return normalize_es(text, remove_articles)
-    elif lang_lower.startswith("pt"):
+    elif lang_code == "pt":
         return normalize_pt(text, remove_articles)
-    elif lang_lower.startswith("it"):
+    elif lang_code == "it":
         return normalize_it(text, remove_articles)
-    elif lang_lower.startswith("fr"):
+    elif lang_code == "fr":
         return normalize_fr(text, remove_articles)
-    elif lang_lower.startswith("sv"):
+    elif lang_code == "sv":
         return normalize_sv(text, remove_articles)
-    elif lang_lower.startswith("de"):
+    elif lang_code == "de":
         return normalize_de(text, remove_articles)
-    elif lang_lower.startswith("da"):
+    elif lang_code == "da":
         return normalize_da(text, remove_articles)
     # TODO: Normalization for other languages
-    _log_unsupported_language(lang_lower,
+    _log_unsupported_language(lang_code,
                               ['en', 'es', 'pt', 'it', 'fr', 'sv', 'de', 'da'])
     return text
 
 
-def get_gender(word, input_string="", lang="en-us"):
-    '''
-    guess gender of word, optionally use raw input text for context
-    returns "m" if the word is male, "f" if female, False if unknown
-    '''
-    if "pt" in lang or "es" in lang:
+def get_gender(word, context="", lang=None):
+    """ Guess the gender of a word
+
+    Some languages assign genders to specific words.  This method will attempt
+    to determine the gender, optionally using the provided context sentence.
+
+    Args:
+        word (str): The word to look up
+        context (str, optional): String containing word, for context
+        lang (str): the BCP-47 code for the language to use, None uses default
+
+    Returns:
+        str: The code "m" (male), "f" (female) or "n" (neutral) for the gender,
+             or None if unknown/or unused in the given language.
+    """
+
+    lang_code = get_primary_lang_code(lang)
+
+    if lang_code in ["pt", "es"]:
         # spanish follows same rules
-        return get_gender_pt(word, input_string)
-    elif "it" in lang:
-        return get_gender_it(word, input_string)
-    return False
+        return get_gender_pt(word, context)
+    elif lang_code == "it":
+        return get_gender_it(word, context)
+    return None

--- a/test/unittests/util/test_format_de.py
+++ b/test/unittests/util/test_format_de.py
@@ -17,6 +17,7 @@
 import unittest
 import datetime
 
+from mycroft.util.lang import get_active_lang, set_active_lang
 from mycroft.util.format import nice_number
 from mycroft.util.format import nice_time
 from mycroft.util.format import pronounce_number
@@ -72,33 +73,40 @@ class TestNiceResponse(unittest.TestCase):
 
 
 class TestNiceNumberFormat(unittest.TestCase):
+    def setUp(self):
+        self.old_lang = get_active_lang()
+        set_active_lang("de-de")
+
+    def tearDown(self):
+        set_active_lang(self.old_lang)
+
     def test_convert_float_to_nice_number(self):
         for number, number_str in NUMBERS_FIXTURE_DE.items():
-            self.assertEqual(nice_number(number, lang="de-de"), number_str,
+            self.assertEqual(nice_number(number), number_str,
                              'should format {} as {} and not {}'.format(
                                  number, number_str,
-                                 nice_number(number, lang="de-de")))
+                                 nice_number(number)))
 
     def test_specify_denominator(self):
-        self.assertEqual(nice_number(5.5, lang="de-de",
+        self.assertEqual(nice_number(5.5,
                                      denominators=[1, 2, 3]), '5 und ein halb',
                          'should format 5.5 as 5 und ein halb not {}'.format(
                              nice_number(5.5, denominators=[1, 2, 3])))
-        self.assertEqual(nice_number(2.333, lang="de-de", denominators=[1, 2]),
+        self.assertEqual(nice_number(2.333, denominators=[1, 2]),
                          '2,333',
                          'should format 2,333 as 2,333 not {}'.format(
-                             nice_number(2.333, lang="de-de",
+                             nice_number(2.333,
                                          denominators=[1, 2])))
 
     def test_no_speech(self):
         self.assertEqual(nice_number(6.777, speech=False),
                          '6 7/9',
                          'should format 6.777 as 6 7/9 not {}'.format(
-                             nice_number(6.777, lang="de-de", speech=False)))
+                             nice_number(6.777, speech=False)))
         self.assertEqual(nice_number(6.0, speech=False),
                          '6',
                          'should format 6.0 as 6 not {}'.format(
-                             nice_number(6.0, lang="de-de", speech=False)))
+                             nice_number(6.0, speech=False)))
 
 
 class TestPronounceOrdinal(unittest.TestCase):
@@ -120,265 +128,277 @@ class TestPronounceOrdinal(unittest.TestCase):
 
 # def pronounce_number(number, lang="de-de", places=2):
 class TestPronounceNumber(unittest.TestCase):
+    def setUp(self):
+        self.old_lang = mycroft.util.lang.active_lang
+        mycroft.util.lang.active_lang = "de-de"
+
+    def tearDown(self):
+        mycroft.util.lang.active_lang = self.old_lang
+
     def test_convert_int_de(self):
-        self.assertEqual(pronounce_number(123456789123456789, lang="de-de"),
+        self.assertEqual(pronounce_number(123456789123456789),
                          "einhundertdreiundzwanzig Billiarden "
                          "vierhundertsechsundfünfzig Billionen "
                          "siebenhundertneunundachtzig Milliarden "
                          "einhundertdreiundzwanzig Millionen "
                          "vierhundertsechsundfünfzigtausendsiebenhundert"
                          "neunundachtzig")
-        self.assertEqual(pronounce_number(1, lang="de-de"), "eins")
-        self.assertEqual(pronounce_number(10, lang="de-de"), "zehn")
-        self.assertEqual(pronounce_number(15, lang="de-de"), u"fünfzehn")
-        self.assertEqual(pronounce_number(20, lang="de-de"), "zwanzig")
-        self.assertEqual(pronounce_number(27, lang="de-de"),
-                         "siebenundzwanzig")
-        self.assertEqual(pronounce_number(30, lang="de-de"), u"dreißig")
-        self.assertEqual(pronounce_number(33, lang="de-de"), u"dreiunddreißig")
-        self.assertEqual(pronounce_number(71, lang="de-de"),
-                         "einundsiebzig")
-        self.assertEqual(pronounce_number(80, lang="de-de"), "achtzig")
-        self.assertEqual(pronounce_number(74, lang="de-de"),
-                         "vierundsiebzig")
-        self.assertEqual(pronounce_number(79, lang="de-de"),
-                         "neunundsiebzig")
-        self.assertEqual(pronounce_number(91, lang="de-de"),
-                         "einundneunzig")
-        self.assertEqual(pronounce_number(97, lang="de-de"),
-                         "siebenundneunzig")
-        self.assertEqual(pronounce_number(300, lang="de-de"), "dreihundert")
+        self.assertEqual(pronounce_number(1), "eins")
+        self.assertEqual(pronounce_number(10), "zehn")
+        self.assertEqual(pronounce_number(15), u"fünfzehn")
+        self.assertEqual(pronounce_number(20), "zwanzig")
+        self.assertEqual(pronounce_number(27), "siebenundzwanzig")
+        self.assertEqual(pronounce_number(30), u"dreißig")
+        self.assertEqual(pronounce_number(33), u"dreiunddreißig")
+
+        self.assertEqual(pronounce_number(71), "einundsiebzig")
+        self.assertEqual(pronounce_number(80), "achtzig")
+        self.assertEqual(pronounce_number(74), "vierundsiebzig")
+        self.assertEqual(pronounce_number(79), "neunundsiebzig")
+        self.assertEqual(pronounce_number(91), "einundneunzig")
+        self.assertEqual(pronounce_number(97), "siebenundneunzig")
+        self.assertEqual(pronounce_number(300), "dreihundert")
 
     def test_convert_negative_int_de(self):
-        self.assertEqual(pronounce_number(-1, lang="de-de"), "minus eins")
-        self.assertEqual(pronounce_number(-10, lang="de-de"), "minus zehn")
-        self.assertEqual(pronounce_number(-15, lang="de-de"),
-                         u"minus fünfzehn")
-        self.assertEqual(pronounce_number(-20, lang="de-de"), "minus zwanzig")
-        self.assertEqual(pronounce_number(-27, lang="de-de"),
-                         "minus siebenundzwanzig")
-        self.assertEqual(pronounce_number(-30, lang="de-de"), u"minus dreißig")
-        self.assertEqual(pronounce_number(-33, lang="de-de"),
-                         u"minus dreiunddreißig")
+        self.assertEqual(pronounce_number(-1), "minus eins")
+        self.assertEqual(pronounce_number(-10), "minus zehn")
+        self.assertEqual(pronounce_number(-15), u"minus fünfzehn")
+        self.assertEqual(pronounce_number(-20), "minus zwanzig")
+        self.assertEqual(pronounce_number(-27), "minus siebenundzwanzig")
+        self.assertEqual(pronounce_number(-30), u"minus dreißig")
+        self.assertEqual(pronounce_number(-33), u"minus dreiunddreißig")
 
     def test_convert_decimals_de(self):
-        self.assertEqual(pronounce_number(1.234, lang="de-de"),
+        self.assertEqual(pronounce_number(1.234),
                          "eins Komma zwei drei")
-        self.assertEqual(pronounce_number(21.234, lang="de-de"),
+        self.assertEqual(pronounce_number(21.234),
                          "einundzwanzig Komma zwei drei")
-        self.assertEqual(pronounce_number(21.234, lang="de-de", places=1),
+        self.assertEqual(pronounce_number(21.234, places=1),
                          "einundzwanzig Komma zwei")
-        self.assertEqual(pronounce_number(21.234, lang="de-de", places=0),
+        self.assertEqual(pronounce_number(21.234, places=0),
                          "einundzwanzig")
-        self.assertEqual(pronounce_number(21.234, lang="de-de", places=3),
+        self.assertEqual(pronounce_number(21.234, places=3),
                          "einundzwanzig Komma zwei drei vier")
-        self.assertEqual(pronounce_number(21.234, lang="de-de", places=4),
+        self.assertEqual(pronounce_number(21.234, places=4),
                          "einundzwanzig Komma zwei drei vier null")
-        self.assertEqual(pronounce_number(21.234, lang="de-de", places=5),
+        self.assertEqual(pronounce_number(21.234, places=5),
                          "einundzwanzig Komma zwei drei vier null null")
-        self.assertEqual(pronounce_number(-1.234, lang="de-de"),
+        self.assertEqual(pronounce_number(-1.234),
                          "minus eins Komma zwei drei")
-        self.assertEqual(pronounce_number(-21.234, lang="de-de"),
+        self.assertEqual(pronounce_number(-21.234),
                          "minus einundzwanzig Komma zwei drei")
-        self.assertEqual(pronounce_number(-21.234, lang="de-de", places=1),
+        self.assertEqual(pronounce_number(-21.234, places=1),
                          "minus einundzwanzig Komma zwei")
-        self.assertEqual(pronounce_number(-21.234, lang="de-de", places=0),
+        self.assertEqual(pronounce_number(-21.234, places=0),
                          "minus einundzwanzig")
-        self.assertEqual(pronounce_number(-21.234, lang="de-de", places=3),
+        self.assertEqual(pronounce_number(-21.234, places=3),
                          "minus einundzwanzig Komma zwei drei vier")
-        self.assertEqual(pronounce_number(-21.234, lang="de-de", places=4),
+        self.assertEqual(pronounce_number(-21.234, places=4),
                          "minus einundzwanzig Komma zwei drei vier null")
-        self.assertEqual(pronounce_number(-21.234, lang="de-de", places=5),
+        self.assertEqual(pronounce_number(-21.234, places=5),
                          "minus einundzwanzig Komma zwei drei vier null null")
 
 
 # def nice_time(dt, lang="de-de", speech=True, use_24hour=False,
 #              use_ampm=False):
 class TestNiceDateFormat_de(unittest.TestCase):
+    def setUp(self):
+        self.old_lang = get_active_lang()
+        set_active_lang("de-de")
+
+    def tearDown(self):
+        set_active_lang(self.old_lang)
+
     def test_convert_times_de(self):
         dt = datetime.datetime(2017, 1, 31,
                                13, 22, 3)
 
-        self.assertEqual(nice_time(dt, lang="de-de"),
+        self.assertEqual(nice_time(dt),
                          "ein Uhr zweiundzwanzig")
-        self.assertEqual(nice_time(dt, lang="de-de", use_ampm=True),
+        self.assertEqual(nice_time(dt, use_ampm=True),
                          "ein Uhr zweiundzwanzig nachmittags")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False),
+        self.assertEqual(nice_time(dt, speech=False),
                          "1:22")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_ampm=True),
                          "1:22 PM")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True),
                          "13:22")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True, use_ampm=True),
                          "13:22")
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True,
+        self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=True),
                          "dreizehn Uhr zweiundzwanzig")
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True,
+        self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=False),
                          "dreizehn Uhr zweiundzwanzig")
 
         dt = datetime.datetime(2017, 1, 31,
                                13, 0, 3)
-        self.assertEqual(nice_time(dt, lang="de-de"),
+        self.assertEqual(nice_time(dt),
                          "ein Uhr")
-        self.assertEqual(nice_time(dt, lang="de-de", use_ampm=True),
+        self.assertEqual(nice_time(dt, use_ampm=True),
                          "ein Uhr nachmittags")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False),
+        self.assertEqual(nice_time(dt, speech=False),
                          "1:00")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_ampm=True),
                          "1:00 PM")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True),
                          "13:00")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True, use_ampm=True),
                          "13:00")
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True,
+        self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=True),
                          "dreizehn Uhr")
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True,
+        self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=False),
                          "dreizehn Uhr")
 
         dt = datetime.datetime(2017, 1, 31,
                                13, 2, 3)
-        self.assertEqual(nice_time(dt, lang="de-de"),
+        self.assertEqual(nice_time(dt),
                          "ein Uhr zwei")
-        self.assertEqual(nice_time(dt, lang="de-de", use_ampm=True),
+        self.assertEqual(nice_time(dt, use_ampm=True),
                          "ein Uhr zwei nachmittags")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False),
+        self.assertEqual(nice_time(dt, speech=False),
                          "1:02")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_ampm=True),
                          "1:02 PM")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True),
                          "13:02")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True, use_ampm=True),
                          "13:02")
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True,
+        self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=True),
                          "dreizehn Uhr zwei")
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True,
+        self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=False),
                          "dreizehn Uhr zwei")
 
         dt = datetime.datetime(2017, 1, 31,
                                0, 2, 3)
-        self.assertEqual(nice_time(dt, lang="de-de"),
+        self.assertEqual(nice_time(dt),
                          u"zwölf Uhr zwei")
-        self.assertEqual(nice_time(dt, lang="de-de", use_ampm=True),
+        self.assertEqual(nice_time(dt, use_ampm=True),
                          u"zwölf Uhr zwei nachts")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False),
+        self.assertEqual(nice_time(dt, speech=False),
                          "12:02")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_ampm=True),
                          "12:02 AM")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True),
                          "00:02")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True, use_ampm=True),
                          "00:02")
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True,
+        self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=True),
                          "null Uhr zwei")
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True,
+        self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=False),
                          "null Uhr zwei")
 
         dt = datetime.datetime(2017, 1, 31,
                                12, 15, 9)
-        self.assertEqual(nice_time(dt, lang="de-de"),
+        self.assertEqual(nice_time(dt),
                          u"zwölf Uhr fünfzehn")
-        self.assertEqual(nice_time(dt, lang="de-de", use_ampm=True),
+        self.assertEqual(nice_time(dt, use_ampm=True),
                          u"zwölf Uhr fünfzehn nachmittags")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False),
+        self.assertEqual(nice_time(dt, speech=False),
                          "12:15")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_ampm=True),
                          "12:15 PM")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True),
                          "12:15")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True, use_ampm=True),
                          "12:15")
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True,
+        self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=True),
                          u"zwölf Uhr fünfzehn")
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True,
+        self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=False),
                          u"zwölf Uhr fünfzehn")
 
         dt = datetime.datetime(2017, 1, 31,
                                19, 40, 49)
-        self.assertEqual(nice_time(dt, lang="de-de"),
+        self.assertEqual(nice_time(dt),
                          "sieben Uhr vierzig")
-        self.assertEqual(nice_time(dt, lang="de-de", use_ampm=True),
+        self.assertEqual(nice_time(dt, use_ampm=True),
                          "sieben Uhr vierzig abends")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False),
+        self.assertEqual(nice_time(dt, speech=False),
                          "7:40")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_ampm=True),
                          "7:40 PM")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True),
                          "19:40")
-        self.assertEqual(nice_time(dt, lang="de-de", speech=False,
+        self.assertEqual(nice_time(dt, speech=False,
                                    use_24hour=True, use_ampm=True),
                          "19:40")
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True,
+        self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=True),
                          "neunzehn Uhr vierzig")
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True,
+        self.assertEqual(nice_time(dt, use_24hour=True,
                                    use_ampm=False),
                          "neunzehn Uhr vierzig")
 
         dt = datetime.datetime(2017, 1, 31,
                                1, 15, 00)
-        self.assertEqual(nice_time(dt, lang="de-de", use_24hour=True),
+        self.assertEqual(nice_time(dt, use_24hour=True),
                          u"ein Uhr fünfzehn")
 
         dt = datetime.datetime(2017, 1, 31,
                                1, 35, 00)
-        self.assertEqual(nice_time(dt, lang="de-de"),
+        self.assertEqual(nice_time(dt),
                          u"ein Uhr fünfunddreißig")
 
         dt = datetime.datetime(2017, 1, 31,
                                1, 45, 00)
-        self.assertEqual(nice_time(dt, lang="de-de"),
+        self.assertEqual(nice_time(dt),
                          u"ein Uhr fünfundvierzig")
 
         dt = datetime.datetime(2017, 1, 31,
                                4, 50, 00)
-        self.assertEqual(nice_time(dt, lang="de-de"),
+        self.assertEqual(nice_time(dt),
                          u"vier Uhr fünfzig")
 
         dt = datetime.datetime(2017, 1, 31,
                                5, 55, 00)
-        self.assertEqual(nice_time(dt, lang="de-de"),
+        self.assertEqual(nice_time(dt),
                          u"fünf Uhr fünfundfünfzig")
 
         dt = datetime.datetime(2017, 1, 31,
                                5, 30, 00)
-        self.assertEqual(nice_time(dt, lang="de-de", use_ampm=True),
+        self.assertEqual(nice_time(dt, use_ampm=True),
                          u"fünf Uhr dreißig morgens")
 
 
 class TestJoinList_de(unittest.TestCase):
+    def setUp(self):
+        self.old_lang = get_active_lang()
+        set_active_lang("de-de")
+
+    def tearDown(self):
+        set_active_lang(self.old_lang)
+
     def test_join_list_de(self):
-        self.assertEqual(join_list(['Hallo', 'Auf wieder Sehen'], 'and',
-                                   lang='de-de'),
+        self.assertEqual(join_list(['Hallo', 'Auf wieder Sehen'], 'and'),
                          'Hallo und Auf wieder Sehen')
 
-        self.assertEqual(join_list(['A', 'B', 'C'], 'or', lang='de-de'),
+        self.assertEqual(join_list(['A', 'B', 'C'], 'or'),
                          'A, B oder C')
 
 

--- a/test/unittests/util/test_format_de.py
+++ b/test/unittests/util/test_format_de.py
@@ -129,11 +129,11 @@ class TestPronounceOrdinal(unittest.TestCase):
 # def pronounce_number(number, lang="de-de", places=2):
 class TestPronounceNumber(unittest.TestCase):
     def setUp(self):
-        self.old_lang = mycroft.util.lang.active_lang
-        mycroft.util.lang.active_lang = "de-de"
+        self.old_lang = get_active_lang()
+        set_active_lang("de-de")
 
     def tearDown(self):
-        mycroft.util.lang.active_lang = self.old_lang
+        set_active_lang(self.old_lang)
 
     def test_convert_int_de(self):
         self.assertEqual(pronounce_number(123456789123456789),

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -747,7 +747,7 @@ class TestNormalize(unittest.TestCase):
 
     def test_gender(self):
         self.assertEqual(get_gender("person"),
-                         False)
+                         None)
 
 
 if __name__ == "__main__":

--- a/test/unittests/util/test_parse_fr.py
+++ b/test/unittests/util/test_parse_fr.py
@@ -396,7 +396,7 @@ class TestNormalize_fr(unittest.TestCase):
 
     def test_gender_fr(self):
         self.assertEqual(get_gender("personne", lang="fr-fr"),
-                         False)
+                         None)
 
 
 if __name__ == "__main__":

--- a/test/unittests/util/test_parse_pt.py
+++ b/test/unittests/util/test_parse_pt.py
@@ -249,7 +249,7 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(get_gender("cavalo", lang="pt"), "m")
         self.assertEqual(get_gender("vacas", lang="pt"), "f")
         self.assertEqual(get_gender("boi", "o boi come erva", lang="pt"), "m")
-        self.assertEqual(get_gender("boi", lang="pt"), False)
+        self.assertEqual(get_gender("boi", lang="pt"), None)
         self.assertEqual(get_gender("homem", "estes homem come merda",
                                     lang="pt"), "m")
         self.assertEqual(get_gender("ponte", lang="pt"), "m")


### PR DESCRIPTION
Much of the code used "en-us" as the default value when not specified.
This limited the internationalization potential.  Changing the default
to None and adds the ability to define the default lang code from other
locations in code.  E.g.

```python

from mycroft.util.lang import set_default_lang

set_default_lang("en-us")
print("English date: "+nice_date(dt))

set_default_lang("de-de")
print("German date: "+nice_date(dt))
```

This allows easier localization of Skills by having the framework set the default without any changes necessary by the Skill writers.

Other minor changes:
* Changed the default return value of get_gender*() to None instead of False

## Description
(Description of what the PR does, such as fixes # {issue number})

## How to test
(Description of how to validate or test this PR)

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
