### PR TITLE
Allow settingsmeta to be a yaml file

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -94,7 +94,7 @@ class SkillSettings(dict):
         self.name = name
         # set file paths
         self._settings_path = join(directory, 'settings.json')
-        self._meta_path = self._get_meta_path(directory)
+        self._meta_path = _get_meta_path(directory)
         self.is_alive = True
         self.loaded_hash = hash(json.dumps(self, sort_keys=True))
         self._complete_intialization = False
@@ -112,16 +112,6 @@ class SkillSettings(dict):
     def __hash__(self):
         """ Simple object unique hash. """
         return hash(str(id(self)) + self.name)
-
-    @staticmethod
-    def _get_meta_path(base_directory):
-        json_path = join(base_directory, 'settingsmeta.json')
-        yaml_path = join(base_directory, 'settingsmeta.yaml')
-        if isfile(json_path):
-            return json_path
-        if isfile(yaml_path):
-            return yaml_path
-        return None
 
     def run_poll(self, _=None):
         """Immediately poll the web for new skill settings"""
@@ -625,3 +615,13 @@ class SkillSettings(dict):
             if uuid is not None:
                 self._delete_metadata(uuid)
             self._upload_meta(settings_meta, hashed_meta)
+
+
+def _get_meta_path(base_directory):
+    json_path = join(base_directory, 'settingsmeta.json')
+    yaml_path = join(base_directory, 'settingsmeta.yaml')
+    if isfile(json_path):
+        return json_path
+    if isfile(yaml_path):
+        return yaml_path
+    return None

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -113,7 +113,8 @@ class SkillSettings(dict):
         """ Simple object unique hash. """
         return hash(str(id(self)) + self.name)
 
-    def _get_meta_path(self, base_directory):
+    @staticmethod
+    def _get_meta_path(base_directory):
         json_path = join(base_directory, 'settingsmeta.json')
         yaml_path = join(base_directory, 'settingsmeta.yaml')
         if isfile(json_path):

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -20,10 +20,11 @@
     settings.
 
     The GUI for the setting is described by a file in the skill's root
-    directory called settingsmeta.json.  The "name" is associates the
-    user-interface field with the setting name in the dictionary.  For
-    example, you might have a setting['username'].  In the settingsmeta
-    you can describe the interface you want to edit that value with:
+    directory called settingsmeta.json (or settingsmeta.yaml, if you
+    prefer working with yaml). The "name" associates the user-interface
+    field with the setting name in the dictionary. For example, you
+    might have a setting['username'].  In the settingsmeta you can
+    describe the interface you want to edit that value with:
         ...
         "fields": [
                {
@@ -61,6 +62,7 @@
 import json
 import hashlib
 import os
+import yaml
 from threading import Timer
 from os.path import isfile, join, expanduser
 from requests.exceptions import RequestException
@@ -92,7 +94,7 @@ class SkillSettings(dict):
         self.name = name
         # set file paths
         self._settings_path = join(directory, 'settings.json')
-        self._meta_path = join(directory, 'settingsmeta.json')
+        self._meta_path = self._get_meta_path(directory)
         self.is_alive = True
         self.loaded_hash = hash(json.dumps(self, sort_keys=True))
         self._complete_intialization = False
@@ -104,12 +106,21 @@ class SkillSettings(dict):
         self._is_alive = True
 
         # if settingsmeta exist
-        if isfile(self._meta_path):
+        if self._meta_path:
             self._poll_skill_settings()
 
     def __hash__(self):
         """ Simple object unique hash. """
         return hash(str(id(self)) + self.name)
+
+    def _get_meta_path(self, base_directory):
+        json_path = join(base_directory, 'settingsmeta.json')
+        yaml_path = join(base_directory, 'settingsmeta.yaml')
+        if isfile(json_path):
+            return json_path
+        if isfile(yaml_path):
+            return yaml_path
+        return None
 
     def run_poll(self, _=None):
         """Immediately poll the web for new skill settings"""
@@ -133,7 +144,7 @@ class SkillSettings(dict):
     # TODO: break this up into two classes
     def initialize_remote_settings(self):
         """ initializes the remote settings to the server """
-        # if settingsmeta.json exists (and is valid)
+        # if the settingsmeta file exists (and is valid)
         # this block of code is a control flow for
         # different scenarios that may arises with settingsmeta
         self.load_skill_settings_from_file()  # loads existing settings.json
@@ -196,20 +207,26 @@ class SkillSettings(dict):
 
     def _load_settings_meta(self):
         """ Loads settings metadata from skills path. """
-        if isfile(self._meta_path):
-            try:
-                with open(self._meta_path, encoding='utf-8') as f:
+        if not self._meta_path:
+            return None
+
+        _, ext = os.path.splitext(self._meta_path)
+        json_file = True if ext.lower() == ".json" else False
+
+        try:
+            with open(self._meta_path, encoding='utf-8') as f:
+                if json_file:
                     data = json.load(f)
-                return data
-            except Exception as e:
-                LOG.error("Failed to load setting file: "+self._meta_path)
-                LOG.error(repr(e))
-                return None
-        else:
+                else:
+                    data = yaml.load(f)
+            return data
+        except Exception as e:
+            LOG.error("Failed to load setting file: " + self._meta_path)
+            LOG.error(repr(e))
             return None
 
     def _send_settings_meta(self, settings_meta):
-        """ Send settingsmeta.json to the server.
+        """ Send settingsmeta to the server.
 
         Args:
             settings_meta (dict): dictionary of the current settings meta
@@ -282,7 +299,7 @@ class SkillSettings(dict):
         return isfile(uuid_file)
 
     def _migrate_settings(self, settings_meta):
-        """ sync settings.json and settingsmeta.json in memory """
+        """ sync settings.json and settingsmeta in memory """
         meta = settings_meta.copy()
         self.load_skill_settings_from_file()
         sections = meta['skillMetadata']['sections']
@@ -299,7 +316,7 @@ class SkillSettings(dict):
         """ uploads the new meta data to settings with settings migration
 
         Args:
-            settings_meta (dict): settingsmeta.json
+            settings_meta (dict): from settingsmeta.json or settingsmeta.yaml
             hashed_meta (str): {skill-folder}-settinsmeta.json
         """
         meta = self._migrate_settings(settings_meta)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ python-vlc==1.1.2
 pulsectl==17.7.4
 google-api-python-client==1.6.4
 fasteners==0.14.1
+PyYAML==3.13
 
 msm==0.7.3
 msk==0.3.12


### PR DESCRIPTION
## Description
Allows settingsmeta to be a yaml file (I find it easier to work with than json).

## How to test
Use the following with the HomeAssistant skill:

```
identifier: HomeAssistantSkill
name: HomeAssistant
skillMetadata:
  sections:
    - name: Login
      fields:
        - label: Host adress
          name: host
          type: text
          value: ''

        - label: Long-Lived Access Tokens
          name: token
          type: password
          value: ''

        - label: Port number
          name: portnum
          type: Number
          value: 8123

    - name: Options
      fields:
        - label: Use SSL
          name: ssl
          type: checkbox
          value: false

        - label: Verify SSL Certificate
          name: verify
          type: checkbox
          value: true

        - label: Enable conversation component as fallback
          name: enable_fallback
          type: checkbox
          value: true

        - label: Brightness Step
          name: brightness_step
          type: Number
          value: 20

        - label: Temperature Step
          name: temperature_step
          type: Number
          value: 2
```
## Contributor license agreement signed?
CLA
 - [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
