### PR TITLE
Update pychromecast to 3.2.2

### DIFF
--- a/mycroft/audio/services/chromecast/__init__.py
+++ b/mycroft/audio/services/chromecast/__init__.py
@@ -89,14 +89,18 @@ class ChromecastService(RemoteAudioBackend):
 
         TODO: add playlist support and repeat
         """
+        self.cast.wait()  # Make sure the device is ready to receive command
         self.cast.quit_app()
+        while self.cast.status.status_text != '':
+            time.sleep(1)
 
         track = self.tracklist[0]
         # Report start of playback to audioservice
         if self._track_start_callback:
             self._track_start_callback(track)
-        LOG.debug('track: {}, type: {}'.format(track, guess_type(track)))
+        LOG.debug('track: {}, type: {}'.format(track, guess_type(track)[0]))
         mime = guess_type(track)[0] or 'audio/mp3'
+        self.cast.wait()  # Make sure the device is ready to receive command
         self.cast.play_media(track, mime)
 
     def stop(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ pocketsphinx==0.1.0
 inflection==0.3.1
 pillow==4.1.1
 python-dateutil==2.6.0
-pychromecast==0.7.7
+pychromecast==3.2.2
 python-vlc==1.1.2
 pulsectl==17.7.4
 google-api-python-client==1.6.4


### PR DESCRIPTION
## Description
pychromecast needed to be updated to fix pip package version conflict
when using streaming google STT.

Minor issues with startup of audio needed to be handled, mainly adding
explicit waits to ensure commands would be accepted


## Contributor license agreement signed?
CLA [ Yes ]
