### PR TITLE
Fix table formatting for docs display

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -1679,14 +1679,16 @@ class FallbackSkill(MycroftSkill):
         view of the user's utterance.  Fallback handlers are called in an order
         determined the priority provided when the the handler is registered.
 
-        Priority   Who?            Purpose
-        --------  --------    ------------------------------------------------
-           1-4    RESERVED    Unused for now, slot for pre-Padatious if needed
-             5    MYCROFT     Padatious near match (conf > 0.8)
-          6-88    USER        General
-            89    MYCROFT     Padatious loose match (conf > 0.5)
-         90-99    USER        Uncaught intents
-           100+   MYCROFT     Fallback Unknown or other future use
+        ========   ========   ================================================
+        Priority   Who?       Purpose
+        ========   ========   ================================================
+           1-4     RESERVED   Unused for now, slot for pre-Padatious if needed
+             5     MYCROFT    Padatious near match (conf > 0.8)
+          6-88     USER       General
+            89     MYCROFT    Padatious loose match (conf > 0.5)
+         90-99     USER       Uncaught intents
+           100+    MYCROFT    Fallback Unknown or other future use
+        ========   ========   ================================================
 
         Handlers with the numerically lowest priority are invoked first.
         Multiple fallbacks can exist at the same priority, but no order is


### PR DESCRIPTION
## Description
- Small formatting fix for table in FallbackSkill class. 
- Uses RST formatting to display actual table in generated documentation.

## How to test
run `./start-mycroft.sh sdkdoc html` and check the generated documentation in the doc/build folder.

## Contributor license agreement signed?
CLA [YES]
