### PR TITLE
Correct skill GID's for skills not in the marketplace

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ google-api-python-client==1.6.4
 fasteners==0.14.1
 PyYAML==3.13
 
-msm==0.7.6
+msm==0.7.7
 msk==0.3.13
 adapt-parser==0.3.3
 padatious==0.4.6


### PR DESCRIPTION
## Description
- Fixes skill GID generated for skills not in marketplace
- Adds caching of skillsmeta.json
- Updates skills manifest if skills gid has changed

## How to test
Make sure Mycroft skills process starts

## Contributor license agreement signed?
CLA [ yes ]
