### PR TITLE
gitignore vscode workspace and html coverage data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 dev.env
 .dev_opts.json
 .idea
+*.code-workspace
 *.pyc
 *.swp
 *~
@@ -16,6 +17,7 @@ mycroft/__version__.py
 scripts/logs/*
 logs/*
 .coverage
+/htmlcov
 mycroft/audio-accuracy-test/data/*
 scripts/*.screen
 doc/_build/


### PR DESCRIPTION
## Description
Adds local HTML output from coverage tests to `.gitignore`.

Also adds vscode workspace files. That's just for me, but I'm in here anyway, and surely I won't be the only workspace user in the long run :)

## Contributor license agreement signed?
CLA [yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
