### PR TITLE
Move quick skill update to after internet check

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 import time
-import datetime as dt
 from threading import Timer
 import mycroft.lock
 from mycroft import dialog
@@ -91,14 +90,6 @@ def _starting_up():
     # network connection
     skill_manager.load_priority()
 
-    # If device has been offline for more than 2 weeks or
-    # skill state is in a limbo do a quick update
-    update_limit = dt.datetime.now() - dt.timedelta(days=14)
-    if (not skill_manager.last_download or
-            skill_manager.last_download < update_limit):
-        skill_manager.download_skills(quick=True)
-    else:  # Just post the skills manifest
-        skill_manager.post_manifest(skill_manager.msm)
     skill_manager.start()
     check_connection()
 

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -15,7 +15,7 @@
 import gc
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 from glob import glob
 from itertools import chain
 
@@ -385,6 +385,15 @@ class SkillManager(Thread):
 
         self.remove_git_locks()
         self._connected_event.wait()
+
+        # If device has been offline for more than 2 weeks or
+        # skill state is in a limbo do a quick update
+        update_limit = datetime.now() - timedelta(days=14)
+        if (not self.last_download or self.last_download < update_limit):
+            self.download_skills(quick=True)
+        else:  # Just post the skills manifest
+            self.post_manifest(self.msm)
+
         has_loaded = False
 
         # check if skill updates are enabled


### PR DESCRIPTION
## Description
Quick-downloading of skills was at some points attempted before internet connection had been properly established. This moves the quickloading behind the internet connection check.

## How to test
Make sure skills are still loaded as expected.

## Contributor license agreement signed?
CLA [ Yes ]
