### PR TITLE
Switch all mock imports to unittest.mock imports

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,6 +3,5 @@ coveralls==1.5.0
 pytest==3.5.0
 pytest-cov==2.5.1
 cov-core==1.15.0
-mock==2.0.0
 sphinx==1.8.2
 sphinx-rtd-theme==0.4.2

--- a/test/unittests/api/test_api.py
+++ b/test/unittests/api/test_api.py
@@ -15,7 +15,7 @@
 import unittest
 from copy import copy
 
-import mock
+from unittest.mock import MagicMock, patch
 
 import mycroft.api
 import mycroft.configuration
@@ -35,11 +35,11 @@ CONFIG.merge(
 )
 
 
-mycroft.api.requests.post = mock.MagicMock()
+mycroft.api.requests.post = MagicMock()
 
 
 def create_identity(uuid, expired=False):
-    mock_identity = mock.MagicMock()
+    mock_identity = MagicMock()
     mock_identity.is_expired.return_value = expired
     mock_identity.uuid = uuid
     return mock_identity
@@ -47,7 +47,7 @@ def create_identity(uuid, expired=False):
 
 def create_response(status, json=None, url='', data=''):
     json = json or {}
-    response = mock.MagicMock()
+    response = MagicMock()
     response.status_code = status
     response.json.return_value = json
     response.url = url
@@ -56,13 +56,13 @@ def create_response(status, json=None, url='', data=''):
 
 class TestApi(unittest.TestCase):
     def setUp(self):
-        patcher = mock.patch('mycroft.configuration.Configuration.get',
-                             return_value=CONFIG)
+        patcher = patch('mycroft.configuration.Configuration.get',
+                        return_value=CONFIG)
         self.mock_config_get = patcher.start()
         self.addCleanup(patcher.stop)
         super().setUp()
 
-    @mock.patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.IdentityManager.get')
     def test_init(self, mock_identity_get):
         mock_identity_get.return_value = create_identity('1234')
         a = mycroft.api.Api('test-path')
@@ -70,8 +70,8 @@ class TestApi(unittest.TestCase):
         self.assertEquals(a.version, 'v1')
         self.assertEquals(a.identity.uuid, '1234')
 
-    @mock.patch('mycroft.api.IdentityManager')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager')
+    @patch('mycroft.api.requests.request')
     def test_send(self, mock_request, mock_identity_manager):
         # Setup an OK response
         mock_response_ok = create_response(200, {})
@@ -108,14 +108,14 @@ class TestApi(unittest.TestCase):
 
 class TestDeviceApi(unittest.TestCase):
     def setUp(self):
-        patcher = mock.patch('mycroft.configuration.Configuration.get',
-                             return_value=CONFIG)
+        patcher = patch('mycroft.configuration.Configuration.get',
+                        return_value=CONFIG)
         self.mock_config_get = patcher.start()
         self.addCleanup(patcher.stop)
         super().setUp()
 
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_init(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200)
         mock_identity_get.return_value = create_identity('1234')
@@ -124,8 +124,8 @@ class TestDeviceApi(unittest.TestCase):
         self.assertEquals(device.identity.uuid, '1234')
         self.assertEquals(device.path, 'device')
 
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_device_activate(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200)
         mock_identity_get.return_value = create_identity('1234')
@@ -136,8 +136,8 @@ class TestDeviceApi(unittest.TestCase):
         self.assertEquals(json['state'], 'state')
         self.assertEquals(json['token'], 'token')
 
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_device_get(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200)
         mock_identity_get.return_value = create_identity('1234')
@@ -147,9 +147,9 @@ class TestDeviceApi(unittest.TestCase):
         url = mock_request.call_args[0][1]
         self.assertEquals(url, 'https://api-test.mycroft.ai/v1/device/1234')
 
-    @mock.patch('mycroft.api.IdentityManager.update')
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.update')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_device_get_code(self, mock_request, mock_identity_get,
                              mock_identit_update):
         mock_request.return_value = create_response(200, '123ABC')
@@ -161,8 +161,8 @@ class TestDeviceApi(unittest.TestCase):
         self.assertEquals(
             url, 'https://api-test.mycroft.ai/v1/device/code?state=state')
 
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_device_get_settings(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200, {})
         mock_identity_get.return_value = create_identity('1234')
@@ -172,8 +172,8 @@ class TestDeviceApi(unittest.TestCase):
         self.assertEquals(
             url, 'https://api-test.mycroft.ai/v1/device/1234/setting')
 
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_device_report_metric(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200, {})
         mock_identity_get.return_value = create_identity('1234')
@@ -189,8 +189,8 @@ class TestDeviceApi(unittest.TestCase):
         self.assertEquals(
             url, 'https://api-test.mycroft.ai/v1/device/1234/metric/mymetric')
 
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_device_send_email(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200, {})
         mock_identity_get.return_value = create_identity('1234')
@@ -206,8 +206,8 @@ class TestDeviceApi(unittest.TestCase):
         self.assertEquals(
             url, 'https://api-test.mycroft.ai/v1/device/1234/message')
 
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_device_get_oauth_token(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200, {})
         mock_identity_get.return_value = create_identity('1234')
@@ -218,8 +218,8 @@ class TestDeviceApi(unittest.TestCase):
         self.assertEquals(
             url, 'https://api-test.mycroft.ai/v1/device/1234/token/1')
 
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_device_get_location(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200, {})
         mock_identity_get.return_value = create_identity('1234')
@@ -229,8 +229,8 @@ class TestDeviceApi(unittest.TestCase):
         self.assertEquals(
             url, 'https://api-test.mycroft.ai/v1/device/1234/location')
 
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_device_get_subscription(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200, {})
         mock_identity_get.return_value = create_identity('1234')
@@ -249,8 +249,8 @@ class TestDeviceApi(unittest.TestCase):
         mock_request.return_value = create_response(200, {'@type': 'yearly'})
         self.assertTrue(device.is_subscriber)
 
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_device_upload_skills_data(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200)
         mock_identity_get.return_value = create_identity('1234')
@@ -270,16 +270,16 @@ class TestDeviceApi(unittest.TestCase):
         with self.assertRaises(ValueError):
             device.upload_skills_data('This isn\'t right at all')
 
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_stt(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200, {})
         mock_identity_get.return_value = create_identity('1234')
         stt = mycroft.api.STTApi('stt')
         self.assertEquals(stt.path, 'stt')
 
-    @mock.patch('mycroft.api.IdentityManager.get')
-    @mock.patch('mycroft.api.requests.request')
+    @patch('mycroft.api.IdentityManager.get')
+    @patch('mycroft.api.requests.request')
     def test_stt_stt(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200, {})
         mock_identity_get.return_value = create_identity('1234')
@@ -292,10 +292,10 @@ class TestDeviceApi(unittest.TestCase):
         params = mock_request.call_args[1].get('params')
         self.assertEquals(params['lang'], 'en-US')
 
-    @mock.patch('mycroft.api.IdentityManager.load')
+    @patch('mycroft.api.IdentityManager.load')
     def test_has_been_paired(self, mock_identity_load):
         # reset pairing cache
-        mock_identity = mock.MagicMock()
+        mock_identity = MagicMock()
         mock_identity_load.return_value = mock_identity
         # Test None
         mock_identity.uuid = None
@@ -308,12 +308,12 @@ class TestDeviceApi(unittest.TestCase):
         self.assertTrue(mycroft.api.has_been_paired())
 
 
-@mock.patch('mycroft.api.IdentityManager.get')
-@mock.patch('mycroft.api.requests.request')
+@patch('mycroft.api.IdentityManager.get')
+@patch('mycroft.api.requests.request')
 class TestSettingsMeta(unittest.TestCase):
     def setUp(self):
-        patcher = mock.patch('mycroft.configuration.Configuration.get',
-                             return_value=CONFIG)
+        patcher = patch('mycroft.configuration.Configuration.get',
+                        return_value=CONFIG)
         self.mock_config_get = patcher.start()
         self.addCleanup(patcher.stop)
         super().setUp()
@@ -381,20 +381,20 @@ class TestSettingsMeta(unittest.TestCase):
             url, 'https://api-test.mycroft.ai/v1/device/1234/skill/testgid')
 
 
-@mock.patch('mycroft.api._paired_cache', False)
-@mock.patch('mycroft.api.IdentityManager.get')
-@mock.patch('mycroft.api.requests.request')
+@patch('mycroft.api._paired_cache', False)
+@patch('mycroft.api.IdentityManager.get')
+@patch('mycroft.api.requests.request')
 class TestIsPaired(unittest.TestCase):
     def setUp(self):
-        patcher = mock.patch('mycroft.configuration.Configuration.get',
-                             return_value=CONFIG)
+        patcher = patch('mycroft.configuration.Configuration.get',
+                        return_value=CONFIG)
         self.mock_config_get = patcher.start()
         self.addCleanup(patcher.stop)
         super().setUp()
 
     def test_is_paired_true(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200)
-        mock_identity = mock.MagicMock()
+        mock_identity = MagicMock()
         mock_identity.is_expired.return_value = False
         mock_identity.uuid = '1234'
         mock_identity_get.return_value = mock_identity
@@ -409,7 +409,7 @@ class TestIsPaired(unittest.TestCase):
 
     def test_is_paired_false_local(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200)
-        mock_identity = mock.MagicMock()
+        mock_identity = MagicMock()
         mock_identity.is_expired.return_value = False
         mock_identity.uuid = ''
         mock_identity_get.return_value = mock_identity
@@ -420,7 +420,7 @@ class TestIsPaired(unittest.TestCase):
 
     def test_is_paired_false_remote(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(401)
-        mock_identity = mock.MagicMock()
+        mock_identity = MagicMock()
         mock_identity.is_expired.return_value = False
         mock_identity.uuid = '1234'
         mock_identity_get.return_value = mock_identity
@@ -429,7 +429,7 @@ class TestIsPaired(unittest.TestCase):
 
     def test_is_paired_error_remote(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(500)
-        mock_identity = mock.MagicMock()
+        mock_identity = MagicMock()
         mock_identity.is_expired.return_value = False
         mock_identity.uuid = '1234'
         mock_identity_get.return_value = mock_identity

--- a/test/unittests/client/test_local_recognizer.py
+++ b/test/unittests/client/test_local_recognizer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 import unittest
-import mock
+from unittest.mock import patch
 
 import os
 from speech_recognition import WavFile
@@ -27,7 +27,7 @@ DATA_DIR = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
 
 class PocketSphinxRecognizerTest(unittest.TestCase):
     def setUp(self):
-        with mock.patch('mycroft.configuration.Configuration.get') as \
+        with patch('mycroft.configuration.Configuration.get') as \
                 mock_config_get:
             conf = base_config()
             conf['hotwords']['hey mycroft']['module'] = 'pocketsphinx'
@@ -50,7 +50,7 @@ class PocketSphinxRecognizerTest(unittest.TestCase):
 
 
 class LocalRecognizerInitTest(unittest.TestCase):
-    @mock.patch.object(Configuration, 'get')
+    @patch.object(Configuration, 'get')
     def testRecognizer(self, mock_config_get):
         test_config = base_config()
         mock_config_get.return_value = test_config

--- a/test/unittests/configuration/test_configuration.py
+++ b/test/unittests/configuration/test_configuration.py
@@ -1,4 +1,4 @@
-import mock
+from unittest.mock import MagicMock, patch
 from unittest import TestCase
 import mycroft.configuration
 
@@ -19,11 +19,11 @@ class TestConfiguration(TestCase):
         self.assertEquals(d['b']['d'], d2['b']['d'])
         self.assertEquals(d['b']['c'], d1['b']['c'])
 
-    @mock.patch('mycroft.api.DeviceApi')
+    @patch('mycroft.api.DeviceApi')
     def test_remote(self, mock_api):
         remote_conf = {'TestConfig': True, 'uuid': 1234}
         remote_location = {'city': {'name': 'Stockholm'}}
-        dev_api = mock.MagicMock()
+        dev_api = MagicMock()
         dev_api.get_settings.return_value = remote_conf
         dev_api.get_location.return_value = remote_location
         mock_api.return_value = dev_api
@@ -32,10 +32,10 @@ class TestConfiguration(TestCase):
         self.assertTrue(rc['test_config'])
         self.assertEquals(rc['location']['city']['name'], 'Stockholm')
 
-    @mock.patch('json.dump')
-    @mock.patch('mycroft.configuration.config.exists')
-    @mock.patch('mycroft.configuration.config.isfile')
-    @mock.patch('mycroft.configuration.config.load_commented_json')
+    @patch('json.dump')
+    @patch('mycroft.configuration.config.exists')
+    @patch('mycroft.configuration.config.isfile')
+    @patch('mycroft.configuration.config.load_commented_json')
     def test_local(self, mock_json_loader, mock_isfile, mock_exists,
                    mock_json_dump):
         local_conf = {'answer': 42, 'falling_objects': ['flower pot', 'whale']}
@@ -64,8 +64,8 @@ class TestConfiguration(TestCase):
         lc = mycroft.configuration.LocalConf('test')
         self.assertEquals(lc, {})
 
-    @mock.patch('mycroft.configuration.config.RemoteConf')
-    @mock.patch('mycroft.configuration.config.LocalConf')
+    @patch('mycroft.configuration.config.RemoteConf')
+    @patch('mycroft.configuration.config.LocalConf')
     def test_update(self, mock_remote, mock_local):
         mock_remote.return_value = {}
         mock_local.return_value = {'a': 1}

--- a/test/unittests/lock/test_lock.py
+++ b/test/unittests/lock/test_lock.py
@@ -16,7 +16,7 @@ import signal
 import unittest
 from shutil import rmtree
 
-import mock
+from unittest.mock import patch
 import os
 from os.path import exists, isfile
 
@@ -38,7 +38,7 @@ class TestLock(unittest.TestCase):
         l1.delete()
         self.assertFalse(isfile('/tmp/mycroft/test.pid'))
 
-    @mock.patch('os.kill')
+    @patch('os.kill')
     def test_existing_lock(self, mock_kill):
         """ Test that an existing lock will kill the old pid. """
         l1 = Lock('test')

--- a/test/unittests/messagebus/client/test_client.py
+++ b/test/unittests/messagebus/client/test_client.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from mock import patch
+from unittest.mock import patch
 
 from mycroft.messagebus.client import MessageBusClient
 

--- a/test/unittests/skills/test_core.py
+++ b/test/unittests/skills/test_core.py
@@ -16,7 +16,7 @@
 import sys
 import unittest
 
-import mock
+from unittest.mock import MagicMock, patch
 from adapt.intent import IntentBuilder
 from os.path import join, dirname, abspath
 from re import error
@@ -425,7 +425,7 @@ class MycroftSkillTest(unittest.TestCase):
         expected = [{'context': 'ADonatello'}]
         check_remove_context(expected)
 
-    @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
+    @patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_skill_location(self):
         s = SimpleSkill1()
         self.assertEqual(s.location, BASE_CONF.get('location'))
@@ -434,9 +434,9 @@ class MycroftSkillTest(unittest.TestCase):
         self.assertEqual(s.location_timezone,
                          BASE_CONF['location']['timezone']['code'])
 
-    @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
+    @patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_add_event(self):
-        emitter = mock.MagicMock()
+        emitter = MagicMock()
         s = SimpleSkill1()
         s.bind(emitter)
         s.add_event('handler1', s.handler)
@@ -445,9 +445,9 @@ class MycroftSkillTest(unittest.TestCase):
         # Check that the handler was stored in the skill
         self.assertTrue('handler1' in [e[0] for e in s.events])
 
-    @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
+    @patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_remove_event(self):
-        emitter = mock.MagicMock()
+        emitter = MagicMock()
         s = SimpleSkill1()
         s.bind(emitter)
         s.add_event('handler1', s.handler)
@@ -460,9 +460,9 @@ class MycroftSkillTest(unittest.TestCase):
         self.assertEqual(emitter.remove_all_listeners.call_args[0][0],
                          'handler1')
 
-    @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
+    @patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_add_scheduled_event(self):
-        emitter = mock.MagicMock()
+        emitter = MagicMock()
         s = SimpleSkill1()
         s.bind(emitter)
 
@@ -481,9 +481,9 @@ class MycroftSkillTest(unittest.TestCase):
         self.assertEqual(emitter.once.call_args[0][0], 'A:float_handler')
         self.assertTrue('A:float_handler' in [e[0] for e in s.events])
 
-    @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
+    @patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_remove_scheduled_event(self):
-        emitter = mock.MagicMock()
+        emitter = MagicMock()
         s = SimpleSkill1()
         s.bind(emitter)
         s.schedule_event(s.handler, datetime.now(), name='sched_handler1')
@@ -495,12 +495,12 @@ class MycroftSkillTest(unittest.TestCase):
                          'A:sched_handler1')
         self.assertTrue('A:sched_handler1' not in [e[0] for e in s.events])
 
-    @mock.patch.dict(Configuration._Configuration__config, BASE_CONF)
+    @patch.dict(Configuration._Configuration__config, BASE_CONF)
     def test_run_scheduled_event(self):
-        emitter = mock.MagicMock()
+        emitter = MagicMock()
         s = SimpleSkill1()
-        with mock.patch.object(s, '_settings',
-                               create=True, value=mock.MagicMock()):
+        with patch.object(s, '_settings',
+                          create=True, value=MagicMock()):
             s.bind(emitter)
             s.schedule_event(s.handler, datetime.now(), name='sched_handler1')
             # Check that the handler was registered with the emitter

--- a/test/unittests/skills/test_event_scheduler.py
+++ b/test/unittests/skills/test_event_scheduler.py
@@ -3,32 +3,32 @@
 """
 
 import unittest
-import mock
 import time
 
+from unittest.mock import MagicMock, patch
 from mycroft.skills.event_scheduler import EventScheduler
 
 
 class TestEventScheduler(unittest.TestCase):
-    @mock.patch('threading.Thread')
-    @mock.patch('json.load')
-    @mock.patch('json.dump')
-    @mock.patch('mycroft.skills.event_scheduler.open')
+    @patch('threading.Thread')
+    @patch('json.load')
+    @patch('json.dump')
+    @patch('mycroft.skills.event_scheduler.open')
     def test_create(self, mock_open, mock_json_dump, mock_load, mock_thread):
         """
             Test creating and shutting down event_scheduler.
         """
         mock_load.return_value = ''
-        mock_open.return_value = mock.MagicMock()
-        emitter = mock.MagicMock()
+        mock_open.return_value = MagicMock()
+        emitter = MagicMock()
         es = EventScheduler(emitter)
         es.shutdown()
         self.assertEquals(mock_json_dump.call_args[0][0], {})
 
-    @mock.patch('threading.Thread')
-    @mock.patch('json.load')
-    @mock.patch('json.dump')
-    @mock.patch('mycroft.skills.event_scheduler.open')
+    @patch('threading.Thread')
+    @patch('json.load')
+    @patch('json.dump')
+    @patch('mycroft.skills.event_scheduler.open')
     def test_add_remove(self, mock_open, mock_json_dump,
                         mock_load, mock_thread):
         """
@@ -36,8 +36,8 @@ class TestEventScheduler(unittest.TestCase):
         """
         # Thread start is mocked so will not actually run the thread loop
         mock_load.return_value = ''
-        mock_open.return_value = mock.MagicMock()
-        emitter = mock.MagicMock()
+        mock_open.return_value = MagicMock()
+        emitter = MagicMock()
         es = EventScheduler(emitter)
 
         # 900000000000 should be in the future for a long time
@@ -54,17 +54,17 @@ class TestEventScheduler(unittest.TestCase):
         self.assertTrue('test-2' in es.events)
         es.shutdown()
 
-    @mock.patch('threading.Thread')
-    @mock.patch('json.load')
-    @mock.patch('json.dump')
-    @mock.patch('mycroft.skills.event_scheduler.open')
+    @patch('threading.Thread')
+    @patch('json.load')
+    @patch('json.dump')
+    @patch('mycroft.skills.event_scheduler.open')
     def test_save(self, mock_open, mock_dump, mock_load, mock_thread):
         """
             Test save functionality.
         """
         mock_load.return_value = ''
-        mock_open.return_value = mock.MagicMock()
-        emitter = mock.MagicMock()
+        mock_open.return_value = MagicMock()
+        emitter = MagicMock()
         es = EventScheduler(emitter)
 
         # 900000000000 should be in the future for a long time
@@ -78,17 +78,17 @@ class TestEventScheduler(unittest.TestCase):
         self.assertEquals(mock_dump.call_args[0][0],
                           {'test': [(900000000000, None, {})]})
 
-    @mock.patch('threading.Thread')
-    @mock.patch('json.load')
-    @mock.patch('json.dump')
-    @mock.patch('mycroft.skills.event_scheduler.open')
+    @patch('threading.Thread')
+    @patch('json.load')
+    @patch('json.dump')
+    @patch('mycroft.skills.event_scheduler.open')
     def test_send_event(self, mock_open, mock_dump, mock_load, mock_thread):
         """
             Test save functionality.
         """
         mock_load.return_value = ''
-        mock_open.return_value = mock.MagicMock()
-        emitter = mock.MagicMock()
+        mock_open.return_value = MagicMock()
+        emitter = MagicMock()
         es = EventScheduler(emitter)
 
         # 0 should be in the future for a long time

--- a/test/unittests/skills/test_event_scheduler.py
+++ b/test/unittests/skills/test_event_scheduler.py
@@ -13,7 +13,7 @@ class TestEventScheduler(unittest.TestCase):
     @patch('threading.Thread')
     @patch('json.load')
     @patch('json.dump')
-    @patch('mycroft.skills.event_scheduler.open')
+    @patch('builtins.open')
     def test_create(self, mock_open, mock_json_dump, mock_load, mock_thread):
         """
             Test creating and shutting down event_scheduler.
@@ -28,7 +28,7 @@ class TestEventScheduler(unittest.TestCase):
     @patch('threading.Thread')
     @patch('json.load')
     @patch('json.dump')
-    @patch('mycroft.skills.event_scheduler.open')
+    @patch('builtins.open')
     def test_add_remove(self, mock_open, mock_json_dump,
                         mock_load, mock_thread):
         """
@@ -57,7 +57,7 @@ class TestEventScheduler(unittest.TestCase):
     @patch('threading.Thread')
     @patch('json.load')
     @patch('json.dump')
-    @patch('mycroft.skills.event_scheduler.open')
+    @patch('builtins.open')
     def test_save(self, mock_open, mock_dump, mock_load, mock_thread):
         """
             Test save functionality.
@@ -81,7 +81,7 @@ class TestEventScheduler(unittest.TestCase):
     @patch('threading.Thread')
     @patch('json.load')
     @patch('json.dump')
-    @patch('mycroft.skills.event_scheduler.open')
+    @patch('builtins.open')
     def test_send_event(self, mock_open, mock_dump, mock_load, mock_thread):
         """
             Test save functionality.

--- a/test/unittests/skills/test_settings.py
+++ b/test/unittests/skills/test_settings.py
@@ -14,7 +14,7 @@
 #
 import json
 import unittest
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 from os import remove
 from os.path import join, dirname

--- a/test/unittests/stt/test_stt.py
+++ b/test/unittests/stt/test_stt.py
@@ -14,7 +14,7 @@
 #
 import unittest
 
-import mock
+from unittest.mock import MagicMock, patch
 
 import mycroft.stt
 from mycroft.configuration import Configuration
@@ -23,9 +23,9 @@ from test.util import base_config
 
 
 class TestSTT(unittest.TestCase):
-    @mock.patch.object(Configuration, 'get')
+    @patch.object(Configuration, 'get')
     def test_factory(self, mock_get):
-        mycroft.stt.STTApi = mock.MagicMock()
+        mycroft.stt.STTApi = MagicMock()
         config = base_config()
         config.merge(
             {
@@ -72,9 +72,9 @@ class TestSTT(unittest.TestCase):
         stt = mycroft.stt.STTFactory.create()
         self.assertEquals(type(stt), mycroft.stt.WITSTT)
 
-    @mock.patch.object(Configuration, 'get')
+    @patch.object(Configuration, 'get')
     def test_stt(self, mock_get):
-        mycroft.stt.STTApi = mock.MagicMock()
+        mycroft.stt.STTApi = MagicMock()
         config = base_config()
         config.merge(
             {
@@ -103,9 +103,9 @@ class TestSTT(unittest.TestCase):
         stt = TestSTT()
         self.assertEqual(stt.lang, 'sv')
 
-    @mock.patch.object(Configuration, 'get')
+    @patch.object(Configuration, 'get')
     def test_mycroft_stt(self, mock_get):
-        mycroft.stt.STTApi = mock.MagicMock()
+        mycroft.stt.STTApi = MagicMock()
         config = base_config()
         config.merge(
             {
@@ -118,13 +118,13 @@ class TestSTT(unittest.TestCase):
         mock_get.return_value = config
 
         stt = mycroft.stt.MycroftSTT()
-        audio = mock.MagicMock()
+        audio = MagicMock()
         stt.execute(audio, 'en-us')
         self.assertTrue(mycroft.stt.STTApi.called)
 
-    @mock.patch.object(Configuration, 'get')
+    @patch.object(Configuration, 'get')
     def test_google_stt(self, mock_get):
-        mycroft.stt.Recognizer = mock.MagicMock
+        mycroft.stt.Recognizer = MagicMock
         config = base_config()
         config.merge(
             {
@@ -136,14 +136,14 @@ class TestSTT(unittest.TestCase):
             })
         mock_get.return_value = config
 
-        audio = mock.MagicMock()
+        audio = MagicMock()
         stt = mycroft.stt.GoogleSTT()
         stt.execute(audio)
         self.assertTrue(stt.recognizer.recognize_google.called)
 
-    @mock.patch.object(Configuration, 'get')
+    @patch.object(Configuration, 'get')
     def test_google_cloud_stt(self, mock_get):
-        mycroft.stt.Recognizer = mock.MagicMock
+        mycroft.stt.Recognizer = MagicMock
         config = base_config()
         config.merge(
             {
@@ -159,14 +159,14 @@ class TestSTT(unittest.TestCase):
             })
         mock_get.return_value = config
 
-        audio = mock.MagicMock()
+        audio = MagicMock()
         stt = mycroft.stt.GoogleCloudSTT()
         stt.execute(audio)
         self.assertTrue(stt.recognizer.recognize_google_cloud.called)
 
-    @mock.patch.object(Configuration, 'get')
+    @patch.object(Configuration, 'get')
     def test_ibm_stt(self, mock_get):
-        mycroft.stt.Recognizer = mock.MagicMock
+        mycroft.stt.Recognizer = MagicMock
         config = base_config()
         config.merge(
             {
@@ -180,14 +180,14 @@ class TestSTT(unittest.TestCase):
             })
         mock_get.return_value = config
 
-        audio = mock.MagicMock()
+        audio = MagicMock()
         stt = mycroft.stt.IBMSTT()
         stt.execute(audio)
         self.assertTrue(stt.recognizer.recognize_ibm.called)
 
-    @mock.patch.object(Configuration, 'get')
+    @patch.object(Configuration, 'get')
     def test_wit_stt(self, mock_get):
-        mycroft.stt.Recognizer = mock.MagicMock
+        mycroft.stt.Recognizer = MagicMock
         config = base_config()
         config.merge(
             {
@@ -199,15 +199,15 @@ class TestSTT(unittest.TestCase):
             })
         mock_get.return_value = config
 
-        audio = mock.MagicMock()
+        audio = MagicMock()
         stt = mycroft.stt.WITSTT()
         stt.execute(audio)
         self.assertTrue(stt.recognizer.recognize_wit.called)
 
-    @mock.patch('mycroft.stt.post')
-    @mock.patch.object(Configuration, 'get')
+    @patch('mycroft.stt.post')
+    @patch.object(Configuration, 'get')
     def test_kaldi_stt(self, mock_get, mock_post):
-        mycroft.stt.Recognizer = mock.MagicMock
+        mycroft.stt.Recognizer = MagicMock
         config = base_config()
         config.merge(
             {
@@ -219,19 +219,19 @@ class TestSTT(unittest.TestCase):
             })
         mock_get.return_value = config
 
-        kaldiResponse = mock.MagicMock()
+        kaldiResponse = MagicMock()
         kaldiResponse.json.return_value = {
                 'hypotheses': [{'utterance': '     [noise]     text'},
                                {'utterance': '     asdf'}]
         }
         mock_post.return_value = kaldiResponse
-        audio = mock.MagicMock()
+        audio = MagicMock()
         stt = mycroft.stt.KaldiSTT()
         self.assertEquals(stt.execute(audio), 'text')
 
-    @mock.patch.object(Configuration, 'get')
+    @patch.object(Configuration, 'get')
     def test_bing_stt(self, mock_get):
-        mycroft.stt.Recognizer = mock.MagicMock
+        mycroft.stt.Recognizer = MagicMock
         config = base_config()
         config.merge(
             {
@@ -243,14 +243,14 @@ class TestSTT(unittest.TestCase):
             })
         mock_get.return_value = config
 
-        audio = mock.MagicMock()
+        audio = MagicMock()
         stt = mycroft.stt.BingSTT()
         stt.execute(audio)
         self.assertTrue(stt.recognizer.recognize_bing.called)
 
-    @mock.patch.object(Configuration, 'get')
+    @patch.object(Configuration, 'get')
     def test_houndify_stt(self, mock_get):
-        mycroft.stt.Recognizer = mock.MagicMock
+        mycroft.stt.Recognizer = MagicMock
         config = base_config()
         config.merge(
             {
@@ -264,7 +264,7 @@ class TestSTT(unittest.TestCase):
             })
         mock_get.return_value = config
 
-        audio = mock.MagicMock()
+        audio = MagicMock()
         stt = mycroft.stt.HoundifySTT()
         stt.execute(audio)
         self.assertTrue(stt.recognizer.recognize_houndify.called)

--- a/test/unittests/version/test_version.py
+++ b/test/unittests/version/test_version.py
@@ -14,7 +14,7 @@
 #
 import unittest
 
-import mock
+from unittest.mock import mock_open, patch
 
 import mycroft.version
 
@@ -27,7 +27,7 @@ VERSION_INFO = """
 
 
 class TestVersion(unittest.TestCase):
-    @mock.patch('mycroft.version.CORE_VERSION_TUPLE', (0, 8, 20))
+    @patch('mycroft.version.CORE_VERSION_TUPLE', (0, 8, 20))
     def test_get_version(self):
         """
             Tests for mycroft.version.get_version()
@@ -41,10 +41,10 @@ class TestVersion(unittest.TestCase):
         self.assertFalse(mycroft.version.check_version('0.9.12'))
         self.assertFalse(mycroft.version.check_version('1.0.2'))
 
-    @mock.patch('mycroft.version.isfile')
-    @mock.patch('mycroft.version.exists')
-    @mock.patch('mycroft.version.open',
-                mock.mock_open(read_data=VERSION_INFO), create=True)
+    @patch('mycroft.version.isfile')
+    @patch('mycroft.version.exists')
+    @patch('mycroft.version.open',
+           mock_open(read_data=VERSION_INFO), create=True)
     def test_version_manager(self, mock_exists, mock_isfile):
         """
             Test mycroft.version.VersionManager.get()


### PR DESCRIPTION
## Description
(Description of what the PR does, such as fixes # {issue number})
Takes care of #2261 by switching all mock imports. I've tested on python 3.4.8 and 3.6.7.

## How to test
(Description of how to validate or test this PR)
Run start-mycroft.sh unittest, though Travis should take care of this.

## Contributor license agreement signed?
CLA [yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
