### PR TITLE
re-order the skill process startup

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -21,9 +21,9 @@ directory.  The executable gets added to the bin directory when installed
 import time
 from threading import Event
 
-import mycroft.lock
 from msm.exceptions import MsmException
 
+import mycroft.lock
 from mycroft import dialog
 from mycroft.api import is_paired, BackendDown, DeviceApi
 from mycroft.audio import wait_while_speaking
@@ -63,38 +63,17 @@ class DevicePrimer(object):
         self.enclosure = EnclosureAPI(self.bus)
         self.is_paired = False
         self.backend_down = False
-        # Remember "now" at startup.  Used to detect clock changes.
-        self.start_ticks = time.monotonic()
-        self.start_clock = time.time()
-
-    @property
-    def time_skew_threshold_exceeded(self):
-        """Did the NTP sync skew system time significantly?"""
-        skew = abs(
-            (time.monotonic() - self.start_ticks) -
-            (time.time() - self.start_clock)
-        )
-
-        return skew > ONE_HOUR
 
     def prepare_device(self):
         """Internet dependent updates of various aspects of the device."""
         self._get_pairing_status()
-        self._update_system_clock()
-        if self.time_skew_threshold_exceeded:
-            self._reboot()
+        self._update_system()
+        if self.backend_down:
+            self._notify_backend_down()
         else:
-            self._update_system()
-            # Above will block during update process and kill this instance if
-            # new software is installed
-
-            if self.backend_down:
-                self._notify_backend_down()
-            else:
-                self._display_skill_loading_notification()
-                self.bus.emit(Message('mycroft.internet.connected'))
-                self._ensure_device_is_paired()
-                self._update_device_attributes_on_backend()
+            self._display_skill_loading_notification()
+            self._ensure_device_is_paired()
+            self._update_device_attributes_on_backend()
 
     def _get_pairing_status(self):
         """Set an instance attribute indicating the device's pairing status"""
@@ -107,7 +86,7 @@ class DevicePrimer(object):
         if self.is_paired:
             LOG.info('Device is paired')
 
-    def _update_system_clock(self):
+    def update_system_clock(self):
         """Force a sync of the local clock with the Network Time Protocol.
 
         The NTP sync is only forced on Raspberry Pi based devices.  The
@@ -128,26 +107,7 @@ class DevicePrimer(object):
                 'system.ntp.sync.complete',
                 15
             )
-
-    def _reboot(self):
-        """If the NTP sync skewed system time significantly, reboot.
-
-        If system time moved by over an hour in the NTP sync, force a reboot to
-        prevent weird things from occurring due to the 'time warp'.
-        """
-        LOG.warning(
-            'Clock sync altered system time by more than one hour,'
-            ' rebooting...'
-        )
-        self._speak_dialog(dialog_id="time.changed.reboot", wait=True)
-        # provide visual indicators of the reboot
-        self.enclosure.mouth_text(dialog.get("message_rebooting"))
-        self.enclosure.eyes_color(70, 65, 69)  # soft gray
-        self.enclosure.eyes_spin()
-        # give the system time to finish processing enclosure messages
-        time.sleep(1.0)
-        # reboot
-        self.bus.emit(Message("system.reboot"))
+            LOG.info('Update of system clock completed.')
 
     def _notify_backend_down(self):
         """Notify user of inability to communicate with the backend."""
@@ -211,27 +171,29 @@ class DevicePrimer(object):
 
 def main():
     reset_sigint_handler()
+
     # Create PID file, prevent multiple instances of this service
     mycroft.lock.Lock('skills')
     config = Configuration.get()
+
     # Set the active lang to match the configured one
     set_active_lang(config.get('lang', 'en-us'))
 
     # Connect this process to the Mycroft message bus
     bus = _start_message_bus_client()
+    _wait_for_internet_connection(bus)
+    device_primer = DevicePrimer(bus, config)
+
+    # Restart the system clock first to prevent side-effects from time drift
+    device_primer.update_system_clock()
+
     _register_intent_services(bus)
     event_scheduler = EventScheduler(bus)
     skill_manager = _initialize_skill_manager(bus)
-
-    _wait_for_internet_connection()
-
     if skill_manager is None:
         skill_manager = _initialize_skill_manager(bus)
-
-    device_primer = DevicePrimer(bus, config)
     device_primer.prepare_device()
     skill_manager.start()
-
     wait_for_exit_signal()
     shutdown(skill_manager, event_scheduler)
 
@@ -274,7 +236,7 @@ def _initialize_skill_manager(bus):
     """Create a thread that monitors the loaded skills, looking for updates
 
     Returns:
-        SkillManager instance or None if it couldn't be initialized
+        SkillManager instance
     """
     try:
         skill_manager = SkillManager(bus)
@@ -292,9 +254,13 @@ def _initialize_skill_manager(bus):
     return skill_manager
 
 
-def _wait_for_internet_connection():
+def _wait_for_internet_connection(bus):
+    if not connected():
+        LOG.info('Waiting for internet connection...')
     while not connected():
-        time.sleep(1)
+        time.sleep(5)
+    LOG.info('Internet connection established')
+    bus.emit(Message('mycroft.internet.connected'))
 
 
 def shutdown(skill_manager, event_scheduler):


### PR DESCRIPTION
## Description
Reorder the skill process startup tasks to take advantage of MSM performance improvements and remove the restart that occurred after NTP sync.

## How to test
Start the skill process and ensure all startup tasks occur without issue.

## Contributor license agreement signed?
CLA [yes]