### PR TITLE
Restructure to get skill_gid after startup

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -125,7 +125,7 @@ class MycroftSkill:
         self.name = name or self.__class__.__name__
         self.resting_name = None
         self.skill_id = ''  # will be set from the path, so guaranteed unique
-        self.skill_gid = None  # set when skill is loaded in SkillLoader
+        self.settings_meta = None  # set when skill is loaded in SkillLoader
         # Get directory of skill
         self.root_dir = dirname(abspath(sys.modules[self.__module__].__file__))
         if use_settings:
@@ -261,10 +261,10 @@ class MycroftSkill:
         that had their settings changed.  Only update this skill's settings
         if its remote settings were among those changed
         """
-        if self.skill_gid is None:
+        if self.settings_meta is None or self.settings_meta.skill_gid is None:
             LOG.error('The skill_gid was not set when this skill was loaded!')
         else:
-            remote_settings = message.data.get(self.skill_gid)
+            remote_settings = message.data.get(self.settings_meta.skill_gid)
             if remote_settings is not None:
                 LOG.info('Updating settings for skill ' + self.name)
                 self.settings.update(**remote_settings)

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -184,18 +184,21 @@ class SettingsMetaUploader:
         The device ID is known to this class.  To "finalize" the skill_gid,
         insert the device ID between the "@" and the "|"
         """
-        skills = {
-            skill.path: skill for skill in
-            self.msm.local_skills.values()
-        }
-        skill = skills[str(self.skill_directory)]
-        # If modified prepend the device uuid
-        self._skill_gid = skill.skill_gid.replace(
-            '@|',
-            '@{}|'.format(self.api.identity.uuid)
-        )
+        if self.api and self.api.identity.uuid:
+            skills = {
+                skill.path: skill for skill in
+                self.msm.local_skills.values()
+            }
+            skill = skills[str(self.skill_directory)]
+            # If modified prepend the device uuid
+            self._skill_gid = skill.skill_gid.replace(
+                '@|',
+                '@{}|'.format(self.api.identity.uuid)
+            )
 
-        return self._skill_gid
+            return self._skill_gid
+        else:
+            return None
 
     @property
     def msm_skill_display_name(self):

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -286,4 +286,4 @@ class SkillLoader:
                 self.instance.name
             )
             settings_meta.upload()
-            self.instance.skill_gid = settings_meta.skill_gid
+            self.instance.settings_meta = settings_meta


### PR DESCRIPTION
## Description
This restructures the code slightly allowing skills to get the skill_gid after pairing is complete.

## How to test
Pair a device fresh device and make sure no errors indicating that skill_gid is missing from the skill.

## Contributor license agreement signed?
CLA [ Yes ]
