### PR TITLE
Fix mixing of int/str in extract_datetime_* code

### DIFF
--- a/mycroft/util/lang/parse_da.py
+++ b/mycroft/util/lang/parse_da.py
@@ -532,17 +532,17 @@ def extract_datetime_da(string, currentDate, default_time):
                         remainder = "pm"
                         used = 2
                     elif wordNext == "natten":
-                        if strHH > 4:
+                        if strHH and int(strHH) > 4:
                             remainder = "pm"
                         else:
                             remainder = "am"
                         used += 1
                     else:
                         if timeQualifier != "":
-                            if strHH <= 12 and \
+                            if strHH and int(strHH) <= 12 and \
                                     (timeQualifier == "aftenen" or
                                      timeQualifier == "eftermiddagen"):
-                                strHH += 12  # what happens when strHH is 24?
+                                strHH = str(int(strHH) + 12)
             else:
                 # try to parse # s without colons
                 # 5 hours, 10 minutes etc.
@@ -666,7 +666,7 @@ def extract_datetime_da(string, currentDate, default_time):
 
                     elif wordNext == timeQualifier:
                         strHH = word
-                        strMM = 00
+                        strMM = "00"
                         isTime = True
                         if wordNext[:10] == "eftermidag":
                             used += 1
@@ -699,17 +699,20 @@ def extract_datetime_da(string, currentDate, default_time):
                 # else:
                 #     isTime = False
 
-            strHH = int(strHH) if strHH else 0
-            strMM = int(strMM) if strMM else 0
-            strHH = strHH + 12 if remainder == "pm" and strHH < 12 else strHH
-            strHH = strHH - 12 if remainder == "am" and strHH >= 12 else strHH
-            if strHH > 24 or strMM > 59:
+            HH = int(strHH) if strHH else 0
+            MM = int(strMM) if strMM else 0
+            if remainder == "pm" and HH < 12:
+                HH += 12
+            if remainder == "am" and HH >= 12:
+                HH -= 12
+            if HH > 24 or MM > 59:
                 isTime = False
                 used = 0
             if isTime:
-                hrAbs = strHH * 1
-                minAbs = strMM * 1
+                hrAbs = HH
+                minAbs = MM
                 used += 1
+
         if used > 0:
             # removed parsed words from the sentence
             for i in range(used):

--- a/mycroft/util/lang/parse_de.py
+++ b/mycroft/util/lang/parse_de.py
@@ -543,17 +543,17 @@ def extract_datetime_de(string, currentDate, default_time):
                         remainder = "pm"
                         used = 2
                     elif wordNext == "nachts":
-                        if strHH > 4:
+                        if strHH and int(strHH) > 4:
                             remainder = "pm"
                         else:
                             remainder = "am"
                         used += 1
                     else:
                         if timeQualifier != "":
-                            if strHH <= 12 and \
+                            if strHH and int(strHH) <= 12 and \
                                     (timeQualifier == "abends" or
                                      timeQualifier == "nachmittags"):
-                                strHH += 12  # what happens when strHH is 24?
+                                strHH = str(int(strHH) + 12)
             else:
                 # try to parse # s without colons
                 # 5 hours, 10 minutes etc.
@@ -676,7 +676,7 @@ def extract_datetime_de(string, currentDate, default_time):
 
                     elif wordNext == timeQualifier:
                         strHH = word
-                        strMM = 00
+                        strMM = "00"
                         isTime = True
                         if wordNext[:10] == "nachmittag":
                             used += 1
@@ -708,17 +708,20 @@ def extract_datetime_de(string, currentDate, default_time):
                 # else:
                 #     isTime = False
 
-            strHH = int(strHH) if strHH else 0
-            strMM = int(strMM) if strMM else 0
-            strHH = strHH + 12 if remainder == "pm" and strHH < 12 else strHH
-            strHH = strHH - 12 if remainder == "am" and strHH >= 12 else strHH
-            if strHH > 24 or strMM > 59:
+            HH = int(strHH) if strHH else 0
+            MM = int(strMM) if strMM else 0
+            if remainder == "pm" and HH < 12:
+                HH += 12
+            if remainder == "am" and HH >= 12:
+                HH -= 12
+            if HH > 24 or MM > 59:
                 isTime = False
                 used = 0
             if isTime:
-                hrAbs = strHH * 1
-                minAbs = strMM * 1
+                hrAbs = HH
+                minAbs = MM
                 used += 1
+
         if used > 0:
             # removed parsed words from the sentence
             for i in range(used):

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -1139,7 +1139,7 @@ def extract_datetime_en(string, dateNow, default_time):
                             military = True
                             if strHH and int(strHH) <= 12 and \
                                     (timeQualifier in timeQualifiersPM):
-                                strHH += str(int(strHH) + 12)
+                                strHH = str(int(strHH) + 12)
             else:
                 # try to parse numbers without colons
                 # 5 hours, 10 minutes etc.

--- a/mycroft/util/lang/parse_es.py
+++ b/mycroft/util/lang/parse_es.py
@@ -887,10 +887,10 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
                         used = 2
                     else:
                         if timeQualifier != "":
-                            if strHH <= 12 and \
+                            if strHH and int(strHH) <= 12 and \
                                     (timeQualifier == u"mañana" or
                                      timeQualifier == "tarde"):
-                                strHH += 12
+                                strHH = str(int(strHH) + 12)
 
             else:
                 # try to parse # s without colons
@@ -943,8 +943,8 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
                                 wordPrev == "cero"
                             )):
                         # 0800 hours (pronounced oh-eight-hundred)
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                        strHH = str(int(word) / 100)
+                        strMM = str(int(word) - int(strHH) * 100)
                         if wordNext == "hora":
                             used += 1
                     elif (
@@ -977,8 +977,8 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
                         hrAbs = -1
                         minAbs = -1
                     elif int(word) > 100:
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                        strHH = str(int(word) / 100)
+                        strMM = str(int(word) - int(strHH) * 100)
                         if wordNext == "hora":
                             used += 1
 
@@ -995,7 +995,7 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
                                 remainder = "am"
                                 used += 1
                             elif wordNextNextNext == "noche":
-                                if 0 > strHH > 6:
+                                if strHH and 0 > int(strHH) > 6:
                                     remainder = "am"
                                 else:
                                     remainder = "pm"
@@ -1010,18 +1010,18 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
                     else:
                         isTime = False
 
-            strHH = int(strHH) if strHH else 0
-            strMM = int(strMM) if strMM else 0
-            strHH = strHH + 12 if (remainder == "pm" and
-                                   0 < strHH < 12) else strHH
-            strHH = strHH - 12 if (remainder == "am" and
-                                   0 < strHH >= 12) else strHH
-            if strHH > 24 or strMM > 59:
+            HH = int(strHH) if strHH else 0
+            MM = int(strMM) if strMM else 0
+            HH = HH + 12 if (remainder == "pm" and
+                                   0 < strHH < 12) else HH
+            HH = HH - 12 if (remainder == "am" and
+                                   0 < strHH >= 12) else HH
+            if HH > 24 or MM > 59:
                 isTime = False
                 used = 0
             if isTime:
-                hrAbs = strHH * 1
-                minAbs = strMM * 1
+                hrAbs = HH
+                minAbs = MM
                 used += 1
 
         if used > 0:

--- a/mycroft/util/lang/parse_es.py
+++ b/mycroft/util/lang/parse_es.py
@@ -943,8 +943,8 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
                                 wordPrev == "cero"
                             )):
                         # 0800 hours (pronounced oh-eight-hundred)
-                        strHH = str(int(word) / 100)
-                        strMM = str(int(word) - int(strHH) * 100)
+                        strHH = str(int(word) // 100)
+                        strMM = str(int(word) % 100)
                         if wordNext == "hora":
                             used += 1
                     elif (
@@ -977,8 +977,8 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
                         hrAbs = -1
                         minAbs = -1
                     elif int(word) > 100:
-                        strHH = str(int(word) / 100)
-                        strMM = str(int(word) - int(strHH) * 100)
+                        strHH = str(int(word) // 100)
+                        strMM = str(int(word) % 100)
                         if wordNext == "hora":
                             used += 1
 
@@ -1012,10 +1012,8 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
 
             HH = int(strHH) if strHH else 0
             MM = int(strMM) if strMM else 0
-            HH = HH + 12 if (remainder == "pm" and
-                                   0 < strHH < 12) else HH
-            HH = HH - 12 if (remainder == "am" and
-                                   0 < strHH >= 12) else HH
+            HH = HH + 12 if (remainder == "pm" and 0 < strHH < 12) else HH
+            HH = HH - 12 if (remainder == "am" and 0 < strHH >= 12) else HH
             if HH > 24 or MM > 59:
                 isTime = False
                 used = 0

--- a/mycroft/util/lang/parse_fr.py
+++ b/mycroft/util/lang/parse_fr.py
@@ -877,8 +877,8 @@ def extract_datetime_fr(string, currentDate, default_time):
                     used = 2
                 elif int(word) > 100:
                     # format militaire
-                    hrAbs = int(word) / 100
-                    minAbs = int(word) - hrAbs * 100
+                    hrAbs = int(word) // 100
+                    minAbs = int(word) % 100
                     used = 1
                     if wordNext == "heures":
                         used += 1

--- a/mycroft/util/lang/parse_it.py
+++ b/mycroft/util/lang/parse_it.py
@@ -1033,8 +1033,8 @@ def extract_datetime_it(string, dateNow, default_time):
                 str_hh = str(int(word))
                 str_mm = '00'
             elif 100 <= int(word) <= 2400:
-                str_hh = int(word) / 100
-                str_mm = int(word) - str_hh * 100
+                str_hh = int(word) // 100
+                str_mm = int(word) % 100
                 military = True
                 isTime = False
             if extractnumber_it(word) and word_next \

--- a/mycroft/util/lang/parse_pt.py
+++ b/mycroft/util/lang/parse_pt.py
@@ -970,8 +970,8 @@ def extract_datetime_pt(input_str, currentDate, default_time):
                                 wordPrev == "zero"
                             )):
                         # 0800 hours (pronounced oh-eight-hundred)
-                        strHH = str(int(word) / 100)
-                        strMM = str(int(word) - int(strHH) * 100)
+                        strHH = str(int(word) // 100)
+                        strMM = str(int(word) % 100)
                         military = True
                         if wordNext == "hora":
                             used += 1
@@ -1005,8 +1005,8 @@ def extract_datetime_pt(input_str, currentDate, default_time):
                         hrAbs = -1
                         minAbs = -1
                     elif int(word) > 100:
-                        strHH = str(int(word) / 100)
-                        strMM = str(int(word) - int(strHH) * 100)
+                        strHH = str(int(word) // 100)
+                        strMM = str(int(word) % 100)
                         military = True
                         if wordNext == "hora":
                             used += 1
@@ -1042,10 +1042,8 @@ def extract_datetime_pt(input_str, currentDate, default_time):
 
             HH = int(strHH) if strHH else 0
             MM = int(strMM) if strMM else 0
-            HH = HH + 12 if (remainder == "pm" and
-                                   0 < HH < 12) else HH
-            HH = HH - 12 if (remainder == "am" and
-                                   0 < HH >= 12) else HH
+            HH = HH + 12 if (remainder == "pm" and 0 < HH < 12) else HH
+            HH = HH - 12 if (remainder == "am" and 0 < HH >= 12) else HH
             if HH > 24 or MM > 59:
                 isTime = False
                 used = 0

--- a/mycroft/util/lang/parse_pt.py
+++ b/mycroft/util/lang/parse_pt.py
@@ -914,10 +914,10 @@ def extract_datetime_pt(input_str, currentDate, default_time):
                     else:
                         if timeQualifier != "":
                             military = True
-                            if strHH <= 12 and \
+                            if strHH and int(strHH) <= 12 and \
                                     (timeQualifier == "manha" or
                                      timeQualifier == "tarde"):
-                                strHH += 12
+                                strHH = str(int(strHH) + 12)
 
             else:
                 # try to parse # s without colons
@@ -970,8 +970,8 @@ def extract_datetime_pt(input_str, currentDate, default_time):
                                 wordPrev == "zero"
                             )):
                         # 0800 hours (pronounced oh-eight-hundred)
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                        strHH = str(int(word) / 100)
+                        strMM = str(int(word) - int(strHH) * 100)
                         military = True
                         if wordNext == "hora":
                             used += 1
@@ -1005,8 +1005,8 @@ def extract_datetime_pt(input_str, currentDate, default_time):
                         hrAbs = -1
                         minAbs = -1
                     elif int(word) > 100:
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                        strHH = str(int(word) / 100)
+                        strMM = str(int(word) - int(strHH) * 100)
                         military = True
                         if wordNext == "hora":
                             used += 1
@@ -1014,7 +1014,7 @@ def extract_datetime_pt(input_str, currentDate, default_time):
                     elif wordNext == "" or (
                             wordNext == "em" and wordNextNext == "ponto"):
                         strHH = word
-                        strMM = 00
+                        strMM = "00"
                         if wordNext == "em" and wordNextNext == "ponto":
                             used += 2
                             if wordNextNextNext == "tarde":
@@ -1040,18 +1040,18 @@ def extract_datetime_pt(input_str, currentDate, default_time):
                     else:
                         isTime = False
 
-            strHH = int(strHH) if strHH else 0
-            strMM = int(strMM) if strMM else 0
-            strHH = strHH + 12 if (remainder == "pm" and
-                                   0 < strHH < 12) else strHH
-            strHH = strHH - 12 if (remainder == "am" and
-                                   0 < strHH >= 12) else strHH
-            if strHH > 24 or strMM > 59:
+            HH = int(strHH) if strHH else 0
+            MM = int(strMM) if strMM else 0
+            HH = HH + 12 if (remainder == "pm" and
+                                   0 < HH < 12) else HH
+            HH = HH - 12 if (remainder == "am" and
+                                   0 < HH >= 12) else HH
+            if HH > 24 or MM > 59:
                 isTime = False
                 used = 0
             if isTime:
-                hrAbs = strHH * 1
-                minAbs = strMM * 1
+                hrAbs = HH
+                minAbs = MM
                 used += 1
 
         if used > 0:

--- a/mycroft/util/lang/parse_sv.py
+++ b/mycroft/util/lang/parse_sv.py
@@ -474,17 +474,17 @@ def extract_datetime_sv(string, currentDate, default_time):
                         remainder = "pm"
                         used = 2
                     elif wordNext == "at" and wordNextNext == "night":
-                        if strHH > 5:
+                        if strHH and int(strHH) > 5:
                             remainder = "pm"
                         else:
                             remainder = "am"
                         used += 2
                     else:
                         if timeQualifier != "":
-                            if strHH <= 12 and \
+                            if strHH and int(strHH) <= 12 and \
                                     (timeQualifier == "evening" or
                                      timeQualifier == "afternoon"):
-                                strHH += 12
+                                strHH = str(int(strHH) + 12)
             else:
                 # try to parse # s without colons
                 # 5 hours, 10 minutes etc.
@@ -532,8 +532,8 @@ def extract_datetime_sv(string, currentDate, default_time):
                                 wordPrev == "oh"
                             )):
                         # 0800 hours (pronounced oh-eight-hundred)
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                        strHH = str(int(word) / 100)
+                        strMM = str(int(word) - int(strHH) * 100)
                         if wordNext == "hours":
                             used += 1
                     elif (
@@ -565,8 +565,8 @@ def extract_datetime_sv(string, currentDate, default_time):
                         hrAbs = -1
                         minAbs = -1
                     elif int(word) > 100:
-                        strHH = int(word) / 100
-                        strMM = int(word) - strHH * 100
+                        strHH = str(int(word) / 100)
+                        strMM = str(int(word) - int(strHH) * 100)
                         if wordNext == "hours":
                             used += 1
                     elif wordNext[0].isdigit():
@@ -585,7 +585,7 @@ def extract_datetime_sv(string, currentDate, default_time):
                                         )
                             )):
                         strHH = word
-                        strMM = 00
+                        strMM = "00"
                         if wordNext == "o'clock":
                             used += 1
                         if wordNext == "in" or wordNextNext == "in":
@@ -616,16 +616,16 @@ def extract_datetime_sv(string, currentDate, default_time):
                     else:
                         isTime = False
 
-            strHH = int(strHH) if strHH else 0
-            strMM = int(strMM) if strMM else 0
-            strHH = strHH + 12 if remainder == "pm" and strHH < 12 else strHH
-            strHH = strHH - 12 if remainder == "am" and strHH >= 12 else strHH
-            if strHH > 24 or strMM > 59:
+            HH = int(strHH) if strHH else 0
+            MM = int(strMM) if strMM else 0
+            HH = HH + 12 if remainder == "pm" and HH < 12 else HH
+            HH = HH - 12 if remainder == "am" and HH >= 12 else HH
+            if HH > 24 or MM > 59:
                 isTime = False
                 used = 0
             if isTime:
-                hrAbs = strHH * 1
-                minAbs = strMM * 1
+                hrAbs = HH
+                minAbs = MM
                 used += 1
         if used > 0:
             # removed parsed words from the sentence

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -304,10 +304,8 @@ class TestNormalize(unittest.TestCase):
                     "2017-06-29 07:00:00", "remind me to call mom")
         testExtract("remind me to call mom at 7:00 Thursday morning",
                     "2017-06-29 07:00:00", "remind me to call mom")
-        # TODO: This test is imperfect due to the "at 7:00" still in the
-        #       remainder.  But let it pass for now since time is correct
         testExtract("remind me to call mom at 7:00 Thursday evening",
-                    "2017-06-29 19:00:00", "remind me to call mom at 7:00")
+                    "2017-06-29 19:00:00", "remind me to call mom")
         testExtract("remind me to call mom at 8 Wednesday evening",
                     "2017-06-28 20:00:00", "remind me to call mom")
         testExtract("remind me to call mom at 8 Wednesday in the evening",
@@ -418,10 +416,8 @@ class TestNormalize(unittest.TestCase):
                     "2017-06-27 19:00:00", "set alarm")
         testExtract("set an alarm for this evening at 7 o'clock",
                     "2017-06-27 19:00:00", "set alarm")
-        # TODO: This test is imperfect due to the "at 7:00" still in the
-        #       remainder.  But let it pass for now since time is correct
         testExtract("set an alarm for this evening at 7:00",
-                    "2017-06-27 19:00:00", "set alarm at 7:00")
+                    "2017-06-27 19:00:00", "set alarm")
         testExtract("on the evening of june 5th 2017 remind me to" +
                     " call my mother",
                     "2017-06-05 19:00:00", "remind me to call my mother")


### PR DESCRIPTION
Found several mismatches of str/int in parsing code that got copied to other
implementations.  Fixed them as a whole.

## How to test
Run unit tests
