### PR TITLE
Interaction target

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -50,6 +50,13 @@ def handle_speak(event):
     Configuration.init(bus)
     global _last_stop_signal
 
+    # if the message is targeted and audio is not the target don't
+    # don't synthezise speech
+    if (event.context and 'destination' in event.context and
+            event.context['destination'] and
+            'audio' not in event.context['destination']):
+        return
+
     # Get conversation ID
     if event.context and 'ident' in event.context:
         ident = event.context['ident']

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -60,7 +60,8 @@ def handle_wakeword(event):
 
 def handle_utterance(event):
     LOG.info("Utterance: " + str(event['utterances']))
-    context = {'client_name': 'mycroft_listener'}
+    context = {'client_name': 'mycroft_listener',
+               'destination': 'audio'}
     if 'ident' in event:
         ident = event.pop('ident')
         context['ident'] = ident

--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -1316,9 +1316,12 @@ def gui_main(stdscr):
                         break
                 else:
                     # Treat this as an utterance
+                    ident = str(time.time()) + str(hash(line.strip()))
                     bus.emit(Message("recognizer_loop:utterance",
                                      {'utterances': [line.strip()],
-                                      'lang': config.get('lang', 'en-us')}))
+                                      'lang': config.get('lang', 'en-us')},
+                                     {'ident': ident, 'target': None}))
+
                 hist_idx = -1
                 line = ""
             elif code == 16 or code == 545:  # Ctrl+P or Ctrl+Left (Previous)


### PR DESCRIPTION
## Description
This restore the accidentally deleted branch for allowing clients to specify destinations for the messages. The idea that a client will assign a destination in the message context, for the speech client it will be the "audio" system but web clients or similar things can set an id per connection so the reply is only picked up and output by the correct client. This can also be used for the Android client to return not output the message on the base unit.

## How to test
Make sure mycroft responds to spoken queries. then edit the `mycroft/client/speech/__main__.py` and set the destination to "asdf" and make sure that no audio answer is received.

## Contributor license agreement signed?
CLA [ Yes ]
