### PR TITLE
'next {day}' to be 3-9 days in future

### DIFF
--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -680,6 +680,10 @@ def extract_datetime_en(string, dateNow, default_time):
     date and the remainder string
        "what is weather forecast".
 
+    The "next" instance of a day or weekend is considered to be no earlier than
+    48 hours in the future. On Friday, "next Monday" would be in 3 days.
+    On Saturday, "next Monday" would be in 9 days.
+
     Args:
         string (str): string containing date words
         dateNow (datetime): A reference date/time for "tommorrow", etc
@@ -886,7 +890,8 @@ def extract_datetime_en(string, dateNow, default_time):
             if dayOffset < 0:
                 dayOffset += 7
             if wordPrev == "next":
-                dayOffset += 7
+                if dayOffset <= 2:
+                    dayOffset += 7
                 used += 1
                 start -= 1
             elif wordPrev == "last":
@@ -952,7 +957,8 @@ def extract_datetime_en(string, dateNow, default_time):
                 tmpOffset = (d + 1) - int(today)
                 used = 3
                 if wordNext == "next":
-                    tmpOffset += 7
+                    if dayOffset <= 2:
+                        tmpOffset += 7
                     used += 1
                     start -= 1
                 elif wordNext == "last":

--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -14,15 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-"""
-The mycroft.util.parse module provides various parsing functions for
-things like numbers, times, durations etc.
-
-The focus of these parsing functions is to extract data from natural speech
-and to allow localization.
-"""
-
 from difflib import SequenceMatcher
 from mycroft.util.time import now_local
 from mycroft.util.lang import get_primary_lang_code
@@ -213,6 +204,10 @@ def extract_datetime(text, anchorDate=None, lang=None, default_time=None):
     Extracts date and time information from a sentence.  Parses many of the
     common ways that humans express dates and times, including relative dates
     like "5 days from today", "tomorrow', and "Tuesday".
+
+    The "next" instance of a day or weekend is considered to be no earlier than
+    48 hours in the future. On Friday, "next Monday" would be in 3 days.
+    On Saturday, "next Monday" would be in 9 days.
 
     Vague terminology are given arbitrary values, like:
         - morning = 8 AM

--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -213,10 +213,6 @@ def extract_datetime(text, anchorDate=None, lang=None, default_time=None):
     common ways that humans express dates and times, including relative dates
     like "5 days from today", "tomorrow', and "Tuesday".
 
-    The "next" instance of a day or weekend is considered to be no earlier than
-    48 hours in the future. On Friday, "next Monday" would be in 3 days.
-    On Saturday, "next Monday" would be in 9 days.
-
     Vague terminology are given arbitrary values, like:
         - morning = 8 AM
         - afternoon = 3 PM

--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -14,6 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+The mycroft.util.parse module provides various parsing functions for
+things like numbers, times, durations etc.
+The focus of these parsing functions is to extract data from natural speech
+and to allow localization.
+"""
+
 from difflib import SequenceMatcher
 from mycroft.util.time import now_local
 from mycroft.util.lang import get_primary_lang_code

--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -18,6 +18,7 @@
 """
 The mycroft.util.parse module provides various parsing functions for
 things like numbers, times, durations etc.
+
 The focus of these parsing functions is to extract data from natural speech
 and to allow localization.
 """

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -340,20 +340,24 @@ class TestNormalize(unittest.TestCase):
                     "2022-06-27 00:00:00", "play happy birthday music")
         testExtract("Skype Mom at 12:45 pm next Thursday",
                     "2017-07-06 12:45:00", "skype mom")
+        testExtract("What's the weather next Wednesday?",
+                    "2017-07-05 00:00:00", "what weather")
         testExtract("What's the weather next Thursday?",
                     "2017-07-06 00:00:00", "what weather")
+        testExtract("What's the weather next Friday?",
+                    "2017-06-30 00:00:00", "what weather")
         testExtract("what is the weather next friday morning",
-                    "2017-07-07 08:00:00", "what is weather")
+                    "2017-06-30 08:00:00", "what is weather")
         testExtract("what is the weather next friday evening",
-                    "2017-07-07 19:00:00", "what is weather")
+                    "2017-06-30 19:00:00", "what is weather")
         testExtract("what is the weather next friday afternoon",
-                    "2017-07-07 15:00:00", "what is weather")
+                    "2017-06-30 15:00:00", "what is weather")
         testExtract("remind me to call mom on august 3rd",
                     "2017-08-03 00:00:00", "remind me to call mom")
         testExtract("Buy fireworks on the 4th of July",
                     "2017-07-04 00:00:00", "buy fireworks")
         testExtract("what is the weather 2 weeks from next friday",
-                    "2017-07-21 00:00:00", "what is weather")
+                    "2017-07-14 00:00:00", "what is weather")
         testExtract("what is the weather wednesday at 0700 hours",
                     "2017-06-28 07:00:00", "what is weather")
         testExtract("set an alarm wednesday at 7 o'clock",
@@ -452,9 +456,9 @@ class TestNormalize(unittest.TestCase):
         testExtract("remind me to call mom at 10am this saturday",
                     "2017-07-01 10:00:00", "remind me to call mom")
         testExtract("remind me to call mom at 10 next saturday",
-                    "2017-07-08 10:00:00", "remind me to call mom")
+                    "2017-07-01 10:00:00", "remind me to call mom")
         testExtract("remind me to call mom at 10am next saturday",
-                    "2017-07-08 10:00:00", "remind me to call mom")
+                    "2017-07-01 10:00:00", "remind me to call mom")
         # Below two tests, ensure that time is picked
         # even if no am/pm is specified
         # in case of weekdays/tonight


### PR DESCRIPTION
## Description
The "next" instance of a day or weekend is considered to be no earlier than 48 hours in the future. This means that the next day will never be outside of 3-9 days in the future.
- On Friday, "next Monday" would be in 3 days. 
- On Saturday, "next Monday" would be in 9 days.

## How to test
Unit tests updated, or ask Mycroft:
- what is the date next Wednesday/Friday/Sunday

## Contributor license agreement signed?
- [x] CLA 
