### PR TITLE
Make is_paired fail early if no uuid in identity

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -482,7 +482,7 @@ def has_been_paired():
 
 
 def is_paired(ignore_errors=True):
-    """ Determine if this device is actively paired with a web backend
+    """Determine if this device is actively paired with a web backend
 
     Determines if the installation of Mycroft has been paired by the user
     with the backend system, and if that pairing is still active.
@@ -497,19 +497,40 @@ def is_paired(ignore_errors=True):
         # The Mark 1 does perform a restart on RESET.
         return True
 
+    api = DeviceApi()
+    _paired_cache = api.identity.uuid and check_remote_pairing(ignore_errors)
+
+    return _paired_cache
+
+
+def check_remote_pairing(ignore_errors):
+    """Check that a basic backend endpoint accepts our pairing.
+
+    Arguments:
+        ignore_errors (bool): True if errors should be ignored when
+
+    Returns:
+        True if pairing checks out, otherwise False.
+    """
     try:
-        api = DeviceApi()
-        device = api.get()
-        _paired_cache = api.identity.uuid is not None and \
-            api.identity.uuid != ""
-        return _paired_cache
+        DeviceApi().get()
+        return True
     except HTTPError as e:
         if e.response.status_code == 401:
             return False
+        error = e
     except Exception as e:
-        LOG.warning('Could not get device info: ' + repr(e))
+        error = e
+
+    LOG.warning('Could not get device info: {}'.format(repr(error)))
+
     if ignore_errors:
         return False
-    if connected():
-        raise BackendDown
-    raise InternetDown
+
+    if isinstance(error, HTTPError):
+        if connected():
+            raise BackendDown from error
+        else:
+            raise InternetDown from error
+    else:
+        raise error

--- a/test/unittests/api/test_api.py
+++ b/test/unittests/api/test_api.py
@@ -351,7 +351,7 @@ class TestApi(unittest.TestCase):
     @mock.patch('mycroft.api._paired_cache', False)
     @mock.patch('mycroft.api.IdentityManager.get')
     @mock.patch('mycroft.api.requests.request')
-    def test_is_paired_false(self, mock_request, mock_identity_get):
+    def test_is_paired_false_local(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200)
         mock_identity = mock.MagicMock()
         mock_identity.is_expired.return_value = False
@@ -360,4 +360,16 @@ class TestApi(unittest.TestCase):
 
         self.assertFalse(mycroft.api.is_paired())
         mock_identity.uuid = None
+        self.assertFalse(mycroft.api.is_paired())
+
+    @mock.patch('mycroft.api._paired_cache', False)
+    @mock.patch('mycroft.api.IdentityManager.get')
+    @mock.patch('mycroft.api.requests.request')
+    def test_is_paired_false_remote(self, mock_request, mock_identity_get):
+        mock_request.return_value = create_response(401)
+        mock_identity = mock.MagicMock()
+        mock_identity.is_expired.return_value = False
+        mock_identity.uuid = '1234'
+        mock_identity_get.return_value = mock_identity
+
         self.assertFalse(mycroft.api.is_paired())


### PR DESCRIPTION
## Description
Refactors code so no request is sent to backend if the local identity
file is empty / has no uuid. Since if this part is missing core already
knows that it's not paired correctly.

## How to test
Check that an unpaired device launches the pairing sequence as intended

## Contributor license agreement signed?
CLA [ Yes ]
