### PR TITLE
Quickfix: readthedocs build

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -62,7 +62,6 @@
 import json
 import hashlib
 import os
-import yaml
 import time
 import copy
 import re
@@ -259,6 +258,8 @@ class SkillSettings(dict):
         Returns:
             (dict) settings meta
         """
+        # Imported here do handle issue with readthedocs build
+        import yaml
         if self._meta_path and os.path.isfile(self._meta_path):
             _, ext = os.path.splitext(self._meta_path)
             json_file = True if ext.lower() == ".json" else False


### PR DESCRIPTION
## Description
The Mycroft API documentation were blank due to the import of the yaml
module for some reason. This moves the import into the method where it's
used.

## How to test
Compare the [new branch](https://mycroft-core.readthedocs.io/en/doc-readthedocs2/) with the [dev-branch](https://mycroft-core.readthedocs.io/en/latest/)

Check that a settingmeta.yaml can be loaded and used.

## Contributor license agreement signed?
CLA [ Yes ]