### PR TITLE
Fix stacktrace on use of deprecated config member

### DIFF
--- a/mycroft/skills/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill.py
@@ -260,7 +260,7 @@ class MycroftSkill:
         """
         LOG.warning('self.config is deprecated.  Switch to using '
                     'self.setting["whatever"] within your skill.')
-        LOG.warning(stack)
+        LOG.warning(simple_trace(traceback.format_stack()))
         return self._config
 
     @property


### PR DESCRIPTION
## Description
The stacktrace when the deprecated config member was used would fail.

## Contributor license agreement signed?
CLA [ Yes ]
