### PR TITLE
Add status queries to the skill process

### DIFF
--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -71,7 +71,9 @@ class TestSkillManager(MycroftUnitTestBase):
             'skillmanager.deactivate',
             'skillmanager.keep',
             'skillmanager.activate',
-            'mycroft.paired'
+            'mycroft.paired',
+            'mycroft.skills.is_alive',
+            'mycroft.skills.all_loaded'
         ]
         self.assertListEqual(
             expected_result,


### PR DESCRIPTION
## Description

`mycroft.skills.is_alive`: The service is started and priority skills are
loaded.
`mycroft.skills.all_loaded`: All skills on the system has been loaded.

## How to test
Check the return of `self.bus.wait_for_response(Message('mycroft.skills.is_alive'))` and `self.bus.wait_for_response(Message('mycroft.skills.all_loaded'))` from a skill.

## Contributor license agreement signed?
CLA [ Yes ]
