### PR TITLE
handling tonight in date & time extraction

### DIFF
--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -1249,7 +1249,7 @@ def extract_datetime_en(string, dateNow, default_time):
                                             wordNextNext == "the" or
                                             wordNextNext == timeQualifier
                                     )
-                            ) or wordNext == 'tonight'or
+                            ) or wordNext == 'tonight' or
                             wordNextNext == 'tonight'):
                         strHH = strNum
                         strMM = "00"

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -741,7 +741,7 @@ def extract_datetime_en(string, dateNow, default_time):
     timeQualifier = ""
 
     timeQualifiersAM = ['morning']
-    timeQualifiersPM = ['afternoon', 'evening', 'night']
+    timeQualifiersPM = ['afternoon', 'evening', 'night', 'tonight']
     timeQualifiersList = set(timeQualifiersAM + timeQualifiersPM)
     markers = ['at', 'in', 'on', 'by', 'this', 'around', 'for', 'of', "within"]
     days = ['monday', 'tuesday', 'wednesday',
@@ -815,9 +815,6 @@ def extract_datetime_en(string, dateNow, default_time):
             timeQualifier = word
         # parse today, tomorrow, day after tomorrow
         elif word == "today" and not fromFlag:
-            dayOffset = 0
-            used += 1
-        elif word == "tonight" and not fromFlag:
             dayOffset = 0
             used += 1
         elif word == "tomorrow" and not fromFlag:
@@ -1092,7 +1089,9 @@ def extract_datetime_en(string, dateNow, default_time):
                     if nextWord == "am" or nextWord == "pm":
                         remainder = nextWord
                         used += 1
-                    elif nextWord == "tonight":
+                    elif nextWord == "tonight" or wordNextNext == "tonight"\
+                            or wordPrev == "tonight"\
+                            or wordPrevPrev == "tonight":
                         remainder = "pm"
                         used += 1
                     elif wordNext == "in" and wordNextNext == "the" and \
@@ -1250,7 +1249,8 @@ def extract_datetime_en(string, dateNow, default_time):
                                             wordNextNext == "the" or
                                             wordNextNext == timeQualifier
                                     )
-                            )):
+                            ) or wordNext == 'tonight'or
+                            wordNextNext == 'tonight'):
                         strHH = strNum
                         strMM = "00"
                         if wordNext == "o'clock":
@@ -1272,8 +1272,16 @@ def extract_datetime_en(string, dateNow, default_time):
                                     remainder = "am"
                                     used += 1
                         if timeQualifier != "":
-                            used += 1  # TODO: Unsure if this is 100% accurate
-                            military = True
+                            if timeQualifier in timeQualifiersPM:
+                                remainder = "pm"
+                                used += 1
+                            elif timeQualifier in timeQualifiersAM:
+                                remainder = "am"
+                                used += 1
+                            else:
+                                # TODO: Unsure if this is 100% accurate
+                                used += 1
+                                military = True
                     else:
                         isTime = False
 
@@ -1337,7 +1345,6 @@ def extract_datetime_en(string, dateNow, default_time):
 
             idx += used - 1
             found = True
-
     # check that we found a date
     if not date_found:
         return None

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -463,10 +463,17 @@ class TestNormalize(unittest.TestCase):
         testExtract("for 8 tonight",
                     "2017-06-27 20:00:00", "")
         testExtract("for 8:30pm tonight",
-                    "2017-06-27 20:30:00", "")
+                    "2017-06-27 20:30:00", "tonight")
         # Tests a time with ':' & without am/pm
+        testExtract("set an alarm for tonight 9:30",
+                    "2017-06-27 21:30:00", "set alarm tonight")
+        testExtract("set an alarm at 9:00 for tonight",
+                    "2017-06-27 21:00:00", "set alarm tonight")
+        # Check if it picks the intent irrespective of correctness
+        testExtract("set an alarm at 9 o'clock for tonight",
+                    "2017-06-27 21:00:00", "set alarm tonight")
         testExtract("remind me about the game tonight at 11:30",
-                    "2017-06-27 23:30:00", "remind me about game")
+                    "2017-06-27 23:30:00", "remind me about game tonight")
         testExtract("set alarm at 7:30 on weekdays",
                     "2017-06-27 19:30:00", "set alarm on weekdays")
 


### PR DESCRIPTION
## Description
``` 
set an alarm for 9 o'clock tonight 
```
Creates an alarm for 9 am (If current time is before 9 am)

## How to test
Added unit tests for special cases. You can try the below examples on Mark1
(Note: Try these before the current time is 9 AM)

- set an alarm for tonight at 9:30
- set an alarm at 9 for tonight
- set an alarm at 10:30 tonight
- set an alarm at 10 o'clock tonight

## Contributor license agreement signed?
CLA [ yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
