### PR TITLE
Make precise sensitivity configurable

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -153,9 +153,13 @@ class PreciseHotword(HotWordEngine):
         def on_activation():
             self.has_found = True
 
+        trigger_level = self.config.get('trigger_level', 3)
+        sensitivity = self.config.get('sensitivity', 0.5)
+
         self.runner = PreciseRunner(
             PreciseEngine(precise_exe, self.precise_model),
-            stream=self.stream, on_activation=on_activation
+            trigger_level, sensitivity,
+            stream=self.stream, on_activation=on_activation,
         )
         self.runner.start()
 

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -202,6 +202,9 @@
         "lang": "en-us"
         // Specify custom model via:
         // "local_model_file": "~/.mycroft/precise/models/something.pb"
+        // Precise options:
+        // "sensitivity": 0.5,  // Higher = more sensitive
+        // "trigger_level": 3  // Higher = more delay & less sensitive
         },
 
     "wake up": {


### PR DESCRIPTION
## Description
This adds the following new configuration options relevant to precise wake words:
```json
{"hotwords": {"MY-WAKE-WORD-THAT-USES-PRECISE": {"sensitivity": 0.5, "trigger_level": 3}}}
```
A description of each is as follows:
 - `sensitivity`: Network output necessary to be considered an activation
 - `trigger_level`: Number of consecutive chunks that are activated to cause a wakeword detection

**Note**: As it is right now (might change soon), the threshold is very nonlinear so changing from 0.5 to 0.6 won't do much, but changing from 0.5 to 0.02 or 0.01 should make a noticeable difference.

## How to test
 - Try setting a precise wakeword's sensitivity setting from 0.5 to `0.01 and 0.99 to see if it makes a difference.
 - Set the trigger_level to a value like 8 and it should be harder to trigger and trigger with a slight delay.