### PR TITLE
bugfix/adapt munging

### DIFF
--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -149,7 +149,7 @@ def munge_intent_parser(intent_parser, name, skill_id):
         skill_id: (int) skill identifier
     """
     # Munge parser name
-    if str(skill_id) + ':' not in name:
+    if not name.startswith(str(skill_id) + ':'):
         intent_parser.name = str(skill_id) + ':' + name
     else:
         intent_parser.name = name
@@ -159,7 +159,7 @@ def munge_intent_parser(intent_parser, name, skill_id):
     # Munge required keyword
     reqs = []
     for i in intent_parser.requires:
-        if skill_id not in i[0]:
+        if not i[0].startswith(skill_id):
             kw = (skill_id + i[0], skill_id + i[0])
             reqs.append(kw)
         else:
@@ -169,7 +169,7 @@ def munge_intent_parser(intent_parser, name, skill_id):
     # Munge optional keywords
     opts = []
     for i in intent_parser.optional:
-        if skill_id not in i[0]:
+        if not i[0].startswith(skill_id):
             kw = (skill_id + i[0], skill_id + i[0])
             opts.append(kw)
         else:


### PR DESCRIPTION
## Description
if a keyword contains the skill id there is a mismatch between registered keyword and keyword required by intents

depending on the name of the skill adapt keywords can get incorrectly munged when registering intent, this causes intents to be registered to a keyword without the skill id, while the keyword itself was correctly munged and contains the skill id

took me a while to understand why some intents magically would not trigger, until i renamed the skill and everything started working

## How to test
register a keyword containing the skill_id

## Contributor license agreement signed?
CLA [yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
