### PR TITLE
Add gui related messages to list of hidden messages

### DIFF
--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -457,7 +457,8 @@ class SkillTest(object):
 
 
 # Messages that should not print debug info
-HIDDEN_MESSAGES = ['skill.converse.request', 'skill.converse.response']
+HIDDEN_MESSAGES = ['skill.converse.request', 'skill.converse.response',
+                   'gui.page.show', 'gui.value.set']
 
 
 def load_dialog_list(skill, dialog):


### PR DESCRIPTION
## Description
These messages currently mainly clutter up the logs when checking the tester output for an error.

## How to test
Run the skill tester for mycroft-weather and check that the output doesn't contain any `gui.page.show` messages

## Contributor license agreement signed?
CLA [ Yes ]
