### PR TITLE
Handle removing unregistered intents

### DIFF
--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -106,8 +106,14 @@ class PadatiousService(FallbackSkill):
             self.train()
 
     def __detach_intent(self, intent_name):
-        self.registered_intents.remove(intent_name)
-        self.container.remove_intent(intent_name)
+        """ Remove an intent if it has been registered.
+
+        Arguments:
+            intent_name (str): intent identifier
+        """
+        if intent_name in self.registered_intents:
+            self.registered_intents.remove(intent_name)
+            self.container.remove_intent(intent_name)
 
     def handle_detach_intent(self, message):
         self.__detach_intent(message.data.get('intent_name'))


### PR DESCRIPTION
## Description
This small change adds a check that the intent has been registered
before removing it.

If an unregistered intent was removed padatious would silently throw an
exception due to a list operation error. But when run synchronously from
the skill tester this silent exception was actually loud causing skills
to fail to load.

## How to test
Run the skill tester on the latest beta of the npr-news skill.

## Contributor license agreement signed?
CLA [ Yes ]
