### PR TITLE
Skills process startup speedup

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import time
+import datetime as dt
 from threading import Timer
 import mycroft.lock
 from mycroft import dialog
@@ -89,6 +90,14 @@ def _starting_up():
     # Wait until priority skills have been loaded before checking
     # network connection
     skill_manager.load_priority()
+
+    # If device has been offline for more than 2 weeks or
+    # skill state is in a limbo
+    update_limit = dt.datetime.now() - dt.timedelta(days=14)
+    if (not skill_manager.last_download or
+            skill_manager.last_download < update_limit):
+        skill_manager.download_skills(quick=True)
+
     skill_manager.start()
     check_connection()
 

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -66,7 +66,7 @@ import yaml
 import time
 import copy
 import re
-from threading import Timer
+from threading import Timer, Thread
 from os.path import isfile, join, expanduser
 from requests.exceptions import RequestException, HTTPError
 from msm import SkillEntry
@@ -161,7 +161,9 @@ class SkillSettings(dict):
 
         # if settingsmeta exist
         if self._meta_path:
-            self._poll_skill_settings()
+            t = Thread(target=self._poll_skill_settings)
+            t.daemon = True
+            t.start()
         # if not disallowed by user upload an entry for all skills installed
         elif self.config['skills']['upload_skill_manifest']:
             self._blank_poll_timer = Timer(1, self._init_blank_meta)

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 import gc
-import json
 import sys
 import time
 from glob import glob
@@ -23,7 +22,7 @@ import os
 from os.path import exists, join, basename, dirname, expanduser, isfile
 from threading import Thread, Event, Lock
 
-from msm import MycroftSkillsManager, SkillRepo, MsmException
+from msm import MsmException
 from mycroft import dialog
 from mycroft.enclosure.api import EnclosureAPI
 from mycroft.configuration import Configuration

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -161,7 +161,7 @@ class SkillManager(Thread):
         with open(self.installed_skills_file, 'w') as f:
             f.write('\n'.join(skill_names))
 
-    def download_skills(self, speak=False):
+    def download_skills(self, speak=False, quick=False):
         """ Invoke MSM to install default skills and/or update installed skills
 
             Args:
@@ -218,7 +218,11 @@ class SkillManager(Thread):
                         raise
                 installed_skills.add(skill.name)
             try:
-                msm.apply(install_or_update, msm.list())
+                # If defaults are installed
+                defaults = all([s.is_local for s in msm.list_defaults()])
+                num_threads = 20 if not defaults or quick else 2
+                msm.apply(install_or_update, msm.list(),
+                          max_threads=num_threads)
                 if SkillManager.manifest_upload_allowed and is_paired():
                     try:
                         DeviceApi().upload_skills_data(msm.skills_data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ google-api-python-client==1.6.4
 fasteners==0.14.1
 PyYAML==3.13
 
-msm==0.7.7
+msm==0.7.8
 msk==0.3.13
 adapt-parser==0.3.3
 padatious==0.4.6


### PR DESCRIPTION
## Description
Try to speed up the skills process startup.
- Run msm update after skills are loaded with a reduced thread count
- Fetch skill settings in parallel with rest of the skill loading
- Ensure that skill manifest is always uploaded as early as possible

This depends on a pending change in msm to allow reducing the number of threads used by the msm.apply() method.

I'm also testing how it behaves when loading skills in parallel using a thread pool.

## How to test
Assert the skills are loaded and updated as normal, with any luck some of the blocking calls have been removed from the critical path and a speedup can be seen. 

## Contributor license agreement signed?
CLA [ Yes ]