### PR TITLE
Poll settings only every 5 minutes

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -409,7 +409,7 @@ class SkillSettings(dict):
             return
 
         # continues to poll settings every minute
-        self._poll_timer = Timer(60, self._poll_skill_settings)
+        self._poll_timer = Timer(5 * 60, self._poll_skill_settings)
         self._poll_timer.daemon = True
         self._poll_timer.start()
 


### PR DESCRIPTION
## Description
Only poll every 5 minutes

## How to test
Make sure the skills settings meta isn't requested more than every 5 minutes.

## Contributor license agreement signed?
CLA [ Yes ]
