### PR TITLE
Use SafeLoader to load settingsmeta yaml

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -268,7 +268,7 @@ class SkillSettings(dict):
                     if json_file:
                         data = json.load(f)
                     else:
-                        data = yaml.load(f)
+                        data = yaml.safe_load(f)
             except Exception as e:
                 LOG.error("Failed to load setting file: " + self._meta_path)
                 LOG.error(repr(e))


### PR DESCRIPTION
## Description
SafeLoader limits the amount of custom methods that can be supplied with
the yaml and supports the basic yaml features.

I'm not certain this is 100% correct but after reading @krisgesling's [issue on msm](https://github.com/MycroftAI/mycroft-skills-manager/issues/36) and the related docs it seems like the way to go.

## How to test
Ensure that settingsmeta.yaml files works. 

## Contributor license agreement signed?
CLA [ Yes ]
