### PR TITLE
Add local DeepSpeech STT

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,8 @@ pulsectl==17.7.4
 google-api-python-client==1.6.4
 fasteners==0.14.1
 PyYAML==3.13
+deepspeech==0.4.1
+numpy==1.16.4
 
 msm==0.7.6
 msk==0.3.13


### PR DESCRIPTION
## Description
Adds a Speech to Text backend that directly interfaces with the
deepspeech streaming API.

## How to test
Edit mycroft.conf to use a local deepspeech server (a DeepSpeech model will need to be downloaded). For example:
```
{
  "stt": {
    "module": "deepspeech",
    "deepspeech": {
      "model": "/home/jwatt/DeepSpeech/models/output_graph.pbmm",
      "alphabet": "/home/jwatt/DeepSpeech/models/alphabet.txt",
      "lm": "/home/jwatt/DeepSpeech/models/lm.binary",
      "trie": "/home/jwatt/DeepSpeech/models/trie"
    }
}
```
Using a memory-mapped model is highly recommended.

## Contributor license agreement signed?
Yes
