### PR TITLE
Handle HTTP errors when updating device attributes

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -21,6 +21,7 @@ directory.  The executable gets added to the bin directory when installed
 import time
 from threading import Event
 
+from requests import HTTPError, ConnectionError
 import mycroft.lock
 from msm.exceptions import MsmException
 
@@ -181,7 +182,7 @@ class DevicePrimer(object):
             try:
                 api = DeviceApi()
                 api.update_version()
-            except BackendDown:
+            except (HTTPError, ConnectionError):
                 self._notify_backend_down()
 
     def _update_system(self):


### PR DESCRIPTION
## Description
If the backend throws an unexpected 500 error (or other status code indicating an error) the startup sequence would halt since the HTTPError isn't expected.

Capture the correct exceptions when updating device version and
enclosure type. Switches from BackendDown to ConnectionError and
HTTPError.

## How to test
Ensure that the skill startup sequence doesn't halt.

## Contributor license agreement signed?
CLA [ Yes ]