### PR TITLE
Allow dnf to be used as pkg manager for Fedora #2255

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -300,7 +300,7 @@ function install_deps() {
         # Debian / Ubuntu / Mint
         echo "$GREEN Installing packages for Debian/Ubuntu/Mint...$RESET"
         $SUDO apt-get install -y git python3 python3-dev python3-setuptools libtool libffi-dev libssl-dev autoconf automake bison swig libglib2.0-dev portaudio19-dev mpg123 screen flac curl libicu-dev pkg-config libjpeg-dev libfann-dev build-essential jq
-    elif os_is_like fedora ; then
+    elif os_is_like fedora || os_is fedora; then
         echo "$GREEN Installing packages for Fedora...$RESET"
         # Fedora
         $SUDO dnf install -y git python3 python3-devel python3-pip python3-setuptools python3-virtualenv pygobject3-devel libtool libffi-devel openssl-devel autoconf bison swig glib2-devel portaudio-devel mpg123 mpg123-plugins-pulseaudio screen curl pkgconfig libicu-devel automake libjpeg-turbo-devel fann-devel gcc-c++ redhat-rpm-config jq


### PR DESCRIPTION
## Description
(Description of what the PR does, such as fixes # {issue number})
@guystreeter pointed out he had issues using `dev_setup.sh` on Fedora (#2255 )
He mentioned that replacing `os_is fedora` for `os_is_like fedora` resolved his issue.  So I substituted the statement `elif os_is_like fedora` for `elif os_is_like fedora || os_is fedora`.  Which should fix the issue

## How to test
Run `./dev_setup.sh` on systems similar to:
> ```shell
> $ cat /etc/os-release 
> NAME=Fedora
> VERSION="30 (Workstation Edition)"
> ID=fedora
> VERSION_ID=30
> VERSION_CODENAME=""
> PLATFORM_ID="platform:f30"
> PRETTY_NAME="Fedora 30 (Workstation Edition)"
> ANSI_COLOR="0;34"
> LOGO=fedora-logo-icon
> CPE_NAME="cpe:/o:fedoraproject:fedora:30"
> HOME_URL="https://fedoraproject.org/"
> DOCUMENTATION_URL="https://docs.fedoraproject.org/en-US/fedora/f30/system-administrators-guide/"
> SUPPORT_URL="https://fedoraproject.org/wiki/Communicating_and_getting_help"
> BUG_REPORT_URL="https://bugzilla.redhat.com/"
> REDHAT_BUGZILLA_PRODUCT="Fedora"
> REDHAT_BUGZILLA_PRODUCT_VERSION=30
> REDHAT_SUPPORT_PRODUCT="Fedora"
> REDHAT_SUPPORT_PRODUCT_VERSION=30
> PRIVACY_POLICY_URL="https://fedoraproject.org/wiki/Legal:PrivacyPolicy"
> VARIANT="Workstation Edition"
> VARIANT_ID=workstation
> ```
> 

## Contributor license agreement signed?
CLA [ ✅] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
(I filled out the form there, and am awaiting the response email 📧)
edit: all signed now!