### PR TITLE
Restore settings polling to 1 minute interval

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -409,7 +409,7 @@ class SkillSettings(dict):
             return
 
         # continues to poll settings every minute
-        self._poll_timer = Timer(5 * 60, self._poll_skill_settings)
+        self._poll_timer = Timer(1 * 60, self._poll_skill_settings)
         self._poll_timer.daemon = True
         self._poll_timer.start()
 


### PR DESCRIPTION
## Description
Polling interval of skill settings will once more be 1 minuet

## How to test
Check that the interval between debug messages related to getting settings is 1 minute apart.

## Contributor license agreement signed?
CLA [ Yes ]
