### PR TITLE
settingsMeta API call to be issued without a device ID in the URL.

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -156,7 +156,7 @@ class SettingsMetaUploader:
         self.yaml_path = self.skill_directory.joinpath('settingsmeta.yaml')
         self.config = Configuration.get()
         self.settings_meta = {}
-        self.api = DeviceApi()
+        self.api = None
         self.upload_timer = None
 
         # Property placeholders
@@ -228,16 +228,20 @@ class SettingsMetaUploader:
         """
         synced = False
         if is_paired():
-            settings_meta_file_exists = (
-                self.json_path.is_file() or
-                self.yaml_path.is_file()
-            )
-            if settings_meta_file_exists:
-                self._load_settings_meta_file()
+            self.api = DeviceApi()
+            if self.api.identity.uuid:
+                settings_meta_file_exists = (
+                    self.json_path.is_file() or
+                    self.yaml_path.is_file()
+                )
+                if settings_meta_file_exists:
+                    self._load_settings_meta_file()
 
-            self._update_settings_meta()
-            LOG.debug('Uploading settings meta for ' + self.skill_gid)
-            synced = self._issue_api_call()
+                self._update_settings_meta()
+                LOG.debug('Uploading settings meta for ' + self.skill_gid)
+                synced = self._issue_api_call()
+            else:
+                LOG.debug('settingsmeta.json not uploaded - no identity')
         else:
             LOG.debug('settingsmeta.json not uploaded - device is not paired')
 

--- a/test/unittests/skills/test_settings.py
+++ b/test/unittests/skills/test_settings.py
@@ -68,24 +68,38 @@ class TestSettingsMetaUploader(MycroftUnitTestBase):
         self._check_api_not_called()
         self._check_timer_called()
 
-    def test_no_settingsmeta(self):
+    @patch('mycroft.skills.settings.DeviceApi')
+    def test_no_settingsmeta(self, mock_api):
+        api_instance = Mock()
+        api_instance.identity.uuid = '42'
+        mock_api.return_value = api_instance
+
         self.uploader.upload()
         self._check_settingsmeta()
         self._check_api_call()
         self._check_timer_not_called()
 
-    def test_failed_upload(self):
+    @patch('mycroft.skills.settings.DeviceApi')
+    def test_failed_upload(self, mock_api):
         """The API call to upload the settingsmeta fails.
 
         This will cause a timer to be generated to retry the update.
         """
-        self.uploader.api.upload_skill_metadata = Mock(side_effect=ValueError)
+        api_instance = Mock()
+        api_instance.identity.uuid = '42'
+        api_instance.upload_skill_metadata = Mock(side_effect=ValueError)
+        mock_api.return_value = api_instance
         self.uploader.upload()
         self._check_settingsmeta()
         self._check_api_call()
         self._check_timer_called()
 
-    def test_json_settingsmeta(self):
+    @patch('mycroft.skills.settings.DeviceApi')
+    def test_json_settingsmeta(self, mock_api):
+        api_instance = Mock()
+        api_instance.identity.uuid = '42'
+        mock_api.return_value = api_instance
+
         json_path = str(self.temp_dir.joinpath('settingsmeta.json'))
         with open(json_path, 'w') as json_file:
             json.dump(self.skill_metadata, json_file)
@@ -95,7 +109,12 @@ class TestSettingsMetaUploader(MycroftUnitTestBase):
         self._check_api_call()
         self._check_timer_not_called()
 
-    def test_yaml_settingsmeta(self):
+    @patch('mycroft.skills.settings.DeviceApi')
+    def test_yaml_settingsmeta(self, mock_api):
+        api_instance = Mock()
+        api_instance.identity.uuid = '42'
+        mock_api.return_value = api_instance
+
         skill_metadata = (
             'skillMetadata:\n  sections:\n    - name: "Test Section"\n      '
             'fields:\n      - type: "label"\n        label: "Test Field"'


### PR DESCRIPTION
## Description
Fix a bug where the settingsMeta API call was failing on initial boot if the device was paired but the device identity attribute of the API class did not yet know the device's ID

## How to test
Boot an unpaired device. There should be no API calls with a URL of `v1/device//settingsMeta` that fail with a 405 error.

## Contributor license agreement signed?
CLA [yes]