### PR TITLE
Restored ability to store wakewords locally

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -471,13 +471,13 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                     if self.save_wake_words:
                         # Save wake word locally
                         audio = self._create_audio_data(byte_data, source)
-                        metadata = self._compile_metadata()
+                        meta = self._compile_metadata()
                         if not isdir(self.saved_wake_words_dir):
                             os.mkdir(self.saved_wake_words_dir)
                         module = self.wake_word_recognizer.__class__.__name__
 
                         fn = join(self.saved_wake_words_dir,
-                                  '.'.join([v for v in metadata.values()])
+                                  '_'.join([meta[k] for k in sorted(meta)])
                                   + '.wav')
                         with open(fn, 'wb') as f:
                             f.write(audio.get_wav_data())
@@ -488,7 +488,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                             target=self._upload_wake_word, daemon=True,
                             args=[audio or
                                   self._create_audio_data(byte_data, source),
-                                  metadata]
+                                  meta]
                         ).start()
 
     @staticmethod

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -19,6 +19,7 @@ import collections
 import datetime
 import json
 import os
+from os.path import isdir, join
 import pyaudio
 import requests
 import speech_recognition
@@ -29,6 +30,7 @@ from speech_recognition import (
     AudioSource,
     AudioData
 )
+from tempfile import gettempdir
 from threading import Thread, Lock
 
 from mycroft.api import DeviceApi
@@ -204,6 +206,10 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         else:
             self.save_utterances = listener_config.get('save_utterances',
                                                        False)
+
+        self.save_wake_words = listener_config.get('record_wake_words')
+        self.saved_wake_words_dir = join(gettempdir(), 'mycroft_wake_words')
+
         self.upload_lock = Lock()
         self.filenames_to_upload = []
         self.mic_level_file = os.path.join(get_ipc_directory(), "mic_level")
@@ -347,7 +353,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         """
         self._stop_signaled = True
 
-    def _upload_wake_word(self, audio):
+    def _compile_metadata(self):
         ww_module = self.wake_word_recognizer.__class__.__name__
         if ww_module == 'PreciseHotword':
             model_path = self.wake_word_recognizer.precise_model
@@ -356,7 +362,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         else:
             model_hash = '0'
 
-        metadata = {
+        return {
             'name': self.wake_word_name.replace(' ', '-'),
             'engine': md5(ww_module.encode('utf-8')).hexdigest(),
             'time': str(int(1000 * get_time())),
@@ -364,6 +370,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             'accountId': self.account_id,
             'model': str(model_hash)
         }
+
+    def _upload_wake_word(self, audio, metadata):
         requests.post(
             self.upload_url, files={
                 'audio': BytesIO(audio.get_wav_data()),
@@ -456,13 +464,31 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                 audio_data = chopped + silence
                 said_wake_word = \
                     self.wake_word_recognizer.found_wake_word(audio_data)
-                # if a wake word is success full then upload wake word
-                if said_wake_word and self.config['opt_in'] and not \
-                        self.upload_disabled:
-                    Thread(
-                        target=self._upload_wake_word, daemon=True,
-                        args=[self._create_audio_data(byte_data, source)]
-                    ).start()
+
+                # Save positive wake words as appropriate
+                if said_wake_word:
+                    audio = None
+                    if self.save_wake_words:
+                        # Save wake word locally
+                        audio = self._create_audio_data(byte_data, source)
+                        metadata = self._compile_metadata()
+                        if not isdir(self.saved_wake_words_dir):
+                            os.mkdir(self.saved_wake_words_dir)
+                        module = self.wake_word_recognizer.__class__.__name__
+
+                        fn = join(self.saved_wake_words_dir,
+                                  '.'.join(metadata) + '.wav')
+                        with open(fn, 'wb') as f:
+                            f.write(audio.get_wav_data())
+
+                    if self.config['opt_in'] and not self.upload_disabled:
+                        # Upload wake word for opt_in people
+                        Thread(
+                            target=self._upload_wake_word, daemon=True,
+                            args=[audio or
+                                  self._create_audio_data(byte_data, source),
+                                  metadata]
+                        ).start()
 
     @staticmethod
     def _create_audio_data(raw_data, source):

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -477,7 +477,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                         module = self.wake_word_recognizer.__class__.__name__
 
                         fn = join(self.saved_wake_words_dir,
-                                  '.'.join(metadata) + '.wav')
+                                  '.'.join([v for v in metadata.values()])
+                                  + '.wav')
                         with open(fn, 'wb') as f:
                             f.write(audio.get_wav_data())
 

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -471,13 +471,13 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                     if self.save_wake_words:
                         # Save wake word locally
                         audio = self._create_audio_data(byte_data, source)
-                        meta = self._compile_metadata()
+                        mtd = self._compile_metadata()
                         if not isdir(self.saved_wake_words_dir):
                             os.mkdir(self.saved_wake_words_dir)
                         module = self.wake_word_recognizer.__class__.__name__
 
                         fn = join(self.saved_wake_words_dir,
-                                  '_'.join([meta[k] for k in sorted(meta)])
+                                  '_'.join([str(mtd[k]) for k in sorted(mtd)])
                                   + '.wav')
                         with open(fn, 'wb') as f:
                             f.write(audio.get_wav_data())
@@ -488,7 +488,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                             target=self._upload_wake_word, daemon=True,
                             args=[audio or
                                   self._create_audio_data(byte_data, source),
-                                  meta]
+                                  mtd]
                         ).start()
 
     @staticmethod

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -149,17 +149,18 @@
   // Override: REMOTE
   "listener": {
     "sample_rate": 16000,
+    // Set 'record_wake_words' to save a copy of wake word triggers
+    // as .wav files under: /tmp/mycroft_wake_words
     "record_wake_words": false,
-    // Override to save each sentence sent to STT -- by default they are only
-    // kept briefly in-memory.  This can be useful for for debugging or other
-    // custom purposes.  Recordings are saved to:
-    // /tmp/mycroft_utterance<TIMESTAMP>.wav
+    // Set 'save_utterances' to save each sentence sent to STT -- by default
+    // they are only kept briefly in-memory.  This can be useful for for
+    // debugging or other custom purposes.  Recordings are saved
+    // under: /tmp/mycroft_utterance<TIMESTAMP>.wav
     "save_utterances": false,
     "wake_word_upload": {
       "disable": false,
       "url": "https://training.mycroft.ai/precise/upload"
     },
-
 
     // Override as SYSTEM or USER to select a specific microphone input instead of
     // the PortAudio default input.
@@ -203,7 +204,7 @@
         // "local_model_file": "~/.mycroft/precise/models/something.pb"
         // Precise options:
         // "sensitivity": 0.5,  // Higher = more sensitive
-        // "trigger_level": 3  // Higher = more delay & less sensitive
+        // "trigger_level": 3   // Higher = more delay & less sensitive
         },
 
     "wake up": {


### PR DESCRIPTION
The code that handles the local save of wake words configuration -
"record_wake_words" - was removed some time ago.  This restores that
capability.

## How to test

Add the mycroft.conf
```json
{
     "record_wake_words": true
}
```
Then restart Mycroft.  It should begin saving .wav files under the
/tmp/mycroft_wake_words directory.
