### PR TITLE
Fix #2129: permission group tests against user

### DIFF
--- a/scripts/prepare-msm.sh
+++ b/scripts/prepare-msm.sh
@@ -60,6 +60,6 @@ if [[ ${IS_TRAVIS} != true ]] ; then
 fi
 
 # fix ownership of ${mycroft_root_dir} if it is not owned by the ${setup_user}
-if [[ $( stat -c "%U:%G" ${mycroft_root_dir} ) != "${setup_user}:${setup_user}" ]] ; then
+if [[ $( stat -c "%U:%G" ${mycroft_root_dir} ) != "${setup_user}:${setup_group}" ]] ; then
     change_ownership
 fi


### PR DESCRIPTION
## Description
Currently the permissions of `/opt/mycroft` are tested against `user:user` instead of `user:group`. This works where the username and usergroup are the same string, but for users where these differ, attempts to update the permissions on each boot of Mycroft. The existing code sets permissions correctly as `user:group` so doesn't cause any change.
Fixes #2129

## How to test
Change username to differ from usergroup, booting Mycroft should prompt to update permissions.
Checkout this commit, no permission update prompted.

## Contributor license agreement signed?
- [x] CLA
