### PR TITLE
Add trigger action

### DIFF
--- a/mycroft/skills/common_iot_skill.py
+++ b/mycroft/skills/common_iot_skill.py
@@ -101,6 +101,7 @@ class Action(Enum):
     SET = auto()
     INCREASE = auto()
     DECREASE = auto()
+    TRIGGER = auto()
 
 
 class IoTRequest():


### PR DESCRIPTION
## Description
Add a `trigger` action to the common IoT skill framework.

## How to test
Install the latest version of https://github.com/MycroftAI/skill-iot-control, and https://github.com/MycroftAI/mycroft-homeassistant/tree/feature/commonIoT, and trigger some home assistant scripts and/or automations.

## Contributor license agreement signed?
CLA
 - [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
