### PR TITLE
Catch exceptions when reloading skills

### DIFF
--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -86,7 +86,13 @@ class SkillLoader:
         Returns:
              bool: if the skill was loaded/reloaded
         """
-        self.last_modified = _get_last_modified_time(self.skill_directory)
+        try:
+            self.last_modified = _get_last_modified_time(self.skill_directory)
+        except FileNotFoundError as e:
+            LOG.error('Failed to get last_modification time '
+                      '({})'.format(repr(e)))
+            self.last_modified = self.last_loaded
+
         modified = self.last_modified > self.last_loaded
 
         # create local reference to avoid threading issues

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -150,9 +150,13 @@ class SkillManager(Thread):
     def _reload_modified_skills(self):
         """Handle reload of recently changed skill(s)"""
         for skill_dir in self._get_skill_directories():
-            skill_loader = self.skill_loaders.get(skill_dir)
-            if skill_loader is not None and skill_loader.reload_needed():
-                skill_loader.reload()
+            try:
+                skill_loader = self.skill_loaders.get(skill_dir)
+                if skill_loader is not None and skill_loader.reload_needed():
+                    skill_loader.reload()
+            except Exception as e:
+                LOG.exception('Unhandled exception occured while '
+                              'reloading {}'.format(skill_dir))
 
     def _load_new_skills(self):
         """Handle load of skills installed since startup."""


### PR DESCRIPTION
## Description
I've experienced a couple of halts of the skill manager due to FileNotFoundErrors when reloading skills.

This will explicitly
- Explicitly catch FileNotFoundError
- Do a general catch and log for other exceptions

## How to test
Make sure skill service is still loading and reloading as expected

## Contributor license agreement signed?
CLA [ Yes ]
