### PR TITLE
Add mycroft.util.time.to_system()

### DIFF
--- a/mycroft/util/time.py
+++ b/mycroft/util/time.py
@@ -93,3 +93,18 @@ def to_local(dt):
         return dt.astimezone(tz)
     else:
         return dt.replace(tzinfo=gettz("UTC")).astimezone(tz)
+
+
+def to_system(dt):
+    """ Convert a datetime to the system's local timezone
+
+    Args:
+        dt (datetime): A datetime (if no timezone, assumed to be UTC)
+    Returns:
+        (datetime): time converted to the operation system's timezone
+    """
+    tz = tzlocal()
+    if dt.tzinfo:
+        return dt.astimezone(tz)
+    else:
+        return dt.replace(tzinfo=gettz("UTC")).astimezone(tz)


### PR DESCRIPTION
Pulling method originally implemented in the default Mycroft skill-alarm, but useful by many for
converting a different timezone to whatever the native timezone is on the host machine.

## How to test
Run the skill-alarm, it should pull in this implementation instead of its own.
