### PR TITLE
Remove "stop_threshold"

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -107,8 +107,6 @@
     "upload_skill_manifest": true,
     // Directory to look for user skills
     "directory": "~/.mycroft/skills",
-    // TODO: Old unused kludge, remove from code
-    "stop_threshold": 2.0,
     // Enable auto update by msm
     "auto_update": true,
     // blacklisted skills to not load
@@ -161,7 +159,7 @@
       "url": "https://training.mycroft.ai/precise/upload"
     },
 
-  
+
     // Override as SYSTEM or USER to select a specific microphone input instead of
     // the PortAudio default input.
     //   "device_name": "somename",  // can be regex pattern or substring

--- a/test/unittests/util/commented.json
+++ b/test/unittests/util/commented.json
@@ -3,20 +3,20 @@
 {
 // C-style comment
   "lang": "en-us",
-  
-  // Comment spaced out  
+
+  // Comment spaced out
   "system_unit": "metric",
-  
+
     // Comment tabbed out
-    
+
   "time_format": "half",
-  
+
     // comment and // another inside
   "date_format": "MDY",
-  
+
   // Comment with " inside it
   "confirm_listening": true,
-  
+
   # Python-style comment
   "sounds": {
 # Commment with no space
@@ -54,8 +54,7 @@
     }
   },
   "skills": {
-    "directory": "~/.mycroft/skills",
-    "stop_threshold": 2.0
+    "directory": "~/.mycroft/skills"
   },
   "server": {
     "url": "https://api.mycroft.ai",
@@ -103,12 +102,12 @@
       "voice": "m1"
     }
   },
-  
+
   // Mixture
   # of types
   // of comments
-  
-  
+
+
   "wifi": {
     "setup": false
   },

--- a/test/unittests/util/plain.json
+++ b/test/unittests/util/plain.json
@@ -36,8 +36,7 @@
     }
   },
   "skills": {
-    "directory": "~/.mycroft/skills",
-    "stop_threshold": 2.0
+    "directory": "~/.mycroft/skills"
   },
   "server": {
     "url": "https://api.mycroft.ai",


### PR DESCRIPTION
The setting "stop_threshold" is not used (and doesn't look like it ever was).  Removing
from mycroft.conf.

## How to test
Search for usage of "stop_threshold".  Not found in mycroft-core or any skills on a unit.
