### PR TITLE
Make messagebus service respect loglevel

### DIFF
--- a/mycroft/messagebus/service/__main__.py
+++ b/mycroft/messagebus/service/__main__.py
@@ -18,6 +18,8 @@ The message bus facilitates inter-process communication between mycroft-core
 processes. It implements a websocket server so can also be used by external
 systems to integrate with the Mycroft system.
 """
+import sys
+
 from tornado import autoreload, web, ioloop
 
 from mycroft.lock import Lock  # creates/supports PID locking file
@@ -36,7 +38,8 @@ def main():
     LOG.info('Starting message bus service...')
     reset_sigint_handler()
     lock = Lock("service")
-    tornado.options.parse_command_line()
+    # Disable all tornado logging so mycroft loglevel isn't overridden
+    tornado.options.parse_command_line(sys.argv + ['--logging=None'])
 
     def reload_hook():
         """ Hook to release lock when auto reload is triggered. """

--- a/mycroft/messagebus/service/event_handler.py
+++ b/mycroft/messagebus/service/event_handler.py
@@ -35,7 +35,7 @@ class MessageBusEventHandler(WebSocketHandler):
         self.emitter.on(event_name, handler)
 
     def on_message(self, message):
-        # LOG.debug(message)
+        LOG.debug(message)
         try:
             deserialized_message = Message.deserialize(message)
         except Exception:


### PR DESCRIPTION
## Description
Sends the --logging=None parameter to tornado to ensure that the mycroft log level is respected.

## How to test
Check that if log level is set to DEBUG in the config file bus messages are logged.

## Contributor license agreement signed?
CLA [ Yes ]
