### PR TITLE
Tidy up the readthedocs documentation

### DIFF
--- a/doc/source/mycroft.rst
+++ b/doc/source/mycroft.rst
@@ -13,7 +13,16 @@ mycroft.util.time - time handling functions
     mycroft.util.time
     :members:
 
-MycroftSkill class
+Api class
+---------
+.. autoclass:: mycroft.Api
+    :members:
+
+
+mycroft.skills
+==============
+
+MycroftSkill class - base class for all Mycroft skills
 ------------------
 
 .. autoclass:: mycroft.MycroftSkill
@@ -47,11 +56,6 @@ AudioService class
 -------------------
 .. autoclass:: mycroft.skills.audioservice.AudioService
     :show-inheritance:
-    :members:
-
-Api class
----------
-.. autoclass:: mycroft.Api
     :members:
 
 intent_handler decorator

--- a/doc/source/mycroft.rst
+++ b/doc/source/mycroft.rst
@@ -19,9 +19,21 @@ MycroftSkill class
 .. autoclass:: mycroft.MycroftSkill
     :members:
 
+CommonIoTSkill class
+-------------------
+.. autoclass:: mycroft.skills.common_iot_skill.CommonIoTSkill
+    :show-inheritance:
+    :members:
+
 CommonPlaySkill class
 -------------------
 .. autoclass:: mycroft.skills.common_play_skill.CommonPlaySkill
+    :show-inheritance:
+    :members:
+
+CommonQuerySkill class
+-------------------
+.. autoclass:: mycroft.skills.common_query_skill.CommonQuerySkill
     :show-inheritance:
     :members:
 

--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -30,6 +30,15 @@ class CPSMatchLevel(Enum):
 
 
 class CommonPlaySkill(MycroftSkill, ABC):
+    """ To integrate with the common play infrastructure of Mycroft
+    skills should use this base class and override the two methods
+    `CPS_match_query_phrase` (for checking if the skill can play the
+    utterance) and `CPS_start` for launching the media.
+
+    The class makes the skill available to queries from the
+    mycroft-playback-control skill and no special vocab for starting playback
+    is needed.
+    """
     def __init__(self, name=None, bus=None):
         super().__init__(name, bus)
         self.audioservice = None
@@ -43,6 +52,13 @@ class CommonPlaySkill(MycroftSkill, ABC):
         # with a translatable name in their initialize() method.
 
     def bind(self, bus):
+        """ Overrides the normal bind method.
+        Adds handlers for play:query and play:start messages allowing
+        interaction with the playback control skill.
+
+        This is called automatically during setup, and
+        need not otherwise be used.
+        """
         if bus:
             super().bind(bus)
             self.audioservice = AudioService(self.bus)

--- a/mycroft/skills/common_query_skill.py
+++ b/mycroft/skills/common_query_skill.py
@@ -41,11 +41,23 @@ def handles_visuals(self, platform):
 
 
 class CommonQuerySkill(MycroftSkill, ABC):
+    """ Question answering skills should be based on this class. The skill
+    author needs to implement `CQS_match_query_phrase` returning an answer
+    and can optionally implement `CQS_action` to perform additional actions
+    if the skill's answer is selected.
 
+    This class works in conjunction with skill-query which collects
+    answers from several skills presenting the best one available.
+    """
     def __init__(self, name=None, bus=None):
         super().__init__(name, bus)
 
     def bind(self, bus):
+        """ Overrides the default bind method of MycroftSkill.
+
+        This registers messagebus handlers for the skill during startup
+        but is nothing the skill author needs to consider.
+        """
         if bus:
             super().bind(bus)
             self.add_event('question:query', self.__handle_question_query)

--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -245,7 +245,7 @@ case ${_opt} in
     "sdkdoc")
         source-venv
         cd doc
-        make ${opt}
+        make ${_params}
         cd ..
         ;;
     "enclosure")


### PR DESCRIPTION
## Description
- Fixes doc build from start-mycroft.sh
- Adds CommonIoTSkill and CommonQuerySkill to the documented skills
- Adds docstrings for the classes CommonPlaySkill and CommonQuerySkill

## How to test
run `./start-mycroft.sh sdkdoc html` and check the generated documentation in the doc/build folder.

## Contributor license agreement signed?
CLA [ Yes ]
