### PR TITLE
Fix TypeError for number values in settings

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -489,7 +489,7 @@ class SkillSettings(dict):
                     value = field.get('value')
 
                     if to_platform == 'core':
-                        if "." in value:
+                        if "." in str(value):
                             sections[i]['fields'][j]['value'] = float(value)
                         else:
                             sections[i]['fields'][j]['value'] = int(value)


### PR DESCRIPTION
In some instances, the backend returns number setting values as an integer rather than a string.

This seems to be the quickest fix for it, but worth investigating further from the backend.

## How to test
This has been seen in the wild but has been difficult to replicate. The circumstances under which it happens are still unclear. I was able to semi-consistently have a number returned as int from the [Severe Weather Skill](https://github.com/domcross/severe-weather-information-skill) when editing an unrelated setting. To test, remove the 3 character country code (`[A-Z]{3} - `) from the service options of this skill .

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
