### PR TITLE
Feature/skill gid restore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
  - sudo apt-get install -qq mpg123 portaudio19-dev libglib2.0-dev swig bison libtool autoconf libglib2.0-dev libicu-dev libfann-dev realpath
  - sudo apt-get install -y gcc-4.8 g++-4.8
  - export CC="gcc-4.8"
+ - export TMPDIR="/tmp/${TRAVIS_PYTHON_VERSION}"
 python:
   - "3.4"
   - "3.5"
@@ -15,6 +16,9 @@ python:
 cache: pocketsphinx-python
 # command to install dependencies
 install:
+ - rm -rf ${TMPDIR}
+ - mkdir ${TMPDIR}
+ - echo ${TMPDIR}
  - VIRTUALENV_ROOT=${VIRTUAL_ENV} ./dev_setup.sh
  - pip install -r requirements.txt
  - pip install -r test-requirements.txt

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -1,0 +1,43 @@
+# Copyright 2019 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+from os.path import join, expanduser, exists
+
+from msm import MycroftSkillsManager, SkillRepo
+from mycroft.util.combo_lock import ComboLock
+
+mycroft_msm_lock = ComboLock('/tmp/mycroft-msm.lck')
+
+
+def create_msm(config):
+    """ Create msm object from config. """
+    msm_config = config['skills']['msm']
+    repo_config = msm_config['repo']
+    data_dir = expanduser(config['data_dir'])
+    skills_dir = join(data_dir, msm_config['directory'])
+    repo_cache = join(data_dir, repo_config['cache'])
+    platform = config['enclosure'].get('platform', 'default')
+
+    with mycroft_msm_lock:
+        # Try to create the skills directory if it doesn't exist
+        if not exists(skills_dir):
+            os.makedirs(skills_dir)
+
+        return MycroftSkillsManager(
+            platform=platform, skills_dir=skills_dir,
+            repo=SkillRepo(repo_cache, repo_config['url'],
+                           repo_config['branch']),
+            versioned=msm_config['versioned'])

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -76,25 +76,6 @@ from mycroft.configuration import ConfigurationManager
 
 from .msm_wrapper import create_msm
 
-# This is the base needed for sending a blank settings meta entry (Tartarus)
-# To this a global id is added
-# TODO reduce the needed boilerplate here
-BLANK_META = {
-    "skillMetadata": {
-        "sections": [
-            {
-                "name": "",
-                "fields": [
-                    {
-                        "type": "label",
-                        "label": ""
-                    }
-                ]
-            }
-        ]
-    }
-}
-
 
 msm = None
 msm_creation_time = 0
@@ -166,6 +147,12 @@ class SkillSettings(dict):
         self._poll_timer = None
         self._blank_poll_timer = None
         self._is_alive = True
+
+        # Add Information extracted from the skills-meta.json entry for the
+        # skill.
+        skill_gid, disp_name = build_global_id(self._directory, self.config)
+        self.skill_gid = skill_gid
+        self.display_name = disp_name
 
         # if settingsmeta exist
         if isfile(self._meta_path):
@@ -283,13 +270,11 @@ class SkillSettings(dict):
                 LOG.error(repr(e))
                 return None
         else:
-            data = copy.copy(BLANK_META)
+            data = {}
 
-        # Add Information extracted from the skills-meta.json entry for the
-        # skill.
-        skill_gid, disp_name = build_global_id(self._directory, self.config)
-        data['skill_gid'] = skill_gid
-        data['display_name'] = (disp_name or data.get('name') or
+        # Insert skill_gid and display_name
+        data['skill_gid'] = self.skill_gid
+        data['display_name'] = (self.display_name or data.get('name') or
                                 display_name(self.name))
 
         # Backwards compatibility:
@@ -322,12 +307,13 @@ class SkillSettings(dict):
         if self._is_new_hash(skill_settings['identifier']):
             self._save_uuid(skill_settings['uuid'])
             self._save_hash(skill_settings['identifier'])
-        sections = skill_settings['skillMetadata']['sections']
-        for section in sections:
-            for field in section["fields"]:
-                if "name" in field and "value" in field:
-                    self[field['name']] = field['value']
-        self.store()
+        if 'skillMetadata' in skill_settings:
+            sections = skill_settings['skillMetadata']['sections']
+            for section in sections:
+                for field in section["fields"]:
+                    if "name" in field and "value" in field:
+                        self[field['name']] = field['value']
+            self.store()
 
     def _load_uuid(self):
         """ Loads uuid
@@ -374,6 +360,8 @@ class SkillSettings(dict):
     def _migrate_settings(self, settings_meta):
         """ sync settings.json and settingsmeta.json in memory """
         meta = settings_meta.copy()
+        if 'skillMetadata' not in meta:
+            return meta
         self.load_skill_settings_from_file()
         sections = meta['skillMetadata']['sections']
         for i, section in enumerate(sections):
@@ -546,6 +534,9 @@ class SkillSettings(dict):
             dict: skills object
         """
         meta = settings_meta.copy()
+        if 'skillMetadata' not in settings_meta:
+            return meta
+
         sections = meta['skillMetadata']['sections']
 
         for i, section in enumerate(sections):

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -61,13 +61,72 @@
 import json
 import hashlib
 import os
+import time
+import copy
+import re
 from threading import Timer
 from os.path import isfile, join, expanduser
 from requests.exceptions import RequestException
+from msm import SkillEntry
 
 from mycroft.api import DeviceApi, is_paired
 from mycroft.util.log import LOG
+from mycroft.util import camel_case_split
 from mycroft.configuration import ConfigurationManager
+
+from .msm_wrapper import create_msm
+
+# This is the base needed for sending a blank settings meta entry (Tartarus)
+# To this a global id is added
+# TODO reduce the needed boilerplate here
+BLANK_META = {
+    "skillMetadata": {
+        "sections": [
+            {
+                "name": "",
+                "fields": [
+                    {
+                        "type": "label",
+                        "label": ""
+                    }
+                ]
+            }
+        ]
+    }
+}
+
+
+msm = None
+msm_creation_time = 0
+
+
+def build_global_id(directory, config):
+    """ Create global id for the skill.
+
+    TODO: Handle dirty skill
+
+    Arguments:
+        directory:  skill directory
+        config:     config for the device to fetch msm setup
+     """
+    # Update the msm object if it's more than an hour old
+    global msm
+    global msm_creation_time
+    if msm is None or time.time() - msm_creation_time > 60 * 60:
+        msm_creation_time = time.time()
+        msm = create_msm(config)
+
+    s = SkillEntry.from_folder(directory, msm)
+    if s.meta_info != {}:
+        return s.meta_info['skill_gid'], s.meta_info['display_name']
+    else:  # No skills meta data available, local or unsubmitted skill
+        return "@{}|{}".format(DeviceApi().identity.uuid, s.name), None
+
+
+def display_name(name):
+    """ Splits camelcase and removes leading/trailing Skill. """
+    name = re.sub(r'(^[Ss]kill|[Ss]kill$)', '', name)
+    return camel_case_split(name)
 
 
 class SkillSettings(dict):
@@ -75,8 +134,10 @@ class SkillSettings(dict):
         also syncs to the backend for skill settings
 
     Args:
-        directory (str): Path to storage directory
-        name (str):      user readable name associated with the settings
+        directory (str):  Path to storage directory
+        name (str):       user readable name associated with the settings
+        no_upload (bool): True if the upload to mycroft servers should be
+                          disabled.
     """
 
     def __init__(self, directory, name):
@@ -93,6 +154,8 @@ class SkillSettings(dict):
         # set file paths
         self._settings_path = join(directory, 'settings.json')
         self._meta_path = join(directory, 'settingsmeta.json')
+        self._directory = directory
+
         self.is_alive = True
         self.loaded_hash = hash(json.dumps(self, sort_keys=True))
         self._complete_intialization = False
@@ -101,11 +164,17 @@ class SkillSettings(dict):
         self._user_identity = None
         self.changed_callback = None
         self._poll_timer = None
+        self._blank_poll_timer = None
         self._is_alive = True
 
         # if settingsmeta exist
         if isfile(self._meta_path):
             self._poll_skill_settings()
+        # if not disallowed by user upload an entry for all skills installed
+        elif self.config['skills']['upload_skill_manifest']:
+            self._blank_poll_timer = Timer(1, self._init_blank_meta)
+            self._blank_poll_timer.daemon = True
+            self._blank_poll_timer.start()
 
     def __hash__(self):
         """ Simple object unique hash. """
@@ -121,6 +190,8 @@ class SkillSettings(dict):
         self._is_alive = False
         if self._poll_timer:
             self._poll_timer.cancel()
+        if self._blank_poll_timer:
+            self._blank_poll_timer.cancel()
 
     def set_changed_callback(self, callback):
         """ Set callback to perform when server settings have changed.
@@ -195,18 +266,37 @@ class SkillSettings(dict):
             return super(SkillSettings, self).__setitem__(key, value)
 
     def _load_settings_meta(self):
-        """ Loads settings metadata from skills path. """
+        """ Load settings metadata from the skill folder.
+
+        If no settingsmeta exists a basic settingsmeta will be created
+        containing a basic identifier.
+
+        Returns:
+            (dict) settings meta
+        """
         if isfile(self._meta_path):
             try:
                 with open(self._meta_path, encoding='utf-8') as f:
                     data = json.load(f)
-                return data
             except Exception as e:
-                LOG.error("Failed to load setting file: "+self._meta_path)
+                LOG.error("Failed to load setting file: " + self._meta_path)
                 LOG.error(repr(e))
                 return None
         else:
-            return None
+            data = copy.copy(BLANK_META)
+
+        # Add Information extracted from the skills-meta.json entry for the
+        # skill.
+        skill_gid, disp_name = build_global_id(self._directory, self.config)
+        data['skill_gid'] = skill_gid
+        data['display_name'] = (disp_name or data.get('name') or
+                                display_name(self.name))
+
+        # Backwards compatibility:
+        if 'name' not in data:
+            data['name'] = data['display_name']
+
+        return data
 
     def _send_settings_meta(self, settings_meta):
         """ Send settingsmeta.json to the server.
@@ -379,6 +469,18 @@ class SkillSettings(dict):
         else:
             settings_meta = self._load_settings_meta()
             self._upload_meta(settings_meta, hashed_meta)
+
+    def _init_blank_meta(self):
+        """ Send blank settingsmeta to remote. """
+        try:
+            if not is_paired() and self.is_alive:
+                self._blank_poll_timer = Timer(60, self._init_blank_meta)
+                self._blank_poll_timer.daemon = True
+                self._blank_poll_timer.start()
+            else:
+                self.initialize_remote_settings()
+        except Exception as e:
+            LOG.exception('Failed to send blank meta: {}'.format(repr(e)))
 
     def _poll_skill_settings(self):
         """ If identifier exists for this skill poll to backend to

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -33,7 +33,7 @@ from mycroft.util.log import LOG
 from mycroft.api import DeviceApi, is_paired
 
 from .core import load_skill, create_skill_descriptor, MainModule
-
+from .msm_wrapper import create_msm as msm_creator
 
 DEBUG = Configuration.get().get("debug", False)
 skills_config = Configuration.get().get("skills")
@@ -132,23 +132,7 @@ class SkillManager(Thread):
 
     @staticmethod
     def create_msm():
-        config = Configuration.get()
-        msm_config = config['skills']['msm']
-        repo_config = msm_config['repo']
-        data_dir = expanduser(config['data_dir'])
-        skills_dir = join(data_dir, msm_config['directory'])
-        # Try to create the skills directory if it doesn't exist
-        if not exists(skills_dir):
-            os.makedirs(skills_dir)
-
-        repo_cache = join(data_dir, repo_config['cache'])
-        platform = config['enclosure'].get('platform', 'default')
-        return MycroftSkillsManager(
-            platform=platform, skills_dir=skills_dir,
-            repo=SkillRepo(
-                repo_cache, repo_config['url'], repo_config['branch']
-            ), versioned=msm_config['versioned']
-        )
+        return msm_creator(Configuration.get())
 
     def schedule_now(self, message=None):
         self.next_download = time.time() - 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ pulsectl==17.7.4
 google-api-python-client==1.6.4
 fasteners==0.14.1
 
-msm==0.7.3
+msm==0.7.4
 msk==0.3.12
 adapt-parser==0.3.2
 padatious==0.4.6

--- a/test/unittests/skills/test_settings.py
+++ b/test/unittests/skills/test_settings.py
@@ -14,11 +14,16 @@
 #
 import json
 import unittest
+from mock import MagicMock
 
 from os import remove
 from os.path import join, dirname
 
 from mycroft.skills.settings import SkillSettings
+
+
+SkillSettings._poll_skill_settings = MagicMock()
+SkillSettings._init_blank_meta = MagicMock()
 
 
 class SkillSettingsTest(unittest.TestCase):

--- a/test/unittests/util/test_signal.py
+++ b/test/unittests/util/test_signal.py
@@ -15,23 +15,25 @@
 import unittest
 from shutil import rmtree
 
-from os.path import exists, isfile
+from os.path import exists, isfile, join
+from tempfile import gettempdir
 
 from mycroft.util import create_signal, check_for_signal
 
 
 class TestSignals(unittest.TestCase):
     def setUp(self):
-        if exists('/tmp/mycroft'):
-            rmtree('/tmp/mycroft')
+        if exists(join(gettempdir(), 'mycroft')):
+            rmtree(join(gettempdir(), 'mycroft'))
 
     def test_create_signal(self):
         create_signal('test_signal')
-        self.assertTrue(isfile('/tmp/mycroft/ipc/signal/test_signal'))
+        self.assertTrue(isfile(join(gettempdir(),
+                                    'mycroft/ipc/signal/test_signal')))
 
     def test_check_signal(self):
-        if exists('/tmp/mycroft'):
-            rmtree('/tmp/mycroft')
+        if exists(join(gettempdir(), 'mycroft')):
+            rmtree(join(gettempdir(), 'mycroft'))
         # check that signal is not found if file does not exist
         self.assertFalse(check_for_signal('test_signal'))
 
@@ -39,7 +41,8 @@ class TestSignals(unittest.TestCase):
         create_signal('test_signal')
         self.assertTrue(check_for_signal('test_signal'))
         # Check that the signal is removed after use
-        self.assertFalse(isfile('/tmp/mycroft/ipc/signal/test_signal'))
+        self.assertFalse(isfile(join(gettempdir(),
+                                     'mycroft/ipc/signal/test_signal')))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Restores the global_id, keeps identity field removes skillMetadata field for empty skills.

## How to test
Verify that skill settings can be fetched and that no empty identity fields are uploaded to tartarus.

## Contributor license agreement signed?
CLA [ Yes ]
