### PR TITLE
Fix copy/paste error in chmod command

### DIFF
--- a/scripts/mycroft-use.sh
+++ b/scripts/mycroft-use.sh
@@ -311,7 +311,7 @@ elif [ "${change_to}" == "stable" ] ; then
 
         if [ -f /etc/init.d/mycroft-skills.original ] ; then
             restore_init_scripts
-            sudo chmod -x /etc/cron.hourly/mycroft-core # Enable updates
+            sudo chmod +x /etc/cron.hourly/mycroft-core # Enable updates
 
             # Reboot since the audio input won't work for some reason
             sudo reboot


### PR DESCRIPTION
The command that is supposed to re-enable the mycroft-core hourly cron job was
using "-x" instead of "+x".

## How to test
Run mycroft-use to switch to unstable then back.  The look for the 'x' attribute on the
file /etc/cron.hourly/mycroft-core.  Previously it would be missing, but after this change
it will be restored upon switching back to stable.
