### PR TITLE
Exception logging for AudioProducer

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -88,6 +88,9 @@ class AudioProducer(Thread):
                     # The internet was not helpful.
                     # http://stackoverflow.com/questions/10733903/pyaudio-input-overflowed
                     self.emitter.emit("recognizer_loop:ioerror", e)
+                except Exception as e:
+                    LOG.exception('Exception in AudioProducer')
+                    raise
                 finally:
                     if self.stream_handler is not None:
                         self.stream_handler.stream_stop()
@@ -406,6 +409,9 @@ class RecognizerLoop(EventEmitter):
                 LOG.error(e)
                 self.stop()
                 raise  # Re-raise KeyboardInterrupt
+            except Exception as e:
+                LOG.exception('Exception in RecognizerLoop')
+                raise
 
     def reload(self):
         """

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -82,12 +82,11 @@ class AudioProducer(Thread):
                     else:
                         LOG.warning("Audio contains no data.")
                 except IOError as e:
-                    # NOTE: Audio stack on raspi is slightly different, throws
-                    # IOError every other listen, almost like it can't handle
-                    # buffering audio between listen loops.
-                    # The internet was not helpful.
-                    # http://stackoverflow.com/questions/10733903/pyaudio-input-overflowed
-                    self.emitter.emit("recognizer_loop:ioerror", e)
+                    # IOError will be thrown if the read is unsuccessful.
+                    # If self.recognizer.overflow_exc is False (default)
+                    # input buffer overflow IOErrors due to not consuming the
+                    # buffers quickly enough will be silently ignored.
+                    LOG.exception('IOError Exception in AudioProducer')
                 except Exception as e:
                     LOG.exception('Exception in AudioProducer')
                     raise


### PR DESCRIPTION
## Description
Make sure exceptions are logged for any mic issues. No longer publish `recognizer_loop:ioerror` event. 

## How to test
Leave device on this PR for weeks until mic explodes

## Contributor license agreement signed?
CLA [Yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
