### PR TITLE
Move pairing check to the relevant stt backends

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -16,7 +16,7 @@ import time
 from threading import Thread
 import speech_recognition as sr
 from pyee import EventEmitter
-from requests import RequestException, HTTPError
+from requests import RequestException
 from requests.exceptions import ConnectionError
 
 from mycroft import dialog
@@ -215,12 +215,6 @@ class AudioConsumer(Thread):
             LOG.error("Connection Error: {0}".format(e))
 
             self.emitter.emit("recognizer_loop:no_internet")
-        except HTTPError as e:
-            if e.response.status_code == 401:
-                LOG.warning("Access Denied at mycroft.ai")
-                return "pair my device"  # phrase to start the pairing process
-            else:
-                LOG.error(e.__class__.__name__ + ': ' + str(e))
         except RequestException as e:
             LOG.error(e.__class__.__name__ + ': ' + str(e))
         except Exception as e:


### PR DESCRIPTION
## Description
The pairing trigger should only be triggered by the 401 status for the
Mycroft hosted STT backends. Doing it for other STT's is only confusing.

This creates the decorator 'requires_pairing' that can be applied to the STT modules where it's relevant.

This adds the decorator to the MycroftSTT and the MycroftDeepSpeechSTT

## How to test
- Assert that voice input is working
- shutdown mycroft
- remove/rename identity2.json
- ./start-mycroft.sh bus
- python mycroft.client.speech

Check that any input comes back as "pair my device"


## Contributor license agreement signed?
CLA [ Yes ]
