### PR TITLE
Lock cryptography version to 2.6.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 six==1.10.0
+cryptography==2.6.1
 requests==2.20.0
 gTTS==2.0.3
 gTTS-token==1.1.3


### PR DESCRIPTION
## Description
The newly released cryptography 2.7 deprecates OpenSSL 1.0.1 and will in
the future not support it.

This version is currently installed on the mark-1 devices, to make sure
thing doesn't break in the future the cryptography version is locked to
v2.6.1 the latest version supporting this OpenSSL version.

We should see if we can update the packaging to install a newer OpenSSL version on the devices.

## How to test
Run dev_setup.sh and check that all python dependencies install and then launch mycroft and check that Mycroft still runs.

## Contributor license agreement signed?
CLA [ Yes ]
