### PR TITLE
Check for AVX instruction set during install for Precise compatibility

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -137,6 +137,22 @@ This script is designed to make working with Mycroft easy.  During this
 first run of dev_setup we will ask you a few questions to help setup
 your environment.'
     sleep 0.5
+    if ! grep -q avx /proc/cpuinfo; then
+      echo "
+The Precise Wake Word Engine requires the AVX instruction set, which is
+not supported on your CPU. Do you want to fall back to the PocketSphinx
+engine? Advanced users can build the precise engine with an older
+version of TensorFlow (v1.13) if desired and change use_precise to true
+in mycroft.conf.
+  Y)es, I want to use the PocketSphinx engine or my own.
+  N)o, stop the installation."
+      if get_YN ; then
+        sed -i "s/\"use_precise\": true/\"use_precise\": false/" config/
+      else
+        echo -e "$HIGHLIGHT N - quit the installation $RESET"
+        exit 1
+      fi
+    fi
     echo "
 Do you want to run on 'master' or against a dev branch?  Unless you are
 a developer modifying mycroft-core itself, you should run on the

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -153,7 +153,7 @@ in mycroft.conf.
           fi
           $SUDO cp $TOP/mycroft/configuration/mycroft.conf /etc/mycroft/
         fi
-        sed -i "s/\"use_precise\": true/\"use_precise\": false/" /etc/mycroft/mycroft.conf
+        $SUDO sed -i "s/\"use_precise\": true/\"use_precise\": false/" /etc/mycroft/mycroft.conf
       else
         echo -e "$HIGHLIGHT N - quit the installation $RESET"
         exit 1

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -147,7 +147,13 @@ in mycroft.conf.
   Y)es, I want to use the PocketSphinx engine or my own.
   N)o, stop the installation."
       if get_YN ; then
-        sed -i "s/\"use_precise\": true/\"use_precise\": false/" config/
+        if [[ ! -f /etc/mycroft/mycroft.conf ]]; then
+          if [[ ! -e /etc/mycroft/ ]]; then
+            $SUDO mkdir /etc/mycroft
+          fi
+          $SUDO cp $TOP/mycroft/configuration/mycroft.conf /etc/mycroft/
+        fi
+        sed -i "s/\"use_precise\": true/\"use_precise\": false/" /etc/mycroft/mycroft.conf
       else
         echo -e "$HIGHLIGHT N - quit the installation $RESET"
         exit 1

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -137,7 +137,7 @@ This script is designed to make working with Mycroft easy.  During this
 first run of dev_setup we will ask you a few questions to help setup
 your environment.'
     sleep 0.5
-    if ! grep -q avx /proc/cpuinfo; then
+    if ! grep -q avx /proc/cpuinfo && [[ ! $(uname -m) == 'arm'* ]]; then
       echo "
 The Precise Wake Word Engine requires the AVX instruction set, which is
 not supported on your CPU. Do you want to fall back to the PocketSphinx

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -41,6 +41,10 @@ class NoModelAvailable(Exception):
     pass
 
 
+class PreciseUnavailable(Exception):
+    pass
+
+
 class HotWordEngine:
     def __init__(self, key_phrase="hey mycroft", config=None, lang="en-us"):
         self.key_phrase = str(key_phrase).lower()
@@ -135,6 +139,8 @@ class PreciseHotword(HotWordEngine):
             PreciseRunner, PreciseEngine, ReadWriteStream
         )
         local_conf = LocalConf(USER_CONFIG)
+        if not local_conf.get('precise', {}).get('use_precise', True):
+            raise PreciseUnavailable
         if (local_conf.get('precise', {}).get('dist_url') ==
                 'http://bootstrap.mycroft.ai/artifacts/static/daily/'):
             del local_conf['precise']['dist_url']
@@ -325,6 +331,9 @@ class HotWordFactory:
                 LOG.warning('Could not found find model for {} on {}.'.format(
                     hotword, module
                 ))
+                instance = None
+            except PreciseUnavailable:
+                LOG.warning('Settings prevent Precise Engine use, falling back to default.')
                 instance = None
             except Exception:
                 LOG.exception(

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -333,7 +333,8 @@ class HotWordFactory:
                 ))
                 instance = None
             except PreciseUnavailable:
-                LOG.warning('Settings prevent Precise Engine use, falling back to default.')
+                LOG.warning('Settings prevent Precise Engine use,
+                            falling back to default.')
                 instance = None
             except Exception:
                 LOG.exception(

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -124,7 +124,7 @@ class PocketsphinxHotWord(HotWordEngine):
 
 
 class PreciseHotword(HotWordEngine):
-    """Precice is the default wakeword engine for mycroft.
+    """Precise is the default wakeword engine for mycroft.
 
     Precise is developed by Mycroft AI and produces quite good wake word
     spotting when trained on a decent dataset.

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -333,8 +333,8 @@ class HotWordFactory:
                 ))
                 instance = None
             except PreciseUnavailable:
-                LOG.warning('Settings prevent Precise Engine use,
-                            falling back to default.')
+                LOG.warning('Settings prevent Precise Engine use, '
+                            'falling back to default.')
                 instance = None
             except Exception:
                 LOG.exception(

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -189,6 +189,7 @@
 
   // Settings used for any precise wake words
   "precise": {
+    "use_precise": true,
     "dist_url": "https://github.com/MycroftAI/precise-data/raw/dist/{arch}/latest",
     "model_url": "https://raw.githubusercontent.com/MycroftAI/precise-data/models/{wake_word}.tar.gz"
   },


### PR DESCRIPTION
## Description
(Description of what the PR does, such as fixes # {issue number})
Check for AVX instruction set during install and warns the user that the Precise Engine will not be supported.

## How to test
(Description of how to validate or test this PR)
Run installer on a machine that does not support AVX

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
