### PR TITLE
Add a safety harness in skill_manager main loop

### DIFF
--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -143,11 +143,17 @@ class SkillManager(Thread):
         # Scan the file folder that contains Skills.  If a Skill is updated,
         # unload the existing version from memory and reload from the disk.
         while not self._stop_event.is_set():
-            self._reload_modified_skills()
-            self._load_new_skills()
-            self._unload_removed_skills()
-            self._update_skills()
-            sleep(2)  # Pause briefly before beginning next scan
+            try:
+                self._reload_modified_skills()
+                self._load_new_skills()
+                self._unload_removed_skills()
+                self._update_skills()
+                sleep(2)  # Pause briefly before beginning next scan
+            except Exception:
+                LOG.exception('Something really unexpected has occured '
+                              'and the skill manager loop safety harness was '
+                              'hit.')
+                sleep(30)
 
     def _remove_git_locks(self):
         """If git gets killed from an abrupt shutdown it leaves lock files."""


### PR DESCRIPTION
## Description
This captures any unhandled expressions and will at least make sure
they're logged properly. (Exceptions in threads are mostly not printed
to stdout).

This sleeps slightly longer than normal (10 seconds) and then tries to resume
normal operation.

I've had one instance where skills reloading / updating stopped.

## How to test
Make sure the normal loop runs as expected and reloads are handled correctly.

## Contributor license agreement signed?
CLA [ Yes ]
