### PR TITLE
feature/enable sending qml ui over network

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -234,11 +234,12 @@ class SkillGUI:
         self.page = None    # the active GUI page (e.g. QML template) to show
         self.skill = skill
         self.on_gui_changed_callback = None
-        self.config_core = Configuration.get()
+        self.config = Configuration.get()
 
     @property
     def remote_url(self):
-        return self.config_core.get('remote-server')
+        """ Returns configuration value for url of remote-server. """
+        return self.config.get('remote-server')
 
     def build_message_type(self, event):
         """ Builds a message matching the output from the enclosure. """
@@ -351,7 +352,7 @@ class SkillGUI:
         for name in page_names:
             page = self.skill.find_resource(name, 'ui')
             if page:
-                if self.config_core.get('remote') is True:
+                if self.config.get('remote') is True:
                     page_urls.append(self.remote_url + "/" + page)
                 else:
                     page_urls.append("file://" + page)

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -234,6 +234,11 @@ class SkillGUI:
         self.page = None    # the active GUI page (e.g. QML template) to show
         self.skill = skill
         self.on_gui_changed_callback = None
+        self.config_core = Configuration.get()
+        
+    @property
+    def remote_url(self):
+        return self.config_core.get('remote-server')
 
     def build_message_type(self, event):
         """ Builds a message matching the output from the enclosure. """
@@ -346,7 +351,10 @@ class SkillGUI:
         for name in page_names:
             page = self.skill.find_resource(name, 'ui')
             if page:
-                page_urls.append("file://" + page)
+                if self.config_core.get('remote') is True:
+                    page_urls.append(self.remote_url + "/" + page)
+                else:
+                    page_urls.append("file://" + page)
             else:
                 raise FileNotFoundError("Unable to find page: {}".format(name))
 

--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -235,7 +235,7 @@ class SkillGUI:
         self.skill = skill
         self.on_gui_changed_callback = None
         self.config_core = Configuration.get()
-        
+
     @property
     def remote_url(self):
         return self.config_core.get('remote-server')


### PR DESCRIPTION
## Description
Enables sending qml ui from remote mycroft-core instance over network 

## How to test
Add to mycroft.conf (any level):
{
    "remote": true,
    "remote-server": "https://instance-where-mycroft-core-is-hosted-.com"
}

Additional Configuration Server Side Running Apache:
`ln -s /opt /var/www/html/opt`

## Contributor license agreement signed?
CLA [Yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
