### PR TITLE
Cycle through dialog files to avoid repeating the same line

### DIFF
--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -35,6 +35,10 @@ class MustacheDialogRenderer:
 
     def __init__(self):
         self.templates = {}
+        self.recent_phrases = []
+
+        # TODO magic numbers are bad!
+        self.max_recent_phrases = 3
 
     def load_template_file(self, template_name, filename):
         """
@@ -67,6 +71,8 @@ class MustacheDialogRenderer:
         Given a template name, pick a template and render it using the context.
         If no matching template exists use template_name as template.
 
+        Tries not to let Mycroft say exactly the same thing twice in a row.
+
         Args:
             template_name (str): the name of a template group.
             context (dict): dictionary representing values to be rendered
@@ -84,7 +90,12 @@ class MustacheDialogRenderer:
             # "record not found" literal.
             return template_name.replace(".", " ")
 
-        template_functions = self.templates.get(template_name)
+        # Get the .dialog file's contents, minus any which have been spoken
+        # recently.
+        template_functions = ([t for t in self.templates.get(template_name)
+                              if t not in self.recent_phrases] or
+                              self.templates.get(template_name))
+
         if index is None:
             line = random.choice(template_functions)
         else:
@@ -92,6 +103,13 @@ class MustacheDialogRenderer:
         # Replace {key} in line with matching values from context
         line = line.format(**context)
         line = random.choice(expand_options(line))
+
+        # Here's where we keep track of what we've said recently. Remember,
+        # this is by line in the .dialog file, not by exact phrase
+        self.recent_phrases.append(line)
+        if len(self.recent_phrases) > min(self.max_recent_phrases,
+                                        len(self.templates.get(template_name)) - 1):
+            self.recent_phrases.pop(0)
         return line
 
 


### PR DESCRIPTION
## Description
Attempts to use a different line from .dialog files each time a skill is invoked. If a dialog file has more than 2 entries, Mycroft will avoid speaking the same line twice in a row. Longer dialog files will not repeat for at least 3 runs.

Changes are to MustacheDialogRenderer.render(), so the little cache of "phrases I won't say next" is per _skill_, not per intent nor per dialog file. However, the decision to cache a phrase (or not) _is_ based on the length of the dialog file, so that the feature will never leave an intent without anything to say.

This could be refactored to keep track on a per-intent basis, or per dialog file, but I think it would be a waste of memory for not much gain. The cache inherently enforces a minimum number of _skill_ invokations before Mycroft can repeat the same phrase, even if it isn't guaranteed to draw another phrase from the same, specific dialog file in the interim.

## How to test
Manual testing with your favorite sandbox skill is easy. I started out testing with Dismissal because it had exactly 4 lines of dialog. At the end of each run, have an intent:

self.log.info(self.dialog_renderer.recent_phrases)

and it will log the array of phrases it's blocking from repetition.

Comment lines out of the associated .dialog file, a few at a time, and observe what happens to the array when the .dialog file is 1, 2, 3, or 4+ lines in length.

## Notes
Might wanna squash the commits. I know that's usually bad practice, but the second one's just noise, apart from its commit message.

credit to @forslund for making the very-pythonic line 105 out of my overdocumented, C-style first attempt.

## Contributor license agreement signed?

CLA [ Yes ]