### PR TITLE
separate the cache & avoid voice overlap

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -30,6 +30,7 @@ config = None
 tts = None
 tts_hash = None
 lock = Lock()
+mimic_fallback_obj = None
 
 _last_stop_signal = 0
 
@@ -130,11 +131,15 @@ def mute_and_speak(utterance, ident):
 
 
 def mimic_fallback_tts(utterance, ident):
+    global mimic_fallback_obj
     # fallback if connection is lost
     config = Configuration.get()
     tts_config = config.get('tts', {}).get("mimic", {})
     lang = config.get("lang", "en-us")
-    tts = Mimic(lang, tts_config)
+    if not mimic_fallback_obj:
+        mimic_fallback_obj = Mimic(lang, tts_config)
+    tts = mimic_fallback_obj
+    LOG.debug("Mimic fallback, utterance : " + str(utterance))
     tts.init(bus)
     tts.execute(utterance, ident)
 

--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -184,3 +184,6 @@ def shutdown():
     if tts:
         tts.playback.stop()
         tts.playback.join()
+    if mimic_fallback_obj:
+        mimic_fallback_obj.playback.stop()
+        mimic_fallback_obj.playback.join()

--- a/mycroft/tts/mimic2_tts.py
+++ b/mycroft/tts/mimic2_tts.py
@@ -266,8 +266,7 @@ class Mimic2(TTS):
                 key:        Hash key for the sentence
                 phonemes:   phoneme string to save
         """
-
-        cache_dir = get_cache_directory("tts")
+        cache_dir = get_cache_directory("tts/" + self.tts_name)
         pho_file = os.path.join(cache_dir, key + ".pho")
         try:
             with open(pho_file, "w") as cachefile:
@@ -282,7 +281,8 @@ class Mimic2(TTS):
             Args:
                 Key:    Key identifying phoneme cache
         """
-        pho_file = os.path.join(get_cache_directory("tts"), key + ".pho")
+        pho_file = os.path.join(get_cache_directory("tts/" + self.tts_name),
+                                key + ".pho")
         if os.path.exists(pho_file):
             try:
                 with open(pho_file, "r") as cachefile:


### PR DESCRIPTION
## Description
Mimic2 fallback to mimic overlaps sentences because multiple Mimic objects are being created for each sentence. This happens in 2 cases

1. When connection to mimic2 is lost while speaking multiple sentences
2. Select mimic2 as your TTS engine and reset the device. Utterances overlap on startup

## How to test

- Set Mimic2 as you TTS engine
- Reset your device and listen to utterances on startup

If you do not want to reset your device

- Hit the top button & select 'WIFI'
- Do not setup the wifi and ask general questions to Mark1 (ex: what is the time, weather..)
- Look for the var/logs/mycroft/auido.log to verify the connection error & fallback
- The utterance "Use your mobile device or computer to connect to the wifi network 'MYCROFT'. Then
- enter the password 1 2 3 4 5 6 7 8" should not overlap

### Also check the cache being created at /tmp/mycroft/cache/tts/<tts_engine_name>

## Contributor license agreement signed?
CLA [ Yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
