### PR TITLE
Feature/better listener update

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -32,6 +32,7 @@ from mycroft.util.log import LOG
 from mycroft.util import find_input_device
 from queue import Queue, Empty
 import json
+from copy import deepcopy
 
 AUDIO_DATA = 0
 STREAM_START = 1
@@ -305,7 +306,11 @@ class RecognizerLoop(EventEmitter):
         # TODO remove this, only for server settings compatibility
         phonemes = self.config.get("phonemes")
         thresh = self.config.get("threshold")
-        config = self.config_core.get("hotwords", {word: {}})
+
+        # Since we're editing it for server backwards compatibility
+        # use a copy so we don't alter the hash of the config and
+        # trigger a reload.
+        config = deepcopy(self.config_core.get("hotwords", {word: {}}))
 
         if word not in config:
             config[word] = {'module': 'precise'}

--- a/test/unittests/client/test_local_recognizer.py
+++ b/test/unittests/client/test_local_recognizer.py
@@ -62,6 +62,7 @@ class LocalRecognizerInitTest(unittest.TestCase):
         # Test "Hey Victoria"
         test_config['listener']['wake_word'] = 'hey victoria'
         test_config['listener']['phonemes'] = 'HH EY . V IH K T AO R IY AH'
+        test_config['listener']['threshold'] = 1e-90
         rl = RecognizerLoop()
         self.assertEquals(rl.wakeword_recognizer.key_phrase, "hey victoria")
 


### PR DESCRIPTION
## Description
- Only trigger reload if listener-related sections have been modified
- Avoid changing the configuration 

## How to test
- Restart the voice service and ensure that the wake word is only loaded once.
- Change default units on the backend and make sure the listener isn't reloaded.
- Change wakeword to Christopher and make sure it is reloaded

## Contributor license agreement signed?
CLA [ Yes ]