### PR TITLE
Fixes index error in parse_en.extract_datetime()

### DIFF
--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -828,7 +828,7 @@ def extract_datetime_en(string, dateNow, default_time):
               wordNext == "after" and
               wordNextNext == "tomorrow" and
               not fromFlag and
-              not wordPrev[0].isdigit()):
+              not (wordPrev[0].isdigit() if wordPrev else False)):
             dayOffset = 2
             used = 3
             if wordPrev == "the":


### PR DESCRIPTION
==== Fixed Issues ====
#2333

====  Tech Notes ====
extract_datetime("day after tomorrow") attempted to check the previous
word. This resulted in an index error. Fixed by introducing a nested
condition. Seems to have solved it.

A similar bug is present in other parts of this file, such as line 843.

I have also discovered a number of other oddities, but they may be
outside the scope of this issue. At least Mycroft can now extract from
"day after tomorrow."

==== Localization Notes ====
I haven't checked parsers for any other languages.

## Description
Only fixes that specific bug. I can't stress that enough. This function will need a bunch more work.

## How to test
Unit tests pass, or just import `extract_datetime` and `extract_datetime("day after tomorrow")

## Contributor license agreement signed?
CLA [ yes ]
