### PR TITLE
Remove abstractmethod for MycroftSkill.stop()

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -24,7 +24,6 @@ import traceback
 from inspect import signature
 from datetime import datetime, timedelta
 
-import abc
 import re
 from itertools import chain
 from adapt.intent import Intent, IntentBuilder
@@ -1478,7 +1477,6 @@ class MycroftSkill:
             LOG.error("Failed to stop skill: {}".format(self.name),
                       exc_info=True)
 
-    @abc.abstractmethod
     def stop(self):
         pass
 


### PR DESCRIPTION
The MycroftSkill.stop() method does not need to be implemented by the majority of skills, no reason to require its implementation with an abstractmethod decorator.

## How to test
No real behavioral impact.