### PR TITLE
Check for terminals ability to display colours

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -115,13 +115,16 @@ function get_YN() {
     done
 }
 
+# If tput is available and can handle multiple colors
 if found_exe tput ; then
-    GREEN=$(tput setaf 2)
-    BLUE=$(tput setaf 4)
-    CYAN=$(tput setaf 6)
-    YELLOW=$(tput setaf 3)
-    RESET=$(tput sgr0)
-    HIGHLIGHT=$YELLOW
+    if [[ $(tput colors) != "-1" ]]; then
+        GREEN=$(tput setaf 2)
+        BLUE=$(tput setaf 4)
+        CYAN=$(tput setaf 6)
+        YELLOW=$(tput setaf 3)
+        RESET=$(tput sgr0)
+        HIGHLIGHT=$YELLOW
+    fi
 fi
 
 # Run a setup wizard the very first time that guides the user through some decisions


### PR DESCRIPTION
## Description

On serial connections, with weird terminal emulators or when run interactively
the terminal may not support colours this would cause the dev_setup to
be aborted. This adds a simple check for terminal colors.

"-1" for no color support was empirically established.

## How to test
Make sure dev_setup still finishes as expected and colors are still showing for normal terminals.

## Contributor license agreement signed?
CLA [ Yes ]
