### PR TITLE
tts_hash to an actual hash

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -182,7 +182,7 @@ def init(messagebus):
 
     tts = TTSFactory.create()
     tts.init(bus)
-    tts_hash = config.get('tts')
+    tts_hash = hash(str(config.get('tts', '')))
 
 
 def shutdown():


### PR DESCRIPTION
## Description
tts_hash was initially set to the text of the config rather than hash so always loaded twice on boot (~750ms for create() for Mimic2)

## How to test
Add log to speech.py mute_and_speak L123 and make sure a reload does not occur at first boot

## Contributor license agreement signed?
CLA [Yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
