### PR TITLE
Remove duplicate load of skill settings

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 """Common functionality relating to the implementation of mycroft skills."""
+
+from copy import deepcopy
 import inspect
 import sys
 import re
@@ -129,11 +131,8 @@ class MycroftSkill:
         # Get directory of skill
         self.root_dir = dirname(abspath(sys.modules[self.__module__].__file__))
         if use_settings:
-            self._initial_settings = get_local_settings(
-                self.root_dir,
-                self.name
-            )
             self.settings = Settings(self)
+            self._initial_settings = deepcopy(self.settings.as_dict())
         else:
             self.settings = None
         self.settings_change_callback = None


### PR DESCRIPTION
## Description
Instead of loading skill settings from disk twice, a copy is made into the
_initial_settings member after load.

## How to test
Load a skill and ensure settings are present

## Contributor license agreement signed?
CLA [ Yes ]