### PR TITLE
Remove additional space after initials

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -76,6 +76,11 @@ def handle_speak(event):
         # so we likely will want to get rid of this when not running on Mimic
         if (config.get('enclosure', {}).get('platform') != "picroft" and
                 len(re.findall('<[^>]*>', utterance)) == 0):
+            # Remove any whitespace present after the period,
+            # if a character (only alpha) ends with a period
+            # ex: A. Lincoln -> A.Lincoln
+            # so that we don't split at the period
+            utterance = re.sub(r'\b([A-za-z][\.])(\s+)', r'\g<1>', utterance)
             chunks = re.split(r'(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\;|\?)\s',
                               utterance)
             for chunk in chunks:


### PR DESCRIPTION
## Description
Ask Mark1 - "when was truman born?" 
It generates the response "Harry S. Truman was born on Thursday, May 8, 1884". 
The period followed by space after the 'S' splits the sentences and leads to additional pause.

## How to test

**Without fix**
`say T. Stark Dr.Strange C. America in avengers` would give
['T.', 'Stark Dr.Strange C.', 'America in avengers'] to TTS and you hear pauses

**With Fix**
`say T. Stark Dr.Strange C. America in avengers` would give
['T.Stark Dr.Strange C.America in avengers'] to TTS and there should be no pauses 

## Contributor license agreement signed?
CLA [Yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
