### PR TITLE
Read .voc files as lowercase

### DIFF
--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -43,7 +43,7 @@ def read_vocab_file(path):
         for line in voc_file.readlines():
             if line.startswith('#') or line.strip() == '':
                 continue
-            vocab.append(expand_options(line))
+            vocab.append(expand_options(line.lower()))
     return vocab
 
 


### PR DESCRIPTION
## Description
The .voc files are now read as lowercase only. Adding capitalization is a common error when creating .voc files or translating them. This mitigates the issue and makes the adapt system be closer to the Padatious behavior.

This also cleans up the lower()-ing of the speech transcription. Empty audio returns None that weren't handled very cleanly.

## How to test
Change _yes_ to _Yes_ in `mycroft/res/text/en-us/yes.voc` and check that a aks_yesno call in a skill can complete.

## Contributor license agreement signed?
CLA [ Yes ]
