### PR TITLE
Fix chown in dev_setup when GROUP != USER

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -222,8 +222,10 @@ fi" > ~/.profile_mycroft
     if [[ ! -d /opt/mycroft/skills ]] ; then
         echo "This script will create that folder for you.  This requires sudo"
         echo "permission and might ask you for a password..."
+        setup_user=$USER
+        setup_group=$( id -gn $USER )
         $SUDO mkdir -p /opt/mycroft/skills
-        $SUDO chown -R $USER:$USER /opt/mycroft
+        $SUDO chown -R ${setup_user}:${setup_group} /opt/mycroft
         echo "Created!"
     fi
     if [[ ! -d skills ]] ; then


### PR DESCRIPTION
## Description
This finds the default group of the user and uses that as group when doing chown in dev_setup.sh the same way as it's done in the prepare-msm.sh script

Resolves #2092 

## How to test
Remove / rename your skills directory and remove the .dev_opts file rerun the dev_setup.sh and check that the skills directory is recreated correctly.

## Contributor license agreement signed?
CLA [ Yes ]
