### PR TITLE
Add Yandex STT support

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -257,7 +257,7 @@
   // Override: REMOTE
   "stt": {
     // Engine.  Options: "mycroft", "google", "wit", "ibm", "kaldi", "bing",
-    //                   "houndify", "deepspeech_server", "govivace"
+    //                   "houndify", "deepspeech_server", "govivace", "yandex"
     "module": "mycroft"
     // "deepspeech_server": {
     //   "uri": "http://localhost:8080/stt"

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -118,6 +118,73 @@ class IBMSTT(BasicSTT):
                                              self.password, self.lang)
 
 
+class YandexSTT(STT):
+    """
+        Yandex SpeechKit STT
+        To use create service account with role 'editor' in your cloud folder,
+        create API key for account and add it to local mycroft.conf file.
+        The STT config will look like this:
+
+        "stt": {
+            "module": "yandex",
+            "yandex": {
+                "lang": "en-US",
+                "credential": {
+                    "api_key": "YOUR_API_KEY"
+                }
+            }
+        }
+    """
+    def __init__(self):
+        super(YandexSTT, self).__init__()
+        self.lang = self.config.get('lang') or self.lang
+        self.api_key = self.credential.get("api_key")
+        if self.api_key is None:
+            raise ValueError("API key for Yandex STT is not defined")
+
+    def execute(self, audio, language=None):
+        self.lang = language or self.lang
+        if self.lang not in ["en-US", "ru-RU", "tr-TR"]:
+            raise ValueError(
+                "Unsupported language '{}' for Yandex STT".format(self.lang))
+
+        # Select sample rate based on source sample rate
+        # and supported sample rate list
+        supported_sample_rates = [8000, 16000, 48000]
+        sample_rate = audio.sample_rate
+        if sample_rate not in supported_sample_rates:
+            for supported_sample_rate in supported_sample_rates:
+                if audio.sample_rate < supported_sample_rate:
+                    sample_rate = supported_sample_rate
+                    break
+            if sample_rate not in supported_sample_rates:
+                sample_rate = supported_sample_rates[-1]
+
+        raw_data = audio.get_raw_data(convert_rate=sample_rate,
+                                      convert_width=2)
+
+        # Based on https://cloud.yandex.com/docs/speechkit/stt#request
+        url = "https://stt.api.cloud.yandex.net/speech/v1/stt:recognize"
+        headers = {"Authorization": "Api-Key {}".format(self.api_key)}
+        params = "&".join([
+            "lang={}".format(self.lang),
+            "format=lpcm",
+            "sampleRateHertz={}".format(sample_rate)
+        ])
+
+        response = post(url + "?" + params, headers=headers, data=raw_data)
+        if response.status_code == 200:
+            result = json.loads(response.text)
+            if result.get("error_code") is None:
+                return result.get("result")
+        elif response.status_code == 401:  # Unauthorized
+            raise Exception("Invalid API key for Yandex STT")
+        else:
+            raise Exception(
+                "Request to Yandex STT failed: code: {}, body: {}".format(
+                    response.status_code, response.text))
+
+
 def requires_pairing(func):
     """Decorator kicking of pairing sequence if client is not allowed access.
 
@@ -424,7 +491,8 @@ class STTFactory:
         "houndify": HoundifySTT,
         "deepspeech_server": DeepSpeechServerSTT,
         "deepspeech_stream_server": DeepSpeechStreamServerSTT,
-        "mycroft_deepspeech": MycroftDeepSpeechSTT
+        "mycroft_deepspeech": MycroftDeepSpeechSTT,
+        "yandex": YandexSTT
     }
 
     @staticmethod


### PR DESCRIPTION
## Description
[Yandex](https://yandex.com) is a the russian biggest cloud platform. Yandex [SpeechKit](https://cloud.yandex.com/docs/speechkit/) is, probably, the best STT/TTS service for Russian language. So, I believe it's a good idea to add Yandex STT support to Mycroft.
Curently I chose authorization with API key, because there is no need for renew key.

## How to test
1. Register an account at Yandex.
2. Create billing account: https://cloud.yandex.com/docs/billing/quickstart/#create_billing_account
You can activate free period in console.
3. Create first "folder" in cloud.
4. Create service account for you Mycroft instance with role `editor`: https://cloud.yandex.com/docs/iam/operations/sa/create
5. Create API key for service account: https://cloud.yandex.com/docs/iam/operations/api-key/create
6. Edit `mycroft.conf`:
```
"stt": {
  "module": "yandex",
  "yandex": {
    "lang": "en-US",
    "credential": {
      "api_key": "YOUR_API_KEY"
    }
  }
}
```
## Contributor license agreement signed?
CLA [ Yes ]