### PR TITLE
Properly call found_date check

### DIFF
--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -1377,7 +1377,7 @@ def extract_datetime_en(string, dateNow, default_time):
             idx += used - 1
             found = True
     # check that we found a date
-    if not date_found:
+    if not date_found():
         return None
 
     if dayOffset is False:

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -486,6 +486,10 @@ class TestNormalize(unittest.TestCase):
         evening = datetime(2017, 6, 27, 20, 1, 2)
         noonish = datetime(2017, 6, 27, 12, 1, 2)
         self.assertEqual(
+            extract_datetime('feed the fish'), None)
+        self.assertEqual(
+            extract_datetime(' '), None)
+        self.assertEqual(
             extract_datetime('feed fish at 10 o\'clock', morning)[0],
             datetime(2017, 6, 27, 10, 0, 0))
         self.assertEqual(


### PR DESCRIPTION
## Description
The check for no date or time in the sentence was never called, this calls it properly and adds a few simple tests.


## Contributor license agreement signed?
CLA [ Yes ]