### PR TITLE
Allow setting loglevel for speech / voice service

### DIFF
--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -23,7 +23,7 @@ from mycroft.lock import Lock as PIDLock  # Create/Support PID locking file
 from mycroft.messagebus.client.ws import WebsocketClient
 from mycroft.messagebus.message import Message
 from mycroft.util import create_daemon, wait_for_exit_signal, \
-    reset_sigint_handler
+    reset_sigint_handler, create_echo_function
 from mycroft.util.log import LOG
 
 bus = None  # Mycroft messagebus connection
@@ -175,6 +175,7 @@ def main():
     bus.on('recognizer_loop:audio_output_start', handle_audio_start)
     bus.on('recognizer_loop:audio_output_end', handle_audio_end)
     bus.on('mycroft.stop', handle_stop)
+    bus.on('message', create_echo_function('VOICE'))
 
     create_daemon(bus.run_forever)
     create_daemon(loop.run)


### PR DESCRIPTION
## Description
Add create_echo_function line to activate the standard logging options

## How to test
use `:log level debug` in cli and check that debug messages from the speech client starts appearing such as "Waiting for wake word" 

## Contributor license agreement signed?
CLA [ Yes ]
