### PR TITLE
Fix parsing dates in utterances that include non-month 'may'

### DIFF
--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -929,7 +929,9 @@ def extract_datetime_en(string, dateNow, default_time):
                     hasYear = False
 
             # if no date indicators found, it may not be the month of May
-            elif word == 'may' and wordNext == 'i':
+            # may "i/we" ...
+            # "... may be"
+            elif word == 'may' and wordNext in ['i', 'we', 'be']:
                 datestr = ""
 
         # parse 5 days from tomorrow, 10 weeks from next thursday,

--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -927,6 +927,11 @@ def extract_datetime_en(string, dateNow, default_time):
                     hasYear = True
                 else:
                     hasYear = False
+
+            # if no date indicators found, it may not be the month of May
+            elif word == 'may' and wordNext == 'i':
+                datestr = ""
+
         # parse 5 days from tomorrow, 10 weeks from next thursday,
         # 2 months from July
         validFollowups = days + months + monthsShort

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -491,6 +491,19 @@ class TestNormalize(unittest.TestCase):
             extract_datetime('feed fish at 10 o\'clock', evening)[0],
             datetime(2017, 6, 27, 22, 0, 0))
 
+    def test_extract_date_with_may_I_en(self):
+        now = datetime(2019, 7, 4, 8, 1, 2)
+        may_date = datetime(2019, 5, 2, 10, 11, 20)
+        self.assertEqual(
+            extract_datetime('May I know what time it is tomorrow', now)[0],
+            datetime(2019, 7, 5, 0, 0, 0))
+        self.assertEqual(
+            extract_datetime('May I when 10 o\'clock is', now)[0],
+            datetime(2019, 7, 4, 10, 0, 0))
+        self.assertEqual(
+            extract_datetime('On 24th of may I want a reminder', may_date)[0],
+            datetime(2019, 5, 24, 0, 0, 0))
+
     def test_extract_relativedatetime_en(self):
         def extractWithFormat(text):
             date = datetime(2017, 6, 27, 10, 1, 2)


### PR DESCRIPTION
## Description
If an utterance includes the term "may" it is considered a date. However this may not be the month of May. 

Have proposed one possible solution but there are likely to be other cases I'm not considering.

## How to test
Unit tests included

## Contributor license agreement signed?
- [x] CLA
