### PR TITLE
Pass the device id as part of the refresh sequence

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -82,7 +82,8 @@ class Api:
                 data = self.send({
                     "path": "auth/token",
                     "headers": {
-                        "Authorization": "Bearer " + self.identity.refresh
+                        "Authorization": "Bearer " + self.identity.refresh,
+                        "Device": self.identity.uuid
                     }
                 })
                 IdentityManager.save(data, lock=False)


### PR DESCRIPTION
Having the device uuid in the packet along with the refresh token is
useful when debugging and recovering from unusual protocol failure
scenarios.
