### PR TITLE
Stop settingmeta upload on skill shutdown

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1151,6 +1151,9 @@ class MycroftSkill:
         if self.settings != self._initial_settings:
             save_settings(self.root_dir, self.settings)
 
+        if self.settings_meta:
+            self.settings_meta.stop()
+
         # Clear skill from gui
         self.gui.clear()
 

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -158,6 +158,7 @@ class SettingsMetaUploader:
         self.settings_meta = {}
         self.api = None
         self.upload_timer = None
+        self._stopped = None
 
         # Property placeholders
         self._msm = None
@@ -248,10 +249,17 @@ class SettingsMetaUploader:
         else:
             LOG.debug('settingsmeta.json not uploaded - device is not paired')
 
-        if not synced:
+        if not synced and not self._stopped:
             self.upload_timer = Timer(ONE_MINUTE, self.upload)
             self.upload_timer.daemon = True
             self.upload_timer.start()
+
+    def stop(self):
+        """ Stop upload attempts if Timer is running."""
+        if self.upload_timer:
+            self.upload_timer.cancel()
+        # Set stopped flag if upload is running when stop is called.
+        self._stopped = True
 
     def _load_settings_meta_file(self):
         """Read the contents of the settingsmeta file into memory."""


### PR DESCRIPTION
## Description
This makes sure to shutdown any Timer handling settingsmetadata upload
on skill shutdown to make sure no duplicates are running.

(Easily occurs when a skill gid doesn't match the one sent in skill
manifest)


## Contributor license agreement signed?
CLA [ Yes ]
