### PR TITLE
add 'affirmative' to yes vocab

### DIFF
--- a/mycroft/res/text/en-us/yes.voc
+++ b/mycroft/res/text/en-us/yes.voc
@@ -5,3 +5,4 @@ sure
 please
 confirm
 confirmed
+affirmative


### PR DESCRIPTION
## Description
Adds "affirmative" as an accepted yes term for use in `ask_yesno()` and similar situations.

## Contributor license agreement signed?
- [x] CLA
