### PR TITLE
restore bus on_message

### DIFF
--- a/mycroft/messagebus/client/ws.py
+++ b/mycroft/messagebus/client/ws.py
@@ -92,6 +92,7 @@ class WebsocketClient:
 
     def on_message(self, message):
         parsed_message = Message.deserialize(message)
+        self.emitter.emit('message', message)
         self.emitter.emit(parsed_message.type, parsed_message)
 
     def emit(self, message):


### PR DESCRIPTION
## Description
previously we could react to all messages in the bus

this was removed in https://github.com/MycroftAI/mycroft-core/pull/2024 , not sure if by accident

this adds the "message" message back on

## How to test
```python
self.bus.on("message", self.handler)
```

## Contributor license agreement signed?
CLA [ yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
