### PR TITLE
Explain the config system used for the log level.

### DIFF
--- a/doc/source/mycroft.rst
+++ b/doc/source/mycroft.rst
@@ -64,6 +64,9 @@ mycroft.util
     mycroft.util
 
 .. toctree::
+    mycroft.util.log
+
+.. toctree::
     mycroft.util.parse
 Parsing functions for extracting data from natural speech.
 

--- a/doc/source/mycroft.util.log.rst
+++ b/doc/source/mycroft.util.log.rst
@@ -1,0 +1,5 @@
+mycroft.util.log
+==================
+
+.. automodule:: mycroft.util.log
+  :members:

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -237,7 +237,11 @@
   },
 
   // Level of logs to store, one of  "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG"
-  "log_level": "DEBUG",
+  // NOTE: This configuration setting is special and can only be changed in the
+  // SYSTEM or USER configuration file, it will not be read if defined in the
+  // DEFAULT (here) or in the REMOTE mycroft config.
+  // If not defined, the default log level is INFO.
+  //"log_level": "INFO",
 
   // Messagebus types that will NOT be output to logs
   "ignore_logs": ["enclosure.mouth.viseme", "enclosure.mouth.display"],

--- a/mycroft/util/log.py
+++ b/mycroft/util/log.py
@@ -12,6 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+
+"""
+Mycroft Logging module.
+
+This module provides the LOG pseudo function quickly creating a logger instance
+for use.
+
+The default log level of the logger created here can ONLY be set in
+/etc/mycroft/mycroft.conf or ~/.mycroft/mycroft.conf
+
+The default log level can also be programatically be changed by setting the
+LOG.level parameter.
+"""
+
 import inspect
 import logging
 import sys
@@ -62,6 +77,13 @@ class LOG:
 
     @classmethod
     def init(cls):
+        """ Initializes the class, sets the default log level and creates
+        the required handlers.
+        """
+
+        # Check configs manually, the Mycroft configuration system can't be
+        # used since it uses the LOG system and would cause horrible cyclic
+        # dependencies.
         confs = [SYSTEM_CONFIG, USER_CONFIG]
         config = {}
         for conf in confs:


### PR DESCRIPTION
## Description

@davidwagnerkc was a bit confused about the log_level setting (totally justified confusion), this adds some more documenation around the logger.

- Add module docstring
- Add comment in the init class method about setting up the log level
- Add mycroft.util.log to the readthedocs documentation
- Add comment in default log

## How to test
Read the docstrings and make sure they make sense.

## Contributor license agreement signed?
CLA [ Yes ]
