### PR TITLE
Limit travis branch builds to dev and master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+branches:
+  only:
+    - master
+    - dev
+
 language: python
 dist: xenial
 


### PR DESCRIPTION
## Description
Limits Travis branch builds to *dev* and *master* according to spec here:
https://docs.travis-ci.com/user/customizing-the-build#building-specific-branches

## How to test
Check that this branch is only built as PR on Travis

## Contributor license agreement signed?
CLA [ Yes ]
