### PR TITLE
Fix missing param when setting up MaryTTS and how it validates a conn…

### DIFF
--- a/mycroft/tts/mary_tts.py
+++ b/mycroft/tts/mary_tts.py
@@ -29,8 +29,8 @@ class MaryTTS(RemoteTTS):
     }
 
     def __init__(self, lang, config):
-        super(MaryTTS, self).__init__(lang, config, '/process',
-                                      MaryTTSValidator(self))
+        super(MaryTTS, self).__init__(lang, config, config.get('url'),
+                                      '/process', MaryTTSValidator(self))
 
     def build_request_params(self, sentence):
         params = self.PARAMS.copy()
@@ -51,8 +51,8 @@ class MaryTTSValidator(TTSValidator):
     def validate_connection(self):
         try:
             resp = requests.get(self.tts.url + "/version", verify=False)
-            if resp.content.find('Mary TTS server') < 0:
-                raise Exception('Invalid MaryTTS server.')
+            if resp.status_code == 200:
+                return True
         except Exception:
             raise Exception(
                 'MaryTTS server could not be verified. Check your connection '


### PR DESCRIPTION
## Description
Fix a missing param in the MaryTTS voice config.
Also fix how the connection is validated.

Referenced in this issue: https://github.com/MycroftAI/mycroft-core/issues/2127

## How to test

1) Grab yourself a copy of MaryTTS, setup your MaryTTS server, make sure you've got that server URL in your mycroft.conf `tts` section.

2) Start mycroft-core and ensure your connection is validated and mycroft uses the MaryTTS voice

## Contributor license agreement signed?
CLA [ ✅ ] (Signed Aug 24)
