### PR TITLE
Fix infinitely adding pages to existing namespace

### DIFF
--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -205,6 +205,8 @@ class Enclosure:
                    "position": len(self.loaded[0].pages),
                    "data": [{"url": p} for p in pages]
                    })
+        # Insert the pages into local reprensentation as well.
+        self.loaded[0].pages += pages
 
     def __remove_page(self, namespace, pos):
         """ Delete page.


### PR DESCRIPTION
## Description
Update the local representation of the GUI structure with the new pages when appending pages to an existing namespace.

This problem was probably introduced when remove page/namespace was added.

## How to test
Run the GUI and trigger repeatedly ask `what time is it` and `what date is it`. No repeating pages should appear.

## Contributor license agreement signed?
CLA [ Yes ]
