### PR TITLE
Remove unused subprocess module

### DIFF
--- a/mycroft/audio/services/simple/__init__.py
+++ b/mycroft/audio/services/simple/__init__.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import subprocess
 import signal
 from time import sleep
 


### PR DESCRIPTION
Does what it says in the title.  Quick and easy.

## How to test
Search code for "subprocess" and run.
