### PR TITLE
Fix import of mplayer

### DIFF
--- a/mycroft/audio/services/mplayer/__init__.py
+++ b/mycroft/audio/services/mplayer/__init__.py
@@ -18,7 +18,7 @@ try:
     from py_mplayer import MplayerCtrl
 except ImportError:
     LOG.error("install py_mplayer with "
-              "pip install git+https://github.com/JarbasAl/py_mplayer")
+              "pip install git+https://github.com/MycroftAI/py_mplayer")
     raise
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ pillow==4.1.1
 python-dateutil==2.6.0
 pychromecast==3.2.2
 python-vlc==1.1.2
+git+https://github.com/MycroftAI/py_mplayer@master
 google-api-python-client==1.6.4
 fasteners==0.14.1
 PyYAML==3.13


### PR DESCRIPTION
## Description
We currently don't seem to be installing py_mplayer and hence it will always fail to load.
The previous error message pointed to Jarbas's repo. I've forked this and pointed to Mycroft AI's repo just for added security.

## How to test
Install Mycroft-core without this PR results in:
> 2019-09-16 19:49:11.410 | INFO     |   874 | mycroft.audio.audioservice:load_services:100 | Loading mplayer
2019-09-16 19:49:11.650 | ERROR    |   874 | mplayer__init__:<module>:20 | install py_mplayer with pip install git+https://github.com/JarbasAl/py_mplayer
2019-09-16 19:49:11.659 | ERROR    |   874 | mycroft.audio.audioservice:load_services:106 | Failed to import module mplayer
ImportError("No module named 'py_mplayer'",)

Install with PR results in successfully loading mplayer

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
