### PR TITLE
Set default log level to INFO

### DIFF
--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -490,6 +490,7 @@ def create_echo_function(name, whitelist=None):
                     LOG.level = lvl
                     LOG(name).info("Changing log level to: {}".format(lvl))
                     try:
+                        logging.getLogger().setLevel(lvl)
                         logging.getLogger('urllib3').setLevel(lvl)
                     except Exception:
                         pass  # We don't really care about if this fails...

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -473,17 +473,18 @@ def create_echo_function(name, whitelist=None):
         global _log_all_bus_messages
         try:
             msg = json.loads(message)
+            msg_type = msg.get("type", "")
             # Whitelist match beginning of message
             # i.e 'mycroft.audio.service' will allow the message
             # 'mycroft.audio.service.play' for example
-            if whitelist and not any([msg.get("type", "").startswith(e)
+            if whitelist and not any([msg_type.startswith(e)
                                      for e in whitelist]):
                 return
 
-            if blacklist and msg.get("type") in blacklist:
+            if blacklist and msg_type in blacklist:
                 return
 
-            if msg.get("type") == "mycroft.debug.log":
+            if msg_type == "mycroft.debug.log":
                 # Respond to requests to adjust the logger settings
                 lvl = msg["data"].get("level", "").upper()
                 if lvl in ["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"]:
@@ -494,22 +495,24 @@ def create_echo_function(name, whitelist=None):
                         logging.getLogger('urllib3').setLevel(lvl)
                     except Exception:
                         pass  # We don't really care about if this fails...
+                else:
+                    LOG(name).info("Invalid level provided: {}".format(lvl))
 
                 # Allow enable/disable of messagebus traffic
                 log_bus = msg["data"].get("bus", None)
                 if log_bus is not None:
-                    LOG(name).info("Bus logging: ".format(log_bus))
+                    LOG(name).info("Bus logging: {}".format(log_bus))
                     _log_all_bus_messages = log_bus
-            elif msg.get("type") == "registration":
+            elif msg_type == "registration":
                 # do not log tokens from registration messages
                 msg["data"]["token"] = None
                 message = json.dumps(msg)
-        except Exception:
-            pass
+        except Exception as e:
+            LOG.info("Error: {}".format(repr(e)), exc_info=True)
 
         if _log_all_bus_messages:
             # Listen for messages and echo them for logging
-            LOG(name).debug(message)
+            LOG(name).info("BUS: {}".format(message))
     return echo
 
 

--- a/mycroft/util/log.py
+++ b/mycroft/util/log.py
@@ -78,14 +78,15 @@ class LOG:
         formatter = logging.Formatter(fmt, datefmt)
         cls.handler = logging.StreamHandler(sys.stdout)
         cls.handler.setFormatter(formatter)
-        cls.create_logger('')  # Enables logging in external modules
+
+        # Enable logging in external modules
+        cls.create_logger('').setLevel(cls.level)
 
     @classmethod
     def create_logger(cls, name):
         logger = logging.getLogger(name)
         logger.propagate = False
         logger.addHandler(cls.handler)
-        logger.setLevel(cls.level)
         return logger
 
     def __init__(self, name):

--- a/mycroft/util/log.py
+++ b/mycroft/util/log.py
@@ -71,7 +71,7 @@ class LOG:
             except Exception as e:
                 print('couldn\'t load {}: {}'.format(conf, str(e)))
 
-        cls.level = logging.getLevelName(config.get('log_level', 'DEBUG'))
+        cls.level = logging.getLevelName(config.get('log_level', 'INFO'))
         fmt = '%(asctime)s.%(msecs)03d - ' \
               '%(name)s - %(levelname)s - %(message)s'
         datefmt = '%H:%M:%S'


### PR DESCRIPTION
## Description
Decrease the default log level to INFO. This also adds a fix to allow changing log levels again and enabling bus logging.

## How to test
Start mycroft and check the cli for log messages. They should be greatly reduced.

## Contributor license agreement signed?
CLA [ Yes ]
