### PR TITLE
Fix clearing of once events

### DIFF
--- a/mycroft/skills/mycroft_skill/event_container.py
+++ b/mycroft/skills/mycroft_skill/event_container.py
@@ -138,9 +138,12 @@ class EventContainer:
         if handler:
             if once:
                 self.bus.once(name, once_wrapper)
+                self.events.append((name, once_wrapper))
             else:
                 self.bus.on(name, handler)
-            self.events.append((name, handler))
+                self.events.append((name, handler))
+
+            LOG.debug('Added event: {}'.format(name))
 
     def remove(self, name):
         """Removes an event from bus emitter and events list.

--- a/test/unittests/skills/test_event_container.py
+++ b/test/unittests/skills/test_event_container.py
@@ -32,12 +32,13 @@ class TestEventContainer(unittest.TestCase):
         self.assertTrue(bus.on.called)
 
         # Test add single shot event handler
+        len_before = len(container.events)
         container.add('test2', example_handler, once=True)
+        self.assertEqual(len_before + 1, len(container.events))
         self.assertTrue(bus.once.called)
 
         # Verify correct content in event container
         self.assertTrue(('test1', example_handler) in container.events)
-        self.assertTrue(('test2', example_handler) in container.events)
         self.assertEqual(len(container.events), 2)
 
     def test_remove(self):


### PR DESCRIPTION
## Description
Store correct function for once events

The handler was always stored even when the event was a once event and
thus was wrapped in once_wrapper.

This handles the once correctly.

Should resolve #2337.

## How to test
Create a skill adding a scheduled (non-repeating) event in the initialize and right after add a `raise Exception` line like this:

```python
     def initialize(self):
        self.schedule_event(self.my_event, datetime.now(), name='HANDLER')
        raise Exception
```

## Contributor license agreement signed?
CLA [ Yes ]
