### PR TITLE
Support chopping old audio via precise upgrade

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -121,6 +121,8 @@ class PocketsphinxHotWord(HotWordEngine):
 
 
 class PreciseHotword(HotWordEngine):
+    CHUNK_SIZE = 2048
+
     def __init__(self, key_phrase="hey mycroft", config=None, lang="en-us"):
         super(PreciseHotword, self).__init__(key_phrase, config, lang)
         from precise_runner import (
@@ -148,7 +150,7 @@ class PreciseHotword(HotWordEngine):
             ).replace('.tar.gz', '.pb')
 
         self.has_found = False
-        self.stream = ReadWriteStream()
+        self.stream = ReadWriteStream(chop_samples=self.CHUNK_SIZE * 3)
 
         def on_activation():
             self.has_found = True
@@ -157,7 +159,7 @@ class PreciseHotword(HotWordEngine):
         sensitivity = self.config.get('sensitivity', 0.5)
 
         self.runner = PreciseRunner(
-            PreciseEngine(precise_exe, self.precise_model),
+            PreciseEngine(precise_exe, self.precise_model, self.CHUNK_SIZE),
             trigger_level, sensitivity,
             stream=self.stream, on_activation=on_activation,
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ adapt-parser==0.3.2
 padatious==0.4.6
 fann2==1.0.7
 padaos==0.1.9
-precise-runner==0.2.1
+precise-runner==0.3.1
 petact==0.1.2
 
 # dev setup tools


### PR DESCRIPTION
# Description
This supports dropping audio buffers when the cpu falls behind so that the latency doesn't infinitely increase.

## How to test
 - Make sure precise still activates on a Desktop / Mark 1