### PR TITLE
Don't kill global events when shutting down skill

### DIFF
--- a/mycroft/skills/mycroft_skill/event_container.py
+++ b/mycroft/skills/mycroft_skill/event_container.py
@@ -180,5 +180,5 @@ class EventContainer:
         events.
         """
         for e, f in self.events:
-            self.bus.remove_all_listeners(e)
+            self.bus.remove(e, f)
         self.events = []  # Remove reference to wrappers


### PR DESCRIPTION

## Description
During skill shutdown remove_all_handlers() was called on all registered
events. This would unregister all global events, such as settings
updating, stop for all skills.

Now the remove only will remove the instance connected to the skills
method.

This is a likely cause for the failure to stopping the news playback.

## How to test
Start skills, trigger a reload of a single skill. Ensure that the news skill can be stopped still.

## Contributor license agreement signed?
CLA [ Yes ]
