### PR TITLE
Refactor/skill settings split

### DIFF
--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -380,30 +380,13 @@ class DeviceApi(Api):
         """ Upload skill metadata.
 
         Arguments:
-            settings_meta (dict): settings_meta typecasted to suite the backend
+            settings_meta (dict): skill info and settings in JSON format
         """
         return self.request({
             "method": "PUT",
-            "path": "/" + self.identity.uuid + "/skill",
+            "path": "/" + self.identity.uuid + "/settingsMeta",
             "json": settings_meta
         })
-
-    def delete_skill_metadata(self, skill_gid):
-        """ Delete the current skill metadata from backend
-
-            TODO: Real implementation when method exists on backend
-        Args:
-            skill_gid (str): skill_gid identifying the skill
-        """
-        try:
-            LOG.debug("Deleting remote metadata for {}".format(skill_gid))
-            self.request({
-                "method": "DELETE",
-                "path": ("/" + self.identity.uuid + "/skill" +
-                         "/{}".format(skill_gid))
-            })
-        except Exception as e:
-            LOG.error("{} cannot delete metadata because this".format(e))
 
     def upload_skills_data(self, data):
         """ Upload skills.json file. This file contains a manifest of installed

--- a/mycroft/api/__init__.py
+++ b/mycroft/api/__init__.py
@@ -12,14 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from copy import copy
-
-import json
-import requests
-from requests import HTTPError, RequestException
 import os
 import time
-from threading import Lock
+from copy import copy
+
+import requests
+from requests import HTTPError, RequestException
 
 from mycroft.configuration import Configuration
 from mycroft.configuration.config import DEFAULT_CONFIG, SYSTEM_CONFIG, \
@@ -219,8 +217,6 @@ class Api:
 
 class DeviceApi(Api):
     """ Web API wrapper for obtaining device-level information """
-    _skill_settings_lock = Lock()
-    _skill_settings = None
 
     def __init__(self):
         super(DeviceApi, self).__init__("device")
@@ -363,21 +359,14 @@ class DeviceApi(Api):
         })
 
     def get_skill_settings(self):
-        """ Fetch all skill settings. """
-        with DeviceApi._skill_settings_lock:
-            if (DeviceApi._skill_settings is None or
-                    time.monotonic() > DeviceApi._skill_settings[0] + 30):
-                DeviceApi._skill_settings = (
-                    time.monotonic(),
-                    self.request({
-                        "method": "GET",
-                        "path": "/" + self.identity.uuid + "/skill"
-                        })
-                )
-            return DeviceApi._skill_settings[1]
+        """Get the remote skill settings for all skills on this device."""
+        return self.request({
+            "method": "GET",
+            "path": "/" + self.identity.uuid + "/skill/settings",
+        })
 
     def upload_skill_metadata(self, settings_meta):
-        """ Upload skill metadata.
+        """Upload skill metadata.
 
         Arguments:
             settings_meta (dict): skill info and settings in JSON format

--- a/mycroft/skills/mycroft_skill/event_container.py
+++ b/mycroft/skills/mycroft_skill/event_container.py
@@ -110,7 +110,7 @@ def create_basic_wrapper(handler, on_error=None):
 class EventContainer:
     """Container tracking messagbus handlers.
 
-    This container tracks events added by a skill, allowing unregestering
+    This container tracks events added by a skill, allowing unregistering
     all events on shutdown.
     """
     def __init__(self, bus=None):

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -266,6 +266,7 @@ class MycroftSkill:
         else:
             remote_settings = message.data.get(self.skill_gid)
             if remote_settings is not None:
+                LOG.info('Updating settings for skill ' + self.name)
                 self.settings.update(**remote_settings)
                 save_settings(self.root_dir, self.settings)
                 if self.settings_change_callback is not None:

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -44,7 +44,7 @@ from mycroft.util.log import LOG
 from .event_container import EventContainer, create_wrapper, get_handler_name
 from ..event_scheduler import EventSchedulerInterface
 from ..intent_service_interface import IntentServiceInterface
-from ..settings import get_local_settings, save_settings
+from ..settings import save_settings, Settings
 from ..skill_data import (
     load_vocabulary,
     load_regex,
@@ -129,7 +129,7 @@ class MycroftSkill:
         # Get directory of skill
         self.root_dir = dirname(abspath(sys.modules[self.__module__].__file__))
         if use_settings:
-            self.settings = get_local_settings(self.root_dir, self.name)
+            self.settings = Settings(self)
         else:
             self.settings = None
         self.settings_change_callback = None

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -73,18 +73,19 @@ ONE_MINUTE = 60
 
 def get_local_settings(skill_dir, skill_name) -> dict:
     """Build a dictionary using the JSON string stored in settings.json."""
+    skill_settings = {}
     settings_path = Path(skill_dir).joinpath('settings.json')
-    if settings_path.is_file():
+    LOG.info(settings_path)
+    if settings_path.exists():
         with open(str(settings_path)) as settings_file:
+            settings_file_content = settings_file.read()
+        if settings_file_content:
             try:
-                skill_settings = json.load(settings_file)
+                skill_settings = json.loads(settings_file_content)
             # TODO change to check for JSONDecodeError in 19.08
             except Exception:
                 log_msg = 'Failed to load {} settings from settings.json'
                 LOG.exception(log_msg.format(skill_name))
-                skill_settings = {}
-    else:
-        skill_settings = {}
 
     return skill_settings
 
@@ -377,7 +378,7 @@ class Settings:
         if attr not in ['store', 'set_changed_callback']:
             return getattr(self._settings, attr)
         else:
-            return super().getattr(attr)
+            return getattr(self, attr)
 
     def __setitem__(self, key, val):
         self._settings[key] = val

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -369,7 +369,8 @@ class SkillSettingsDownloader:
             try:
                 previous_settings = self.last_download_result[skill_gid]
             except KeyError:
-                settings_changed = True
+                if remote_settings is not None:
+                    settings_changed = True
             except Exception:
                 LOG.exception('error occurred handling setting change events')
             else:

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -277,9 +277,14 @@ class SettingsMetaUploader:
                 get_display_name(self.skill_name)
             )
         )
-        # Backwards compatibility:
-        if 'name' not in self.settings_meta:
-            self.settings_meta.update(name=self.settings_meta['display_name'])
+        for deprecated in ('color', 'identifier', 'name'):
+            if deprecated in self.settings_meta:
+                log_msg = (
+                    'DEPRECATION WARNING: The "{}" attribute in the '
+                    'settingsmeta file is no longer supported.'
+                )
+                LOG.warning(log_msg.format(deprecated))
+                del(self.settings_meta[deprecated])
 
     def _issue_api_call(self):
         """Use the API to send the settings meta to the server."""
@@ -369,7 +374,7 @@ class SkillSettingsDownloader:
             try:
                 previous_settings = self.last_download_result[skill_gid]
             except KeyError:
-                if remote_settings is not None:
+                if remote_settings:
                     settings_changed = True
             except Exception:
                 LOG.exception('error occurred handling setting change events')
@@ -415,7 +420,7 @@ class Settings:
         save_settings(self._skill.root_dir, self._settings)
 
     def set_changed_callback(self, callback):
-        LOG.warning('DEPRECATED - set the settings_changed_callback attribute')
+        LOG.warning('DEPRECATED - set the settings_change_callback attribute')
         self._skill.settings_change_callback = callback
 
     def as_dict(self):

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -236,7 +236,7 @@ class SettingsMetaUploader:
         """Read the contents of the settingsmeta file into memory."""
         # Imported here do handle issue with readthedocs build
         import yaml
-        _, ext = os.path.splitext(self.settings_meta_path)
+        _, ext = os.path.splitext(str(self.settings_meta_path))
         is_json_file = self.settings_meta_path.suffix == ".json"
         try:
             with open(str(self.settings_meta_path)) as meta_file:

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -293,7 +293,7 @@ class SkillSettingsDownloader:
         self.continue_downloading = True
         self.changed_callback = None
         self.settings_meta_fields = None
-        self.last_download_result = None
+        self.last_download_result = {}
         self.remote_settings = None
         self.settings_changed = False
         self.api = DeviceApi()
@@ -357,10 +357,14 @@ class SkillSettingsDownloader:
                 previous_settings = self.last_download_result[skill_gid]
             except KeyError:
                 settings_changed = True
+            except Exception:
+                LOG.exception('error occurred handling setting change events')
             else:
                 if previous_settings != remote_settings:
                     settings_changed = True
             if settings_changed:
+                log_msg = 'Emitting skill settings change event for skill {} '
+                LOG.info(log_msg.format(skill_gid))
                 message = Message(
                     'mycroft.skills.settings.changed',
                     data={skill_gid: remote_settings}

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -23,6 +23,7 @@ from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
 from .msm_wrapper import create_msm as msm_creator, build_msm_config
+from .settings import SkillSettingsDownloader
 from .skill_loader import SkillLoader
 from .skill_updater import SkillUpdater
 
@@ -46,6 +47,7 @@ class SkillManager(Thread):
         self.enclosure = EnclosureAPI(bus)
         self.initial_load_complete = False
         self.num_install_retries = 0
+        self.settings_downloader = SkillSettingsDownloader(self.bus)
         self._define_message_bus_events()
         self.skill_updater = SkillUpdater()
         self.daemon = True
@@ -74,6 +76,10 @@ class SkillManager(Thread):
         self.bus.on('mycroft.paired', self.handle_paired)
         self.bus.on('mycroft.skills.is_alive', self.is_alive)
         self.bus.on('mycroft.skills.all_loaded', self.is_all_loaded)
+        self.bus.on(
+            'mycroft.skills.settings.update',
+            self.settings_downloader.download
+        )
 
     @property
     def config(self):
@@ -132,6 +138,7 @@ class SkillManager(Thread):
         self._remove_git_locks()
         self._connected_event.wait()
         self._load_on_startup()
+        self.settings_downloader.download()
 
         # Scan the file folder that contains Skills.  If a Skill is updated,
         # unload the existing version from memory and reload from the disk.
@@ -170,8 +177,8 @@ class SkillManager(Thread):
                 self._load_skill(skill_dir)
 
     def _load_skill(self, skill_directory):
+        skill_loader = SkillLoader(self.bus, skill_directory)
         try:
-            skill_loader = SkillLoader(self.bus, skill_directory)
             skill_loader.load()
         except Exception:
             LOG.exception('Load of skill {} failed!'.format(skill_directory))
@@ -284,6 +291,7 @@ class SkillManager(Thread):
     def stop(self):
         """Tell the manager to shutdown."""
         self._stop_event.set()
+        self.settings_downloader.stop_downloading()
 
         # Do a clean shutdown of all skills
         for skill_loader in self.skill_loaders.values():

--- a/test/unittests/api/test_api.py
+++ b/test/unittests/api/test_api.py
@@ -351,7 +351,7 @@ class TestSettingsMeta(unittest.TestCase):
         self.assertEquals(method, 'PUT')
         self.assertEquals(params['json'], settings_meta)
         self.assertEquals(
-            url, 'https://api-test.mycroft.ai/v1/device/1234/skill')
+            url, 'https://api-test.mycroft.ai/v1/device/1234/settingsMeta')
 
     def test_get_skill_settings(self, mock_request, mock_identity_get):
         mock_request.return_value = create_response(200, {})
@@ -365,20 +365,6 @@ class TestSettingsMeta(unittest.TestCase):
         self.assertEquals(method, 'GET')
         self.assertEquals(
             url, 'https://api-test.mycroft.ai/v1/device/1234/skill')
-
-    def test_delete_meta(self, mock_request, mock_identity_get):
-        mock_request.return_value = create_response(200, {})
-        mock_identity_get.return_value = create_identity('1234')
-        device = mycroft.api.DeviceApi()
-        device.delete_skill_metadata('testgid')
-        method = mock_request.call_args[0][0]
-        url = mock_request.call_args[0][1]
-        params = mock_request.call_args[1]
-
-        content_type = params['headers']['Content-Type']
-        self.assertEquals(method, 'DELETE')
-        self.assertEquals(
-            url, 'https://api-test.mycroft.ai/v1/device/1234/skill/testgid')
 
 
 @patch('mycroft.api._paired_cache', False)

--- a/test/unittests/api/test_api.py
+++ b/test/unittests/api/test_api.py
@@ -364,7 +364,7 @@ class TestSettingsMeta(unittest.TestCase):
 
         self.assertEquals(method, 'GET')
         self.assertEquals(
-            url, 'https://api-test.mycroft.ai/v1/device/1234/skill')
+            url, 'https://api-test.mycroft.ai/v1/device/1234/skill/settings')
 
 
 @patch('mycroft.api._paired_cache', False)

--- a/test/unittests/mocks.py
+++ b/test/unittests/mocks.py
@@ -36,9 +36,13 @@ def mock_msm(temp_dir):
     )
     skill = Mock()
     skill.is_local = True
+    skill.path = str(temp_dir)
+    skill.skill_gid = 'test_skill|99.99'
+    skill.meta_info = dict(display_name='Test Skill')
     msm_mock.list_all_defaults.return_value = [skill]
     msm_mock.default_skills = dict(test_skill=skill)
     msm_mock.all_skills = [skill]
+    msm_mock.local_skills = dict(test_skill=skill)
 
     return msm_mock
 

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -61,7 +61,7 @@ def vocab_base_path():
     return join(dirname(__file__), '..', 'vocab_test')
 
 
-class FunctionTest(unittest.TestCase):
+class TestFunction(unittest.TestCase):
     def test_resting_screen_handler(self):
         class T(MycroftSkill):
             def __init__(self):
@@ -76,13 +76,24 @@ class FunctionTest(unittest.TestCase):
         self.assertEquals(test_class.f.resting_handler, 'humbug')
 
 
-class MycroftSkillTest(unittest.TestCase):
+class TestMycroftSkill(unittest.TestCase):
     emitter = MockEmitter()
     regex_path = abspath(join(dirname(__file__), '../regex_test'))
     vocab_path = abspath(join(dirname(__file__), '../vocab_test'))
 
     def setUp(self):
         self.emitter.reset()
+        self.local_settings_mock = self._mock_local_settings()
+
+    def _mock_local_settings(self):
+        local_settings_patch = patch(
+            'mycroft.skills.mycroft_skill.mycroft_skill.get_local_settings'
+        )
+        self.addCleanup(local_settings_patch.stop)
+        local_settings_mock = local_settings_patch.start()
+        local_settings_mock.return_value = True
+
+        return local_settings_mock
 
     def check_vocab(self, filename, results=None):
         results = results or {}

--- a/test/unittests/skills/test_settings.py
+++ b/test/unittests/skills/test_settings.py
@@ -67,22 +67,12 @@ class TestSettingsMetaUploader(MycroftUnitTestBase):
         self.uploader.upload()
         self._check_api_not_called()
         self._check_timer_called()
-        self.assertListEqual(
-            [call.debug(
-                'settingsmeta.json not uploaded - device is not paired'
-            )],
-            self.log_mock.method_calls
-        )
 
     def test_no_settingsmeta(self):
         self.uploader.upload()
         self._check_settingsmeta()
         self._check_api_call()
         self._check_timer_not_called()
-        self.assertListEqual(
-            [call.debug('Uploading settings meta for test_skill|99.99')],
-            self.log_mock.method_calls
-        )
 
     def test_failed_upload(self):
         """The API call to upload the settingsmeta fails.
@@ -94,13 +84,6 @@ class TestSettingsMetaUploader(MycroftUnitTestBase):
         self._check_settingsmeta()
         self._check_api_call()
         self._check_timer_called()
-        self.assertListEqual(
-            [
-                call.debug('Uploading settings meta for test_skill|99.99'),
-                call.exception('Failed to upload skill settings meta')
-            ],
-            self.log_mock.method_calls
-        )
 
     def test_json_settingsmeta(self):
         json_path = str(self.temp_dir.joinpath('settingsmeta.json'))
@@ -111,10 +94,6 @@ class TestSettingsMetaUploader(MycroftUnitTestBase):
         self._check_settingsmeta(self.skill_metadata)
         self._check_api_call()
         self._check_timer_not_called()
-        self.assertListEqual(
-            [call.debug('Uploading settings meta for test_skill|99.99')],
-            self.log_mock.method_calls
-        )
 
     def test_yaml_settingsmeta(self):
         skill_metadata = (
@@ -129,10 +108,6 @@ class TestSettingsMetaUploader(MycroftUnitTestBase):
         self._check_settingsmeta(self.skill_metadata)
         self._check_api_call()
         self._check_timer_not_called()
-        self.assertListEqual(
-            [call.debug('Uploading settings meta for test_skill|99.99')],
-            self.log_mock.method_calls
-        )
 
     def _check_settingsmeta(self, skill_settings=None):
         expected_settings_meta = dict(
@@ -197,10 +172,6 @@ class TestSettingsDownloader(MycroftUnitTestBase):
         self.downloader.download()
         self._check_api_not_called()
         self._check_timer_called()
-        self.assertListEqual(
-            [call.debug('Settings not downloaded - device is not paired')],
-            self.log_mock.method_calls
-        )
 
     def test_settings_not_changed(self):
         test_skill_settings = {
@@ -208,16 +179,11 @@ class TestSettingsDownloader(MycroftUnitTestBase):
         }
         self.downloader.last_download_result = test_skill_settings
         self.downloader.api.get_skill_settings = Mock(
-            return_value=test_skill_settings
-        )
+            return_value=test_skill_settings)
         self.downloader.download()
         self._check_api_called()
         self._check_timer_called()
         self._check_no_message_bus_events()
-        self.assertListEqual(
-            [call.debug('No skill settings changes since last download')],
-            self.log_mock.method_calls
-        )
 
     def test_settings_changed(self):
         local_skill_settings = {
@@ -247,12 +213,6 @@ class TestSettingsDownloader(MycroftUnitTestBase):
         self.assertEqual(
             pre_download_local_settings,
             self.downloader.last_download_result
-        )
-        self.assertListEqual(
-            [call.exception(
-                'Failed to download remote settings from server.'
-            )],
-            self.log_mock.method_calls
         )
 
     def _check_api_called(self):

--- a/test/unittests/skills/test_settings.py
+++ b/test/unittests/skills/test_settings.py
@@ -138,7 +138,6 @@ class TestSettingsMetaUploader(MycroftUnitTestBase):
         expected_settings_meta = dict(
             skill_gid='test_skill|99.99',
             display_name='Test Skill',
-            name='Test Skill'
         )
         if skill_settings is not None:
             expected_settings_meta.update(skill_settings)

--- a/test/unittests/skills/test_settings.py
+++ b/test/unittests/skills/test_settings.py
@@ -229,16 +229,11 @@ class TestSettingsDownloader(MycroftUnitTestBase):
         }
         self.downloader.last_download_result = local_skill_settings
         self.downloader.api.get_skill_settings = Mock(
-            return_value=remote_skill_settings
-        )
+            return_value=remote_skill_settings)
         self.downloader.download()
         self._check_api_called()
         self._check_timer_called()
         self._check_message_bus_events(remote_skill_settings)
-        self.assertListEqual(
-            [call.debug('Skill settings changed since last download')],
-            self.log_mock.method_calls
-        )
 
     def test_download_failed(self):
         self.downloader.api.get_skill_settings = Mock(side_effect=ValueError)

--- a/test/unittests/skills/test_settings.py
+++ b/test/unittests/skills/test_settings.py
@@ -103,7 +103,7 @@ class TestSettingsMetaUploader(MycroftUnitTestBase):
         )
 
     def test_json_settingsmeta(self):
-        json_path = self.temp_dir.joinpath('settingsmeta.json')
+        json_path = str(self.temp_dir.joinpath('settingsmeta.json'))
         with open(json_path, 'w') as json_file:
             json.dump(self.skill_metadata, json_file)
 
@@ -121,7 +121,7 @@ class TestSettingsMetaUploader(MycroftUnitTestBase):
             'skillMetadata:\n  sections:\n    - name: "Test Section"\n      '
             'fields:\n      - type: "label"\n        label: "Test Field"'
         )
-        yaml_path = self.temp_dir.joinpath('settingsmeta.yaml')
+        yaml_path = str(self.temp_dir.joinpath('settingsmeta.yaml'))
         with open(yaml_path, 'w') as yaml_file:
             yaml_file.write(skill_metadata)
 
@@ -304,7 +304,7 @@ class TestSettings(TestCase):
         self.assertDictEqual(settings._settings, {})
 
     def test_settings_file_exists(self):
-        settings_path = self.temp_dir.joinpath('settings.json')
+        settings_path = str(self.temp_dir.joinpath('settings.json'))
         with open(settings_path, 'w') as settings_file:
             settings_file.write('{"foo": "bar"}\n')
 
@@ -324,7 +324,7 @@ class TestSettings(TestCase):
         settings = Settings(self.skill_mock)
         settings['foo'] = 'bar'
         settings.store()
-        settings_path = self.temp_dir.joinpath('settings.json')
+        settings_path = str(self.temp_dir.joinpath('settings.json'))
         with open(settings_path) as settings_file:
             file_contents = settings_file.read()
 

--- a/test/unittests/skills/test_skill_loader.py
+++ b/test/unittests/skills/test_skill_loader.py
@@ -14,7 +14,7 @@
 #
 """Unit tests for the SkillLoader class."""
 from time import time
-from unittest.mock import call, MagicMock, patch
+from unittest.mock import call, MagicMock, Mock, patch
 
 from mycroft.skills.skill_loader import _get_last_modified_time, SkillLoader
 from ..base import MycroftUnitTestBase
@@ -34,10 +34,10 @@ class TestSkillLoader(MycroftUnitTestBase):
         )
         self._mock_skill_instance()
         # TODO: un-mock these when they are more testable
-        self.loader._load_skill_source = MagicMock(
-            return_value=MagicMock()
+        self.loader._load_skill_source = Mock(
+            return_value=Mock()
         )
-        self.loader._check_for_first_run = MagicMock()
+        self.loader._check_for_first_run = Mock()
 
     def _load_skill_directory(self):
         """The skill loader expects certain things in a skill directory."""
@@ -50,11 +50,11 @@ class TestSkillLoader(MycroftUnitTestBase):
 
     def _mock_skill_instance(self):
         """Mock the skill instance, we are not testing skill functionality."""
-        skill_instance = MagicMock()
+        skill_instance = Mock()
         skill_instance.name = 'test_skill'
         skill_instance.reload_skill = True
-        skill_instance.default_shutdown = MagicMock()
-        skill_instance.settings = MagicMock()
+        skill_instance.default_shutdown = Mock()
+        skill_instance.settings = Mock()
         self.skill_instance_mock = skill_instance
 
     def test_get_last_modified_date(self):
@@ -67,7 +67,7 @@ class TestSkillLoader(MycroftUnitTestBase):
 
     def test_skill_already_loaded(self):
         """The loader should take to action for an already loaded skill."""
-        self.loader.instance = MagicMock
+        self.loader.instance = Mock
         self.loader.instance.reload_skill = True
         self.loader.loaded = True
         self.loader.last_loaded = time() + ONE_MINUTE
@@ -76,7 +76,7 @@ class TestSkillLoader(MycroftUnitTestBase):
 
     def test_skill_reloading_blocked(self):
         """The loader should skip reloads for skill that doesn't allow it."""
-        self.loader.instance = MagicMock()
+        self.loader.instance = Mock()
         self.loader.instance.reload_skill = False
         self.loader.active = True
         self.loader.loaded = True
@@ -84,7 +84,7 @@ class TestSkillLoader(MycroftUnitTestBase):
 
     def test_skill_reloading_deactivated(self):
         """The loader should skip reloads for skill that aren't active."""
-        self.loader.instance = MagicMock()
+        self.loader.instance = Mock()
         self.loader.instance.reload_skill = True
         self.loader.active = False
         self.loader.loaded = False
@@ -92,13 +92,14 @@ class TestSkillLoader(MycroftUnitTestBase):
 
     def test_skill_reload(self):
         """Test reloading a skill that was modified."""
-        self.loader.instance = MagicMock()
+        self.loader.instance = Mock()
         self.loader.loaded = True
         self.loader.last_loaded = 0
 
         with patch(self.mock_package + 'time') as time_mock:
             time_mock.return_value = 100
-            self.loader.reload()
+            with patch(self.mock_package + 'SettingsMetaUploader'):
+                self.loader.reload()
 
         self.assertTrue(self.loader.load_attempted)
         self.assertTrue(self.loader.loaded)
@@ -117,7 +118,8 @@ class TestSkillLoader(MycroftUnitTestBase):
     def test_skill_load(self):
         with patch(self.mock_package + 'time') as time_mock:
             time_mock.return_value = 100
-            self.loader.load()
+            with patch(self.mock_package + 'SettingsMetaUploader'):
+                self.loader.load()
 
         self.assertTrue(self.loader.load_attempted)
         self.assertTrue(self.loader.loaded)
@@ -135,7 +137,8 @@ class TestSkillLoader(MycroftUnitTestBase):
     def test_skill_load_blacklisted(self):
         """Skill should not be loaded if it is blacklisted"""
         self.loader.config['skills']['blacklisted_skills'] = ['test_skill']
-        self.loader.load()
+        with patch(self.mock_package + 'SettingsMetaUploader'):
+            self.loader.load()
 
         self.assertTrue(self.loader.load_attempted)
         self.assertFalse(self.loader.loaded)

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -28,6 +28,7 @@ class TestSkillManager(MycroftUnitTestBase):
     def setUp(self):
         super().setUp()
         self._mock_skill_updater()
+        self._mock_skill_settings_downloader()
         self.skill_manager = SkillManager(self.message_bus_mock)
         self._mock_skill_loader_instance()
 
@@ -38,6 +39,14 @@ class TestSkillManager(MycroftUnitTestBase):
             self.create_msm_mock = msm_patch.start()
             self.msm_mock = mock_msm(str(self.temp_dir))
             self.create_msm_mock.return_value = self.msm_mock
+
+    def _mock_skill_settings_downloader(self):
+        settings_download_patch = patch(
+            self.mock_package + 'SkillSettingsDownloader',
+            spec=True
+        )
+        self.addCleanup(settings_download_patch.stop)
+        self.settings_download_mock = settings_download_patch.start()
 
     def _mock_skill_updater(self):
         skill_updater_patch = patch(
@@ -73,7 +82,8 @@ class TestSkillManager(MycroftUnitTestBase):
             'skillmanager.activate',
             'mycroft.paired',
             'mycroft.skills.is_alive',
-            'mycroft.skills.all_loaded'
+            'mycroft.skills.all_loaded',
+            'mycroft.skills.settings.update'
         ]
         self.assertListEqual(
             expected_result,


### PR DESCRIPTION
## Description
Complete rethink of how we deal with settings and settingsmeta in core

## How to test
Make changes to settingsmeta.json for a skill.  Confirm that the changes are accurately reflected on the backend.  Make changes to skill settings at account.mycroft.ai.  Confirm that changes are accurately reflected in settings.json

## Contributor license agreement signed?
CLA [yes]