### PR TITLE
add default value to nice_number param

### DIFF
--- a/mycroft/util/lang/format_common.py
+++ b/mycroft/util/lang/format_common.py
@@ -16,7 +16,7 @@
 #
 
 
-def convert_to_mixed_fraction(number, denominators):
+def convert_to_mixed_fraction(number, denominators=range(1, 21)):
     """
     Convert floats to components of a mixed fraction representation
 

--- a/mycroft/util/lang/format_da.py
+++ b/mycroft/util/lang/format_da.py
@@ -98,7 +98,7 @@ FRACTION_STRING_DA = {
 EXTRA_SPACE = ""
 
 
-def nice_number_da(number, speech, denominators):
+def nice_number_da(number, speech, denominators=range(1, 21)):
     """ Danish helper for nice_number
     This function formats a float to human understandable functions. Like
     4.5 becomes "4 einhalb" for speech and "4 1/2" for text

--- a/mycroft/util/lang/format_de.py
+++ b/mycroft/util/lang/format_de.py
@@ -97,7 +97,7 @@ FRACTION_STRING_DE = {
 EXTRA_SPACE = ""
 
 
-def nice_number_de(number, speech, denominators):
+def nice_number_de(number, speech, denominators=range(1, 21)):
     """ German helper for nice_number
     This function formats a float to human understandable functions. Like
     4.5 becomes "4 einhalb" for speech and "4 1/2" for text
@@ -154,7 +154,7 @@ def pronounce_number_de(num, places=2):
             hundreds = floor(num / 100)
             if hundreds > 0:
                 result += NUM_STRING_DE[
-                              hundreds] + EXTRA_SPACE + 'hundert' + EXTRA_SPACE
+                    hundreds] + EXTRA_SPACE + 'hundert' + EXTRA_SPACE
                 num -= hundreds * 100
         if num == 0:
             result += ''  # do nothing

--- a/mycroft/util/lang/format_en.py
+++ b/mycroft/util/lang/format_en.py
@@ -21,7 +21,7 @@ from mycroft.util.lang.common_data_en import _NUM_STRING_EN, \
     _FRACTION_STRING_EN, _LONG_SCALE_EN, _SHORT_SCALE_EN
 
 
-def nice_number_en(number, speech, denominators):
+def nice_number_en(number, speech, denominators=range(1, 21)):
     """ English helper for nice_number
 
     This function formats a float to human understandable functions. Like

--- a/mycroft/util/lang/format_es.py
+++ b/mycroft/util/lang/format_es.py
@@ -74,7 +74,7 @@ FRACTION_STRING_ES = {
 }
 
 
-def nice_number_es(number, speech, denominators):
+def nice_number_es(number, speech, denominators=range(1, 21)):
     """ Spanish helper for nice_number
 
     This function formats a float to human understandable functions. Like

--- a/mycroft/util/lang/format_fr.py
+++ b/mycroft/util/lang/format_fr.py
@@ -71,7 +71,7 @@ FRACTION_STRING_FR = {
 }
 
 
-def nice_number_fr(number, speech, denominators):
+def nice_number_fr(number, speech, denominators=range(1, 21)):
     """ French helper for nice_number
 
     This function formats a float to human understandable functions. Like

--- a/mycroft/util/lang/format_hu.py
+++ b/mycroft/util/lang/format_hu.py
@@ -106,7 +106,7 @@ def _get_vocal_type(word):
     return 0 if vowels_high == 0 else 1            # 0: type is low, 1: is high
 
 
-def nice_number_hu(number, speech, denominators):
+def nice_number_hu(number, speech, denominators=range(1, 21)):
     """ Hungarian helper for nice_number
 
     This function formats a float to human understandable functions. Like

--- a/mycroft/util/lang/format_it.py
+++ b/mycroft/util/lang/format_it.py
@@ -178,7 +178,7 @@ SHORT_SCALE_IT = collections.OrderedDict([
 ])
 
 
-def nice_number_it(number, speech, denominators):
+def nice_number_it(number, speech, denominators=range(1, 21)):
     """ Italian helper for nice_number
 
     This function formats a float to human understandable functions. Like

--- a/mycroft/util/lang/format_nl.py
+++ b/mycroft/util/lang/format_nl.py
@@ -97,7 +97,7 @@ FRACTION_STRING_NL = {
 EXTRA_SPACE = ""
 
 
-def nice_number_nl(number, speech, denominators):
+def nice_number_nl(number, speech, denominators=range(1, 21)):
     """ Dutch helper for nice_number
     This function formats a float to human understandable functions. Like
     4.5 becomes "4 einhalb" for speech and "4 1/2" for text

--- a/mycroft/util/lang/format_pt.py
+++ b/mycroft/util/lang/format_pt.py
@@ -20,7 +20,7 @@ from mycroft.util.lang.common_data_pt import _FRACTION_STRING_PT, \
     _NUM_STRING_PT
 
 
-def nice_number_pt(number, speech, denominators):
+def nice_number_pt(number, speech, denominators=range(1, 21)):
     """ Portuguese helper for nice_number
 
     This function formats a float to human understandable functions. Like

--- a/mycroft/util/lang/format_sv.py
+++ b/mycroft/util/lang/format_sv.py
@@ -90,7 +90,7 @@ FRACTION_STRING_SV = {
 EXTRA_SPACE = " "
 
 
-def nice_number_sv(number, speech, denominators):
+def nice_number_sv(number, speech, denominators=range(1, 21)):
     """ Swedish helper for nice_number
 
     This function formats a float to human understandable functions. Like

--- a/test/unittests/util/test_format_common.py
+++ b/test/unittests/util/test_format_common.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import unittest
+from mycroft.util.lang.format_common import convert_to_mixed_fraction as cmf
+
+
+class TestMixedFraction(unittest.TestCase):
+    def test_convert_to_fraction(self):
+        self.assertEqual(cmf(8), (8, 0, 1))
+        self.assertEqual(cmf(8.00001), (8, 0, 1))
+        self.assertEqual(cmf(8.5), (8, 1, 2))
+        self.assertEqual(cmf(8.587465135), None)
+        self.assertEqual(cmf(8.587465135, range(1, 101)), (8, 47, 80))


### PR DESCRIPTION
Add default value to parameter in `nice_number` & `convert_mixed_fraction`

Add tests for convert_mixed_fraction

## Description
Docstrings for `nice_number()` and `convert_to_mixed_fraction` indicate that their `denominators` parameter should have a default value, but it didn't. `convert_to_mixed_fraction` also lacked tests.

## How to test
Unit test coverage :+1: 

## Contributor license agreement signed?
CLA [ yes ]