### PR TITLE
CommonIoT/state

### DIFF
--- a/mycroft/skills/common_iot_skill.py
+++ b/mycroft/skills/common_iot_skill.py
@@ -133,6 +133,7 @@ class Action(Enum):
     TRIGGER = auto()
     BINARY_QUERY = auto()  # yes/no answer
     INFORMATION_QUERY = auto()  # detailed answer
+    LOCATE = auto()
 
 
 @total_ordering

--- a/mycroft/skills/common_iot_skill.py
+++ b/mycroft/skills/common_iot_skill.py
@@ -30,7 +30,7 @@ from mycroft.messagebus.message import Message
 
 ENTITY = "ENTITY"
 SCENE = "SCENE"
-IOT_REQUEST_ID = "iot_request_id"  #TODO make the id a property of the request
+IOT_REQUEST_ID = "iot_request_id"  # TODO make the id a property of the request
 
 
 _counter = count()
@@ -88,6 +88,7 @@ class Attribute(Enum):
     BRIGHTNESS = auto()
     COLOR = auto()
     COLOR_TEMPERATURE = auto()
+    TEMPERATURE = auto()
 
 
 @unique
@@ -106,8 +107,8 @@ class State(Enum):
     brightness or color.
     """
     STATE = auto()
-    ON = auto()
-    OFF = auto()
+    POWERED = auto()
+    UNPOWERED = auto()
     LOCKED = auto()
     UNLOCKED = auto()
     OCCUPIED = auto()
@@ -130,7 +131,8 @@ class Action(Enum):
     INCREASE = auto()
     DECREASE = auto()
     TRIGGER = auto()
-    QUERY = auto()
+    BINARY_QUERY = auto()  # yes/no answer
+    INFORMATION_QUERY = auto()  # detailed answer
 
 
 @total_ordering
@@ -369,7 +371,6 @@ class CommonIoTSkill(MycroftSkill, ABC):
         self._current_iot_request = id
         yield id
         self._current_iot_request = None
-
 
     @_track_request
     def _handle_trigger(self, message: Message):

--- a/mycroft/skills/common_iot_skill.py
+++ b/mycroft/skills/common_iot_skill.py
@@ -243,13 +243,16 @@ class IoTRequest():
                     ' value={value},'
                     ' state={state}'
                     ')')
+        entity = '"{}"'.format(self.entity) if self.entity else None
+        scene = '"{}"'.format(self.scene) if self.scene else None
+        value = '"{}"'.format(self.value) if self.value is not None else None
         return template.format(
             action=self.action,
             thing=self.thing,
             attribute=self.attribute,
-            entity='"{}"'.format(self.entity) if self.entity else None,
-            scene='"{}"'.format(self.scene) if self.scene else None,
-            value='"{}"'.format(self.value) if self.value is not None else None,
+            entity=entity,
+            scene=scene,
+            value=value,
             state=self.state
         )
 
@@ -412,11 +415,12 @@ class CommonIoTSkill(MycroftSkill, ABC):
     def speak(self, utterance, *args, **kwargs):
         if self._current_iot_request:
             self.bus.emit(Message(_BusKeys.SPEAK,
-                              data={"skill_id": self.skill_id,
-                                    IOT_REQUEST_ID: self._current_iot_request,
-                                    "speak_args": args,
-                                    "speak_kwargs": kwargs,
-                                    "speak": utterance}))
+                                  data={"skill_id": self.skill_id,
+                                        IOT_REQUEST_ID:
+                                            self._current_iot_request,
+                                        "speak_args": args,
+                                        "speak_kwargs": kwargs,
+                                        "speak": utterance}))
         else:
             super().speak(utterance, *args, **kwargs)
 

--- a/mycroft/skills/common_iot_skill.py
+++ b/mycroft/skills/common_iot_skill.py
@@ -62,6 +62,11 @@ class _BusKeys():
     SPEAK = BASE + ":speak"
 
 
+####################################################################
+# When adding a new Thing, Attribute, etc, be sure to also add the #
+# corresponding voc files to the skill-iot-control.                #
+####################################################################
+
 @unique
 class Thing(Enum):
     """
@@ -134,6 +139,8 @@ class Action(Enum):
     BINARY_QUERY = auto()  # yes/no answer
     INFORMATION_QUERY = auto()  # detailed answer
     LOCATE = auto()
+    LOCK = auto()
+    UNLOCK = auto()
 
 
 @total_ordering


### PR DESCRIPTION
## Description
This updates the common IoT skill to allow for query type requests (e.g. "what is the living room temperature," "where is my phone," and "is the bedside outlet on"). Note that a key difference between these requests and all others is that these _require_ verbal responses. To accommodate this, the `CommonIoTSkill` base class has been updated to intercept `speak` calls and pass them through to the control skill when handling an IoT request (calls to `speak` at any other time will be handled normally, by the `MycroftSkill` base class).

## How to test
Using the latest version of the [iot control skill](https://github.com/MycroftAI/skill-iot-control) and the [common iot homeassistant skill](https://github.com/MycroftAI/mycroft-homeassistant/tree/feature/commonIoT) try some of the queries above.


## Contributor license agreement signed?
CLA
 - [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
