### PR TITLE
Feature/audioservice list

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -194,6 +194,7 @@ class AudioService:
         self.bus.on('mycroft.audio.service.next', self._next)
         self.bus.on('mycroft.audio.service.prev', self._prev)
         self.bus.on('mycroft.audio.service.track_info', self._track_info)
+        self.bus.on('mycroft.audio.service.list_backends', self._list_backends)
         self.bus.on('mycroft.audio.service.seek_forward', self._seek_forward)
         self.bus.on('mycroft.audio.service.seek_backward', self._seek_backward)
         self.bus.on('recognizer_loop:audio_output_start', self._lower_volume)
@@ -429,6 +430,18 @@ class AudioService:
             track_info = {}
         self.bus.emit(Message('mycroft.audio.service.track_info_reply',
                               data=track_info))
+
+    def _list_backends(self, message):
+        """ Return a dict of available backends. """
+        data = {}
+        for s in self.service:
+            info = {
+                'supported_uris': s.supported_uris(),
+                'default': s == self.default,
+                'remote': isinstance(s, RemoteAudioBackend)
+            }
+            data[s.name] = info
+        self.bus.emit(message.response(data))
 
     def _seek_forward(self, message):
         """

--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -496,4 +496,3 @@ class AudioService:
         self.bus.remove('recognizer_loop:audio_output_end',
                         self._restore_volume)
         self.bus.remove('recognizer_loop:record_end', self._restore_volume)
-        self.bus.remove('mycroft.stop', self._stop)

--- a/mycroft/skills/audioservice.py
+++ b/mycroft/skills/audioservice.py
@@ -168,6 +168,16 @@ class AudioService:
 
         return self.info or {}
 
+    def available_backends(self):
+        """ Return available audio backends.
+
+        Returns:
+            dict with backend names as keys
+        """
+        msg = Message('mycroft.audio.service.list_backends')
+        response = self.bus.wait_for_response(msg)
+        return response.data if response else {}
+
     @property
     def is_playing(self):
         return self.track_info() != {}


### PR DESCRIPTION
## Description
The AudioService object now has the new method available_backends() returning a dict of all available audio backends as keys containing 'supported_uris' listing supported uri types (file:// http:// etc.), 'remote' (bool) True if remote), 'default' (bool) true if the default audio backend.

## How to test
Ensure the AudioService.available_backends() returns a valid response

## Contributor license agreement signed?
CLA [ Yes ]
