### PR TITLE
Fix usage of mtd before assignment

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -468,6 +468,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                 # Save positive wake words as appropriate
                 if said_wake_word:
                     audio = None
+                    mtd = None
                     if self.save_wake_words:
                         # Save wake word locally
                         audio = self._create_audio_data(byte_data, source)
@@ -488,7 +489,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                             target=self._upload_wake_word, daemon=True,
                             args=[audio or
                                   self._create_audio_data(byte_data, source),
-                                  mtd]
+                                  mtd or self._compile_metadata()]
                         ).start()
 
     @staticmethod


### PR DESCRIPTION
## Description
When opt in is set and local saving of the file no mtd would be generated and the cause a undefined variable exception. This generates metadata if it's missing

## How to test
Ensure that voice input works.

## Contributor license agreement signed?
CLA [ Yes ]