### PR TITLE
[Debian] Replace Python 2 packages by their Python 3 counterparts and remove doubled "automake"

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -290,7 +290,7 @@ function install_deps() {
         redhat_common_install
     elif found_exe apt-get ; then
         # Debian / Ubuntu
-        $SUDO apt-get install -y git python3 python3-dev python-setuptools python-gobject-2-dev libtool libffi-dev libssl-dev autoconf automake bison swig libglib2.0-dev portaudio19-dev mpg123 screen flac curl libicu-dev pkg-config automake libjpeg-dev libfann-dev build-essential jq
+        $SUDO apt-get install -y git python3 python3-dev python3-setuptools python3-gi libtool libffi-dev libssl-dev autoconf automake bison swig libglib2.0-dev portaudio19-dev mpg123 screen flac curl libicu-dev pkg-config libjpeg-dev libfann-dev build-essential jq
     elif found_exe pacman; then
         # Arch Linux
         $SUDO pacman -S --needed --noconfirm git python python-pip python-setuptools python-virtualenv python-gobject python-virtualenvwrapper libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq pulseaudio pulseaudio-alsa

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -290,7 +290,7 @@ function install_deps() {
         redhat_common_install
     elif found_exe apt-get ; then
         # Debian / Ubuntu
-        $SUDO apt-get install -y git python3 python3-dev python3-setuptools python3-gi libtool libffi-dev libssl-dev autoconf automake bison swig libglib2.0-dev portaudio19-dev mpg123 screen flac curl libicu-dev pkg-config libjpeg-dev libfann-dev build-essential jq
+        $SUDO apt-get install -y git python3 python3-dev python3-setuptools libtool libffi-dev libssl-dev autoconf automake bison swig libglib2.0-dev portaudio19-dev mpg123 screen flac curl libicu-dev pkg-config libjpeg-dev libfann-dev build-essential jq
     elif found_exe pacman; then
         # Arch Linux
         $SUDO pacman -S --needed --noconfirm git python python-pip python-setuptools python-virtualenv python-gobject python-virtualenvwrapper libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq pulseaudio pulseaudio-alsa


### PR DESCRIPTION
## Description
The aim is simply to skip installing Python 2 on Debian where only Python 3 is required. (Removal of the doubled `automake` package from dependency list is trivial. 😉)
+ python3-setuptools: https://packages.debian.org/stretch/python3-setuptools
+ python3-gi: https://packages.debian.org/stretch/python3-gi

The second one is not the -dev package. There is non available for Python 3 only, instead for both: https://packages.debian.org/stretch/python-gi-dev
However I tested with the above two on x86 and didn't notice any compilation (including Mimic) or related run error with Mycroft. However clearly needs additional testing on e.g. ARM devices in case, or knowledge of the devs who know where/how the GObject libs/headers are actually used.

So take this PR for now as an idea to think about skipping the install of Python 2 on Debian.

## How to test
Install on Debian on different CPU architectures, where compilation might have different needs compared to x86.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)