### PR TITLE
Change default listener in config

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -194,7 +194,7 @@
   // Hotword configurations
   "hotwords": {
     "hey mycroft": {
-        "module": "pocketsphinx",
+        "module": "precise",
         "phonemes": "HH EY . M AY K R AO F T",
         "threshold": 1e-90,
         "lang": "en-us"

--- a/test/unittests/client/test_local_recognizer.py
+++ b/test/unittests/client/test_local_recognizer.py
@@ -25,11 +25,13 @@ from test.util import base_config
 DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
 
 
-class LocalRecognizerTest(unittest.TestCase):
+class PocketSphinxRecognizerTest(unittest.TestCase):
     def setUp(self):
         with mock.patch('mycroft.configuration.Configuration.get') as \
                 mock_config_get:
-            mock_config_get.return_value = base_config()
+            conf = base_config()
+            conf['hotwords']['hey mycroft']['module'] = 'pocketsphinx'
+            mock_config_get.return_value = conf
             rl = RecognizerLoop()
             self.recognizer = RecognizerLoop.create_wake_word_recognizer(rl)
 


### PR DESCRIPTION
## Description
The listener has been previously set via other configurations like /etc/mycroft.conf on the Mark 1. This sets it to Precise by default on all platforms.

## How to test
 - Ensure it starts on a desktop (look for `precise-something` executable in process monitor
 - Ensure Pocketsphinx starts as a fallback after making the `precise.dist_url` field invalid with something like:

```json
{"precise": {"dist_url": "https://github.com/MycroftAI/INVALID/{arch}/latest"}}
```