### PR TITLE
Only report STT timing if transcription exists

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -187,12 +187,13 @@ class AudioConsumer(Thread):
                 }
                 self.emitter.emit("recognizer_loop:utterance", payload)
                 self.metrics.attr('utterances', [transcription])
+
+                # Report timing metrics
+                report_timing(ident, 'stt', stopwatch,
+                              {'transcription': transcription,
+                               'stt': self.stt.__class__.__name__})
             else:
                 ident = str(stopwatch.timestamp)
-            # Report timing metrics
-            report_timing(ident, 'stt', stopwatch,
-                          {'transcription': transcription,
-                           'stt': self.stt.__class__.__name__})
 
     def transcribe(self, audio):
         def send_unknown_intent():

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -14,7 +14,6 @@
 #
 import time
 from threading import Thread
-import sys
 import speech_recognition as sr
 from pyee import EventEmitter
 from requests import RequestException, HTTPError


### PR DESCRIPTION
## Description
To clean up the metrics log empty transcriptions from false activation
are no longer reported.

## How to test
Make sure the speech client still runs as expected.

## Contributor license agreement signed?
CLA [ Yes ]
