### PR TITLE
Resting screen handler name fix

### DIFF
--- a/mycroft/skills/core.py
+++ b/mycroft/skills/core.py
@@ -460,13 +460,11 @@ class SkillGUI:
         self.show_page("SYSTEM_UrlFrame.qml", override_idle)
 
 
-def resting_screen_handler(name=None):
+def resting_screen_handler(name):
     """ Decorator for adding a method as an resting screen handler.
 
         If selected will be shown on screen when device enters idle mode
     """
-    name = name or func.__self__.name
-
     def real_decorator(func):
         # Store the resting information inside the function
         # This will be used later in register_resting_screen

--- a/test/unittests/skills/test_core.py
+++ b/test/unittests/skills/test_core.py
@@ -27,7 +27,7 @@ from mycroft.messagebus.message import Message
 from mycroft.skills.skill_data import load_regex_from_file, load_regex, \
     load_vocab_from_file, load_vocabulary
 from mycroft.skills.core import MycroftSkill, load_skill, \
-    create_skill_descriptor, open_intent_envelope
+    create_skill_descriptor, open_intent_envelope, resting_screen_handler
 
 from test.util import base_config
 
@@ -54,6 +54,21 @@ class MockEmitter(object):
     def reset(self):
         self.types = []
         self.results = []
+
+
+class FunctionTest(unittest.TestCase):
+    def test_resting_screen_handler(self):
+        class T(MycroftSkill):
+            def __init__(self):
+                self.name = 'TestObject'
+
+            @resting_screen_handler('humbug')
+            def f(self):
+                pass
+
+        test_class = T()
+        self.assertTrue('resting_handler' in dir(test_class.f))
+        self.assertEquals(test_class.f.resting_handler, 'humbug')
 
 
 class MycroftSkillTest(unittest.TestCase):

--- a/test/unittests/skills/test_core.py
+++ b/test/unittests/skills/test_core.py
@@ -365,6 +365,8 @@ class MycroftSkillTest(unittest.TestCase):
                      'name': str(s.skill_id) + ':test.intent'}]
 
         self.check_register_decorators(expected)
+        # Restore sys.path
+        sys.path = path_orig
 
     def test_failing_set_context(self):
         s = SimpleSkill1()


### PR DESCRIPTION
## Description
The resting screen handler was accepting being set without a name parameter, however the the code handling the no name path wasn't working at all (and was completely wrong)

## How to test
Ensure that the date-time skill loads.

## Contributor license agreement signed?
CLA [ Yes ]