### PR TITLE
Add Yandex TTS support

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -276,7 +276,7 @@
   // Text to Speech parameters
   // Override: REMOTE
   "tts": {
-    // Engine.  Options: "mimic", "google", "marytts", "fatts", "espeak", "spdsay", "responsive_voice"
+    // Engine.  Options: "mimic", "google", "marytts", "fatts", "espeak", "spdsay", "responsive_voice", "yandex"
     "pulse_duck": false,
     "module": "mimic",
     "mimic": {

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -445,6 +445,7 @@ class TTSFactory:
     from mycroft.tts.ibm_tts import WatsonTTS
     from mycroft.tts.responsive_voice_tts import ResponsiveVoice
     from mycroft.tts.mimic2_tts import Mimic2
+    from mycroft.tts.yandex_tts import YandexTTS
 
     CLASSES = {
         "mimic": Mimic,
@@ -456,7 +457,8 @@ class TTSFactory:
         "spdsay": SpdSay,
         "watson": WatsonTTS,
         "bing": BingTTS,
-        "responsive_voice": ResponsiveVoice
+        "responsive_voice": ResponsiveVoice,
+        "yandex": YandexTTS
     }
 
     @staticmethod

--- a/mycroft/tts/yandex_tts.py
+++ b/mycroft/tts/yandex_tts.py
@@ -1,0 +1,97 @@
+# Copyright 2019 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from mycroft.tts import TTS, TTSValidator
+from mycroft.configuration import Configuration
+
+import requests
+import wave
+
+_API_URL = "https://tts.api.cloud.yandex.net/speech/v1/tts:synthesize"
+
+
+class YandexTTS(TTS):
+    def __init__(self, lang, config):
+        super(YandexTTS, self).__init__(lang, config, YandexTTSValidator(self))
+        self.type = "wav"
+        self.config = Configuration.get().get("tts", {}).get("yandex", {})
+        self.api_key = self.config.get("api_key")
+        self.voice = self.config.get("voice", "oksana")
+        self.emotion = self.config.get("emotion", "neutral")
+        self.speed = self.config.get("speed", 1.0)
+        self.sample_rate = self.config.get("sample_rate", 48000)
+
+    def get_tts(self, sentence, wav_file):
+        with wave.open(wav_file, "wb") as f:
+            f.setparams((1, 2, self.sample_rate, 0, "NONE", "NONE"))
+            for audio_content in self._synthesize(sentence):
+                f.writeframes(audio_content)
+        return (wav_file, None)  # No phonemes
+
+    # Based on example: https://cloud.yandex.com/docs/speechkit/tts/request#wav
+    def _synthesize(self, text):
+        headers = {"Authorization": "Api-Key {}".format(self.api_key)}
+
+        data = {
+            "text": text,
+            "lang": self.lang,
+            "voice": self.voice,
+            "emotion": self.emotion,
+            "speed": self.speed,
+            "format": "lpcm",
+            "sampleRateHertz": self.sample_rate
+        }
+
+        with requests.post(_API_URL, headers=headers, data=data,
+                           stream=True) as resp:
+            if resp.status_code != 200:
+                raise Exception(
+                    "Request to Yandex TTS failed: code: {}, body: {}".format(
+                        resp.status_code, resp.text))
+
+            for chunk in resp.iter_content(chunk_size=None):
+                yield chunk
+
+
+class YandexTTSValidator(TTSValidator):
+    def __init__(self, tts):
+        super(YandexTTSValidator, self).__init__(tts)
+
+    def validate_lang(self):
+        config = Configuration.get().get("tts", {}).get("yandex", {})
+        lang = config.get("lang")
+        if lang in ["en-US", "ru-RU", "tr-TR"]:
+            return True
+        raise ValueError("Unsupported language for Yandex TTS")
+
+    def validate_connection(self):
+        config = Configuration.get().get("tts", {}).get("yandex", {})
+        api_key = config.get("api_key")
+        if api_key is not None:
+            headers = {"Authorization": "Api-Key {}".format(api_key)}
+            r = requests.get(_API_URL, headers=headers)
+            if r.status_code == 400:  # Authorized, but bad request
+                return True
+            elif r.status_code == 401:  # Unauthorized
+                raise Exception("Invalid API key for Yandex TTS")
+            else:
+                raise Exception(
+                    "Unexpected HTTP code from Yandex TTS ({})".format(
+                        r.status_code))
+        else:
+            raise ValueError("API key for Yandex TTS is not defined")
+
+    def get_tts_class(self):
+        return YandexTTS


### PR DESCRIPTION
## Description
[Yandex](https://yandex.com) is a the russian biggest cloud platform. Yandex [SpeechKit](https://cloud.yandex.com/docs/speechkit/) is, probably, the best STT/TTS service for Russian language. So, I believe it's a good idea to add Yandex TTS support to Mycroft.
Curently I chose authorization with API key, because there is no need for renew key.

## How to test
1. Register an account at Yandex.
2. Create billing account: https://cloud.yandex.com/docs/billing/quickstart/#create_billing_account
You can activate free period in console.
3. Create first "folder" in cloud.
4. Create service account for you Mycroft instance with role `editor`: https://cloud.yandex.com/docs/iam/operations/sa/create
5. Create API key for service account: https://cloud.yandex.com/docs/iam/operations/api-key/create
6. Edit `mycroft.conf`:
```
"tts": {
  "module": "yandex",
  "yandex": {
    "lang": "en-US",
    "api_key": "YOUR_API_KEY",
    "voice": "oksana", #optional
    "emotion": "good" #optional
  }
}
```
You can find list of available values [here](https://cloud.yandex.com/docs/speechkit/tts/request#body_params).

## Contributor license agreement signed?
CLA [ Yes ]