### PR TITLE
Changes to MSM logic to improve performance.

### DIFF
--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -12,42 +12,97 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""Common logic for instantiating the Mycroft Skills Manager.
 
-import os
-from os.path import join, expanduser, exists
+The Mycroft Skills Manager (MSM) does a lot of interactions with git.  The
+more skills that are installed on a device, the longer these interactions
+take.  This is especially true at boot time when MSM is instantiated
+frequently.  To improve performance, the MSM instance is cached.
+"""
+from collections import namedtuple
+from functools import lru_cache
+from os import path, makedirs
 
 from msm import MycroftSkillsManager, SkillRepo
 
 from mycroft.util.combo_lock import ComboLock
 from mycroft.util.log import LOG
 
-mycroft_msm_lock = None
+MsmConfig = namedtuple(
+    'MsmConfig',
+    [
+        'platform',
+        'repo_branch',
+        'repo_cache',
+        'repo_url',
+        'skills_dir',
+        'versioned'
+    ]
+)
 
 
-def create_msm(config):
-    """ Create msm object from config. """
-    global mycroft_msm_lock
-    if mycroft_msm_lock is None:
-        try:
-            mycroft_msm_lock = ComboLock('/tmp/mycroft-msm.lck')
-            LOG.debug('mycroft-msm combo lock created')
-        except Exception as e:
-            LOG.error('Failed to create msm lock ({})'.format(repr(e)))
+def _init_msm_lock():
+    msm_lock = None
+    try:
+        msm_lock = ComboLock('/tmp/mycroft-msm.lck')
+        LOG.debug('mycroft-msm combo lock instantiated')
+    except Exception:
+        LOG.exception('Failed to create msm lock!')
 
-    msm_config = config['skills']['msm']
-    repo_config = msm_config['repo']
-    data_dir = expanduser(config['data_dir'])
-    skills_dir = join(data_dir, msm_config['directory'])
-    repo_cache = join(data_dir, repo_config['cache'])
-    platform = config['enclosure'].get('platform', 'default')
+    return msm_lock
 
-    with mycroft_msm_lock:
-        # Try to create the skills directory if it doesn't exist
-        if not exists(skills_dir):
-            os.makedirs(skills_dir)
 
-        return MycroftSkillsManager(
-            platform=platform, skills_dir=skills_dir,
-            repo=SkillRepo(repo_cache, repo_config['url'],
-                           repo_config['branch']),
-            versioned=msm_config['versioned'])
+def build_msm_config(device_config: dict) -> MsmConfig:
+    """Extract from the device configs values needed to instantiate MSM
+
+    Why not just pass the device_config to the create_msm function, you ask?
+    Rationale is that the create_msm function is cached.  The lru_cached
+    decorator will instantiate MSM anew each time it is called with a different
+    configuration argument.  Calling this function before create_msm will
+    ensure that changes to configs not related to MSM will not result in new
+    instances of MSM being created.
+    """
+    msm_config = device_config['skills']['msm']
+    msm_repo_config = msm_config['repo']
+    enclosure_config = device_config['enclosure']
+    data_dir = path.expanduser(device_config['data_dir'])
+
+    return MsmConfig(
+        platform=enclosure_config.get('platform', 'default'),
+        repo_branch=msm_repo_config['branch'],
+        repo_cache=path.join(data_dir, msm_repo_config['cache']),
+        repo_url=msm_repo_config['url'],
+        skills_dir=path.join(data_dir, msm_config['directory']),
+        versioned=msm_config['versioned']
+    )
+
+
+@lru_cache()
+def create_msm(msm_config: MsmConfig) -> MycroftSkillsManager:
+    """Returns an instantiated MSM object.
+
+    This function is cached because it can take as long as 15 seconds to
+    instantiate MSM.  Caching the instance improves performance significantly,
+    especially during the boot sequence when this function is called multiple
+    times.
+    """
+    msm_lock = _init_msm_lock()
+    LOG.info('Acquiring lock to instantiate MSM')
+    with msm_lock:
+        if not path.exists(msm_config.skills_dir):
+            makedirs(msm_config.skills_dir)
+
+        msm_skill_repo = SkillRepo(
+            msm_config.repo_cache,
+            msm_config.repo_url,
+            msm_config.repo_branch
+        )
+        msm_instance = MycroftSkillsManager(
+            platform=msm_config.platform,
+            skills_dir=msm_config.skills_dir,
+            repo=msm_skill_repo,
+            versioned=msm_config.versioned
+        )
+    LOG.info('Releasing MSM instantiation lock.')
+
+    return msm_instance

--- a/mycroft/skills/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill.py
@@ -18,7 +18,7 @@ import sys
 import re
 import traceback
 import inspect
-from inspect import signature
+from inspect import ismethod, signature
 import collections
 import time
 from datetime import datetime, timedelta
@@ -62,6 +62,31 @@ def simple_trace(stack_trace):
         if line.strip():
             tb += line
     return tb
+
+
+def get_non_properties(obj):
+    """Get attibutes that are not properties from object.
+
+    Will return members of object class along with bases down to MycroftSkill.
+
+    Arguments:
+        obj:    object to scan
+
+    Returns:
+        Set of attributes that are not a property.
+    """
+
+    def check_class(cls):
+        """Find all non-properties in a class."""
+        # Current class
+        d = cls.__dict__
+        np = [k for k in d if not isinstance(d[k], property)]
+        # Recurse through base classes excluding MycroftSkill and object
+        for b in [b for b in cls.__bases__ if b not in (object, MycroftSkill)]:
+            np += check_class(b)
+        return np
+
+    return set(check_class(obj.__class__))
 
 
 def dig_for_message():
@@ -175,7 +200,6 @@ class MycroftSkill:
         bus (MycroftWebsocketClient): Optional bus connection
         use_settings (bool): Set to false to not use skill settings at all
     """
-
     def __init__(self, name=None, bus=None, use_settings=True):
         self.name = name or self.__class__.__name__
         self.resting_name = None
@@ -234,12 +258,9 @@ class MycroftSkill:
         """Provide deprecation warning when accessing config.
         TODO: Remove in 19.08
         """
-        stack = simple_trace(traceback.format_stack())
-        if (" _register_decorated" not in stack and
-                "register_resting_screen" not in stack):
-            LOG.warning('self.config is deprecated.  Switch to using '
-                        'self.setting["whatever"] within your skill.')
-            LOG.warning(stack)
+        LOG.warning('self.config is deprecated.  Switch to using '
+                    'self.setting["whatever"] within your skill.')
+        LOG.warning(stack)
         return self._config
 
     @property
@@ -561,10 +582,8 @@ class MycroftSkill:
         This only allows one screen and if two is registered only one
         will be used.
         """
-        attributes = [a for a in dir(self)]
-        for attr_name in attributes:
+        for attr_name in get_non_properties(self):
             method = getattr(self, attr_name)
-
             if hasattr(method, 'resting_handler'):
                 self.resting_name = method.resting_handler
                 self.log.info('Registering resting screen {} for {}.'.format(
@@ -580,18 +599,18 @@ class MycroftSkill:
                 # Do a send at load to make sure the skill is registered
                 # if reloaded
                 self._handle_collect_resting()
-                return
+                break
 
     def _register_decorated(self):
         """Register all intent handlers that are decorated with an intent.
 
         Looks for all functions that have been marked by a decorator
-        and read the intent data from them
+        and read the intent data from them.  The intent handlers aren't the
+        only decorators used.  Skip properties as calling getattr on them
+        executes the code which may have unintended side-effects
         """
-        attributes = [a for a in dir(self)]
-        for attr_name in attributes:
+        for attr_name in get_non_properties(self):
             method = getattr(self, attr_name)
-
             if hasattr(method, 'intents'):
                 for intent in getattr(method, 'intents'):
                     self.register_intent(intent, method)

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -62,20 +62,19 @@
 import json
 import hashlib
 import os
-import time
-import copy
 import re
-from threading import Timer, Thread
-from os.path import isfile, join, expanduser
+import time
+from os.path import isfile, join
 from requests.exceptions import RequestException, HTTPError
+from threading import Timer, Thread
+
 from msm import SkillEntry
 
 from mycroft.api import DeviceApi, is_paired
 from mycroft.util.log import LOG
 from mycroft.util import camel_case_split
 from mycroft.configuration import ConfigurationManager
-
-from .msm_wrapper import create_msm
+from .msm_wrapper import build_msm_config, create_msm
 
 
 msm = None
@@ -96,11 +95,16 @@ def build_global_id(directory, config):
     global msm_creation_time
     if msm is None or time.time() - msm_creation_time > 60 * 60:
         msm_creation_time = time.time()
-        msm = create_msm(config)
+        LOG.info('instantiating msm...')
+        msm_config = build_msm_config(config)
+        msm = create_msm(msm_config)
+        LOG.info('msm instantiation complete')
 
-    s = SkillEntry.from_folder(directory, msm)
+    skills = {skill.path: skill for skill in msm.local_skills.values()}
+    skill = skills[directory]
     # If modified prepend the device uuid
-    return s.skill_gid, s.meta_info.get('display_name')
+    LOG.info('building skill gid for ' + skill.name)
+    return skill.skill_gid, skill.meta_info.get('display_name')
 
 
 def display_name(name):
@@ -121,8 +125,6 @@ class SkillSettings(dict):
     Args:
         directory (str):  Path to storage directory
         name (str):       user readable name associated with the settings
-        no_upload (bool): True if the upload to mycroft servers should be
-                          disabled.
     """
 
     def __init__(self, directory, name):

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -100,8 +100,7 @@ def build_global_id(directory, config):
         msm = create_msm(msm_config)
         LOG.info('msm instantiation complete')
 
-    skills = {skill.path: skill for skill in msm.local_skills.values()}
-    skill = skills[directory]
+    skill = SkillEntry.from_folder(directory, msm)
     # If modified prepend the device uuid
     LOG.info('building skill gid for ' + skill.name)
     return skill.skill_gid, skill.meta_info.get('display_name')

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -22,7 +22,7 @@ from mycroft.enclosure.api import EnclosureAPI
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
-from .msm_wrapper import create_msm as msm_creator
+from .msm_wrapper import create_msm as msm_creator, build_msm_config
 from .skill_loader import SkillLoader
 from .skill_updater import SkillUpdater
 
@@ -30,6 +30,8 @@ SKILL_MAIN_MODULE = '__init__.py'
 
 
 class SkillManager(Thread):
+    _msm = None
+
     def __init__(self, bus):
         """Constructor
 
@@ -43,10 +45,9 @@ class SkillManager(Thread):
         self.skill_loaders = {}
         self.enclosure = EnclosureAPI(bus)
         self.initial_load_complete = False
-        self.msm = self.create_msm()
         self.num_install_retries = 0
         self._define_message_bus_events()
-        self.skill_updater = SkillUpdater(self.bus)
+        self.skill_updater = SkillUpdater()
         self.daemon = True
 
     def _define_message_bus_events(self):
@@ -76,9 +77,21 @@ class SkillManager(Thread):
     def skills_config(self):
         return Configuration.get()['skills']
 
+    @property
+    def msm(self):
+        if self._msm is None:
+            msm_config = build_msm_config(self.config)
+            self._msm = msm_creator(msm_config)
+
+        return self._msm
+
     @staticmethod
     def create_msm():
-        return msm_creator(Configuration.get())
+        LOG.debug('instantiating msm via static method...')
+        msm_config = build_msm_config(Configuration.get())
+        msm_instance = msm_creator(msm_config)
+
+        return msm_instance
 
     def schedule_now(self, _):
         self.skill_updater.next_download = time() - 1
@@ -88,7 +101,7 @@ class SkillManager(Thread):
         self.skill_updater.post_manifest()
 
     def load_priority(self):
-        skills = {skill.name: skill for skill in self.msm.list()}
+        skills = {skill.name: skill for skill in self.msm.all_skills}
         priority_skills = self.skills_config.get("priority_skills", [])
         for skill_name in priority_skills:
             skill = skills.get(skill_name)

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -32,15 +32,17 @@ FIVE_MINUTES = 300  # number of seconds in a minute
 
 
 class SkillUpdater:
+    """Class facilitating skill update / install actions.
+
+    Arguments
+        bus (MessageBusClient): Optional bus emitter Used to communicate
+                                with the mycroft core system and handle
+                                commands.
+    """
     _installed_skills_file_path = None
     _msm = None
 
-    def __init__(self, bus):
-        """Constructor
-
-        Arguments
-            bus (MessageBusClient): Used to communicate events to the bus.
-        """
+    def __init__(self, bus=None):
         self.msm_lock = ComboLock('/tmp/mycroft-msm.lck')
         self.install_retries = 0
         update_interval = self.config['skills']['update_interval']
@@ -50,6 +52,12 @@ class SkillUpdater:
         self._log_next_download_time()
         self.installed_skills = set()
         self.default_skill_install_error = False
+
+        if bus:
+            self._register_bus_handlers()
+
+    def _register_bus_handlers(self):
+        """TODO: Register bus handlers for triggering updates and such."""
 
     def _determine_next_download_time(self):
         """Determine the initial values of the next/last download times.

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ google-api-python-client==1.6.4
 fasteners==0.14.1
 PyYAML==3.13
 
-msm==0.7.9
+msm==0.8.2
 msk==0.3.13
 adapt-parser==0.3.3
 padatious==0.4.6

--- a/test/unittests/base.py
+++ b/test/unittests/base.py
@@ -1,3 +1,17 @@
+# Copyright 2019 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 import tempfile
 from pathlib import Path
 from shutil import rmtree

--- a/test/unittests/mocks.py
+++ b/test/unittests/mocks.py
@@ -1,4 +1,18 @@
-from unittest.mock import Mock, PropertyMock
+# Copyright 2019 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from unittest.mock import Mock
 
 from msm import MycroftSkillsManager
 from msm.skill_repo import SkillRepo

--- a/test/unittests/mocks.py
+++ b/test/unittests/mocks.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import Mock, PropertyMock
 
 from msm import MycroftSkillsManager
 from msm.skill_repo import SkillRepo
@@ -15,14 +15,16 @@ def mock_msm(temp_dir):
         ('default', ['time', 'weather']),
         ('test_platform', ['test_skill'])
     ])
-    msm_mock.skills_data = dict(
+    msm_mock.device_skill_state = dict(
         skills=[
             dict(name='test_skill', beta=False)
         ]
     )
     skill = Mock()
     skill.is_local = True
-    msm_mock.list_defaults.return_value = [skill]
+    msm_mock.list_all_defaults.return_value = [skill]
+    msm_mock.default_skills = dict(test_skill=skill)
+    msm_mock.all_skills = [skill]
 
     return msm_mock
 
@@ -47,7 +49,8 @@ def mock_config(temp_dir):
             priority_skills=['foobar'],
             upload_skill_manifest=True
         ),
-        data_dir=str(temp_dir)
+        data_dir=str(temp_dir),
+        enclosure=dict()
     )
 
     return get_config_mock

--- a/test/unittests/skills/test_skill_loader.py
+++ b/test/unittests/skills/test_skill_loader.py
@@ -1,3 +1,17 @@
+# Copyright 2019 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 """Unit tests for the SkillLoader class."""
 from time import time
 from unittest.mock import call, MagicMock, patch

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -1,3 +1,17 @@
+# Copyright 2019 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 from os import path
 from unittest.mock import Mock, patch
 

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -79,6 +79,7 @@ class TestSkillManager(MycroftUnitTestBase):
         load_mock = Mock()
         self.skill_manager._load_skill = load_mock
         skill, self.skill_manager.msm.list = self._build_mock_msm_skill_list()
+        self.msm_mock.all_skills = [skill]
         self.skill_manager.load_priority()
 
         self.assertFalse(skill.install.called)
@@ -89,6 +90,7 @@ class TestSkillManager(MycroftUnitTestBase):
         self.skill_manager._load_skill = load_mock
         skill, self.skill_manager.msm.list = self._build_mock_msm_skill_list()
         skill.is_local = False
+        self.msm_mock.all_skills = [skill]
         self.skill_manager.load_priority()
 
         self.assertTrue(skill.install.called)
@@ -226,7 +228,6 @@ class TestSkillManager(MycroftUnitTestBase):
     def test_handle_paired(self):
         self.skill_updater_mock.next_download = 0
         self.skill_manager.handle_paired(None)
-
         updater = self.skill_manager.skill_updater
         updater.post_manifest.assert_called_once_with()
 
@@ -258,7 +259,6 @@ class TestSkillManager(MycroftUnitTestBase):
     def test_activate_skill(self):
         message = Mock()
         message.data = dict(skill='test_skill')
-
         test_skill_loader = Mock(spec=SkillLoader)
         test_skill_loader.skill_id = 'test_skill'
         test_skill_loader.active = False
@@ -291,7 +291,6 @@ class TestSkillManager(MycroftUnitTestBase):
         self.skill_dir.joinpath('__init__.py').touch()
         patch_obj = self.mock_package + 'SkillLoader'
         self.skill_manager.skill_loaders = {}
-
         with patch(patch_obj, spec=True) as loader_mock:
             self.skill_manager._load_new_skills()
             loader_mock.return_value.load.assert_called_once_with()

--- a/test/unittests/skills/test_skill_updater.py
+++ b/test/unittests/skills/test_skill_updater.py
@@ -70,7 +70,7 @@ class TestSkillUpdater(MycroftUnitTestBase):
     def test_apply_install_or_update(self):
         """Test invoking MSM to install or update skills"""
         skill = self._build_mock_msm_skill_list()
-        self.msm_mock.list_defaults.return_value = [skill]
+        self.msm_mock.list_all_defaults.return_value = [skill]
         updater = SkillUpdater(self.message_bus_mock)
         updater._apply_install_or_update(quick=False)
 
@@ -83,7 +83,7 @@ class TestSkillUpdater(MycroftUnitTestBase):
     def test_apply_install_or_update_quick(self):
         """Test invoking MSM to install or update skills quickly"""
         skill = self._build_mock_msm_skill_list()
-        self.msm_mock.list_defaults.return_value = [skill]
+        self.msm_mock.list_all_defaults.return_value = [skill]
         updater = SkillUpdater(self.message_bus_mock)
         updater._apply_install_or_update(quick=True)
 
@@ -97,7 +97,7 @@ class TestSkillUpdater(MycroftUnitTestBase):
         """Test invoking MSM to install missing default skills"""
         skill = self._build_mock_msm_skill_list()
         skill.is_local = False
-        self.msm_mock.list_defaults.return_value = [skill]
+        self.msm_mock.list_all_defaults.return_value = [skill]
         updater = SkillUpdater(self.message_bus_mock)
         updater._apply_install_or_update(quick=True)
 
@@ -168,31 +168,18 @@ class TestSkillUpdater(MycroftUnitTestBase):
 
     def test_post_manifest_allowed(self):
         """Test calling the skill manifest API endpoint"""
-        self.msm_mock.skills_data = 'foo'
+        self.msm_mock.device_skill_state = 'foo'
         with patch(self.mock_package + 'is_paired') as paired_mock:
             paired_mock.return_value = True
             with patch(self.mock_package + 'DeviceApi', spec=True) as api_mock:
                 SkillUpdater(self.message_bus_mock).post_manifest()
                 api_instance = api_mock.return_value
                 api_instance.upload_skills_data.assert_called_once_with('foo')
-            print(paired_mock.called)
             paired_mock.assert_called_once_with()
-
-    def test_get_skill_data(self):
-        """Test invoking MSM to retrieve skill data."""
-        updater = SkillUpdater(self.message_bus_mock)
-        skill_data = updater._get_skill_data('test_skill')
-        self.assertDictEqual(dict(name='test_skill', beta=False), skill_data)
-
-    def test_get_skill_data_not_found(self):
-        """Test invoking MSM to retrieve unknown skill data."""
-        updater = SkillUpdater(self.message_bus_mock)
-        skill_data = updater._get_skill_data('foo')
-        self.assertDictEqual({}, skill_data)
 
     def test_install_or_update_beta(self):
         """Test calling install_or_update with a beta skill."""
-        self.msm_mock.skills_data['skills'][0]['beta'] = True
+        self.msm_mock.device_skill_state['skills'][0]['beta'] = True
         skill = self._build_mock_msm_skill_list()
         skill.is_local = False
         updater = SkillUpdater(self.message_bus_mock)


### PR DESCRIPTION
## Description
Half of the time it takes to boot the device is consumed by interactions with MSM. Skill-related data just doesn't change that frequently. Use caching of MSM data to speed cut boot time in half. There is a related PR for MSM that has the same branch name.

## How to test
At its core, this is a refactor. The logic hasn't changed, how frequently it executes has. Boot up a device and ensure all still works as expected. Install, remove and update a skill to ensure those actions reset the cached values.

## Contributor license agreement signed?
CLA [Yes]