### PR TITLE
Add the SkillGUI method send_event()

### DIFF
--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -152,7 +152,7 @@ class Enclosure:
         if self.datastore[namespace].get(name) != value:
             self.datastore[namespace][name] = value
 
-            # If the namespace is loaded send data to gui
+            # If the namespace is loaded send data to GUI
             if namespace in [l.name for l in self.loaded]:
                 msg = {"type": "mycroft.session.set",
                        "namespace": namespace,

--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -123,7 +123,7 @@ class Enclosure:
                 LOG.error('GUI connection {} has no socket!'.format(gui))
 
     def on_gui_send_event(self, message):
-        """ Send an event to the guis. """
+        """ Send an event to the GUIs. """
         try:
             data = {'type': 'mycroft.events.triggered',
                     'namespace': message.data.get('__from'),

--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -102,6 +102,7 @@ class Enclosure:
         self.bus.on("gui.page.show", self.on_gui_show_page)
         self.bus.on("gui.page.delete", self.on_gui_delete_page)
         self.bus.on("gui.clear.namespace", self.on_gui_delete_namespace)
+        self.bus.on("gui.event.send", self.on_gui_send_event)
 
     def run(self):
         try:
@@ -120,6 +121,17 @@ class Enclosure:
                 gui.socket.send(*args, **kwargs)
             else:
                 LOG.error('GUI connection {} has no socket!'.format(gui))
+
+    def on_gui_send_event(self, message):
+        """ Send an event to the guis. """
+        try:
+            data = {'type': 'mycroft.events.triggered',
+                    'namespace': message.data.get('__from'),
+                    'event_name': message.data.get('event_name'),
+                    'params': message.data.get('params')}
+            self.send(data)
+        except Exception as e:
+            LOG.error('Could not send event ({})'.format(repr(e)))
 
     def on_gui_set_value(self, message):
         data = message.data

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -243,7 +243,7 @@ class SkillGUI:
         self.skill.add_event(msg_type, self.gui_set)
 
     def register_handler(self, event, handler):
-        """ Register a handler for gui events.
+        """ Register a handler for GUI events.
 
             when using the triggerEvent method from Qt
             triggerEvent("event", {"data": "cool"})
@@ -286,7 +286,7 @@ class SkillGUI:
         return self.__session_data.__contains__(key)
 
     def clear(self):
-        """ Reset the value dictionary, and remove namespace from gui """
+        """ Reset the value dictionary, and remove namespace from GUI """
         self.__session_data = {}
         self.page = None
         self.skill.bus.emit(Message("gui.clear.namespace",
@@ -355,7 +355,7 @@ class SkillGUI:
                                      "__idle": override_idle}))
 
     def remove_page(self, page):
-        """ Remove a single page from the gui.
+        """ Remove a single page from the GUI.
 
             Args:
                 page (str): Page to remove from the GUI

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -292,6 +292,19 @@ class SkillGUI:
         self.skill.bus.emit(Message("gui.clear.namespace",
                                     {"__from": self.skill.skill_id}))
 
+    def send_event(self, event_name, params={}):
+        """ Trigger a gui event.
+
+        Arguments:
+            event_name (str): name of event to be triggered
+            params: json serializable object containing any parameters that
+                    should be sent along with the request.
+        """
+        self.skill.bus.emit(Message("gui.event.send",
+                                    {"__from": self.skill.skill_id,
+                                     "event_name": event_name,
+                                     "params": params}))
+
     def show_page(self, name, override_idle=None):
         """
         Begin showing the page in the GUI


### PR DESCRIPTION
## Description
Sends raw mycroft.events.triggered messages to the gui for the skills namespace.

Example usage:
  self.gui.send_event('event_name' {'param1': 12, 'param2': 'abc'})

## How to test
Tested as working by @notmart 

## Contributor license agreement signed?
CLA [ Yes ]
