### PR TITLE
Force install if IS_TRAVIS

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -298,7 +298,7 @@ function install_deps() {
     elif os_is_like debian || os_is debian || os_is_like ubuntu || os_is ubuntu || os_is linuxmint; then
         # Debian / Ubuntu / Mint
         echo "$GREEN Installing packages for Debian/Ubuntu/Mint...$RESET"
-        if dpkg -V libjack-jackd2-0 > /dev/null 2>&1 ; then
+        if dpkg -V libjack-jackd2-0 > /dev/null 2>&1 && [[ -z $IS_TRAVIS ]] ; then
             echo "
 We have detected that your computer has the libjack-jackd2-0 package installed.
 Mycroft requires a conflicting package, and will likely uninstall this package.


### PR DESCRIPTION
## Description
Makes sure `IS_TRAVIS` builds are non-interactive

## How to test
Run `dev_setup.sh` on new Ubuntu box

## Contributor license agreement signed?
CLA [ Yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
