### PR TITLE
Feature/non hard coded paths

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -23,7 +23,8 @@ from requests import RequestException
 from mycroft.util.json_helper import load_commented_json, merge_dict
 from mycroft.util.log import LOG
 
-from .locations import DEFAULT_CONFIG, SYSTEM_CONFIG, USER_CONFIG
+from .locations import (DEFAULT_CONFIG, SYSTEM_CONFIG, USER_CONFIG,
+                        WEB_CONFIG_CACHE)
 
 
 def is_remote_list(values):
@@ -134,7 +135,7 @@ class RemoteConf(LocalConf):
     def __init__(self, cache=None):
         super(RemoteConf, self).__init__(None)
 
-        cache = cache or '/var/tmp/mycroft_web_cache.json'
+        cache = cache or WEB_CONFIG_CACHE
         from mycroft.api import is_paired
         if not is_paired():
             self.load_local(cache)

--- a/mycroft/configuration/locations.py
+++ b/mycroft/configuration/locations.py
@@ -11,9 +11,28 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from os.path import join, dirname, expanduser
+import os
+from os.path import join, dirname, expanduser, exists
 
 DEFAULT_CONFIG = join(dirname(__file__), 'mycroft.conf')
-SYSTEM_CONFIG = '/etc/mycroft/mycroft.conf'
+SYSTEM_CONFIG = os.environ.get('MYCROFT_SYSTEM_CONFIG',
+                               '/etc/mycroft/mycroft.conf')
 USER_CONFIG = join(expanduser('~'), '.mycroft/mycroft.conf')
 REMOTE_CONFIG = "mycroft.ai"
+WEB_CONFIG_CACHE = os.environ.get('MYCROFT_WEB_CACHE',
+                                  '/var/tmp/mycroft_web_cache.json')
+
+
+def __ensure_folder_exists(path):
+    """ Make sure the directory for the specified path exists.
+
+        Arguments:
+            path (str): path to config file
+     """
+    directory = dirname(path)
+    if not exists(directory):
+        os.makedirs(directory)
+
+
+__ensure_folder_exists(WEB_CONFIG_CACHE)
+__ensure_folder_exists(USER_CONFIG)

--- a/mycroft/util/signal.py
+++ b/mycroft/util/signal.py
@@ -55,7 +55,10 @@ def ensure_directory_exists(directory, domain=None):
     """
     if domain:
         directory = os.path.join(directory, domain)
+
+    # Expand and normalize the path
     directory = os.path.normpath(directory)
+    directory = os.path.expanduser(directory)
 
     if not os.path.isdir(directory):
         try:


### PR DESCRIPTION
## Description
- Adds possibility to override the default websettings cache location and system config using environment variables
- Fix an possible issue with cache folder if it is in the set to a `~/` path (an android implementation had issues with this)

## How to test
Ensure that websettings still works and that the new path is created.

## Contributor license agreement signed?
CLA [ Yes ]
