### PR TITLE
fix bug, redundancy in parse_en; improve coverage

### DIFF
--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -1119,18 +1119,6 @@ def extract_datetime_en(string, dateNow, default_time):
                         remainder = nextWord
                         used += 1
 
-                    elif wordNext == "in" and wordNextNext == "the" and \
-                            words[idx + 3] == "morning":
-                        remainder = "am"
-                        used += 3
-                    elif wordNext == "in" and wordNextNext == "the" and \
-                            words[idx + 3] == "afternoon":
-                        remainder = "pm"
-                        used += 3
-                    elif wordNext == "in" and wordNextNext == "the" and \
-                            words[idx + 3] == "evening":
-                        remainder = "pm"
-                        used += 3
                     elif wordNext == "in" and wordNextNext == "morning":
                         remainder = "am"
                         used += 2

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -24,6 +24,9 @@ from mycroft.util.parse import fuzzy_match
 from mycroft.util.parse import get_gender
 from mycroft.util.parse import match_one
 from mycroft.util.parse import normalize
+from mycroft.util.lang.parse_en import _ReplaceableNumber, \
+    _extract_whole_number_with_text_en, _tokenize, _Token, \
+    _extract_decimal_with_text_en
 
 
 class TestFuzzyMatch(unittest.TestCase):
@@ -157,12 +160,12 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(extract_duration("7.5 seconds"),
                          (timedelta(seconds=7.5), ""))
         self.assertEqual(extract_duration("eight and a half days thirty"
-                         " nine seconds"),
+                                          " nine seconds"),
                          (timedelta(days=8.5, seconds=39), ""))
         self.assertEqual(extract_duration("Set a timer for 30 minutes"),
                          (timedelta(minutes=30), "set a timer for"))
         self.assertEqual(extract_duration("Four and a half minutes until"
-                         " sunset"),
+                                          " sunset"),
                          (timedelta(minutes=4.5), "until sunset"))
         self.assertEqual(extract_duration("Nineteen minutes past the hour"),
                          (timedelta(minutes=19), "past the hour"))
@@ -175,6 +178,29 @@ class TestNormalize(unittest.TestCase):
                                           " and a half minutes long"),
                          (timedelta(hours=1, minutes=57.5),
                              "the movie is ,  long"))
+        self.assertEqual(extract_duration(""), None)
+
+    def test_datetime_helpers(self):
+        # invoke helper functions directly to test certain conditions which are
+        # difficult to trigger on purpose.
+        replaceable = _ReplaceableNumber(1, ["test_token"])
+        self.assertRaises(AttributeError, setattr(replaceable, "key", None))
+        with self.assertRaises(Exception) as error:
+            setattr(replaceable, "key", type(None))
+            self.assertEqual(error.message, "Immutable!")
+        self.assertEqual(str(replaceable), "(1, ['test_token'])")
+        self.assertEqual(repr(replaceable),
+                         "_ReplaceableNumber(1, ['test_token'])")
+
+        self.assertEqual(_extract_whole_number_with_text_en(_tokenize(
+            "test string"), False, False), (False, []))
+        self.assertEqual(_extract_whole_number_with_text_en(_tokenize(
+            "! half"), False, False), (0.5, [_Token(word='half', index=1)]))
+
+        self.assertEqual(_extract_decimal_with_text_en(_tokenize(
+            "dot boom"), False, False), (None, None))
+        self.assertEqual(_extract_decimal_with_text_en(_tokenize(
+            "0 0 0"), False, False), (None, None))
 
     def test_extractdatetime_en(self):
         def extractWithFormat(text):
@@ -192,6 +218,8 @@ class TestNormalize(unittest.TestCase):
                     "2017-06-27 13:04:00", "is time")
         testExtract("in a second",
                     "2017-06-27 13:04:01", "")
+        testExtract("in a couple of seconds",
+                    "2017-06-27 13:04:02", "")
         testExtract("in a minute",
                     "2017-06-27 13:05:00", "")
         testExtract("in a couple minutes",
@@ -252,9 +280,17 @@ class TestNormalize(unittest.TestCase):
                     "2017-06-27 13:34:00", "set ambush")
         testExtract("Set the ambush for 5 days from today",
                     "2017-07-02 00:00:00", "set ambush")
+        testExtract("Set the ambush for 5 days from Tuesday",
+                    "2017-07-02 00:00:00", "set ambush")
+        testExtract("Set the ambush for 2 days from next Friday at 0500",
+                    "2017-07-09 05:00:00", "set ambush")
+        testExtract("Describe the ambush 2 days after last Friday at 0500",
+                    "2017-06-25 05:00:00", "describe ambush")
         testExtract("What is the day after tomorrow's weather?",
                     "2017-06-29 00:00:00", "what is weather")
         testExtract("day after tomorrow",
+                    "2017-06-29 00:00:00", "")
+        testExtract("the day after tomorrow",
                     "2017-06-29 00:00:00", "")
         testExtract("Remind me at 10:45 pm",
                     "2017-06-27 22:45:00", "remind me")
@@ -298,6 +334,10 @@ class TestNormalize(unittest.TestCase):
                     "2017-06-27 19:00:00", "remind me to call mom")
         testExtract("remind me to call mom at 7 o'clock in the morning",
                     "2017-06-28 07:00:00", "remind me to call mom")
+        testExtract("remind me to call mom at 7:00 in the morning",
+                    "2017-06-28 07:00:00", "remind me to call mom")
+        testExtract("7 in the morning",
+                    "2017-06-28 07:00:00", "")
         testExtract("remind me to call mom Thursday evening at 7 o'clock",
                     "2017-06-29 19:00:00", "remind me to call mom")
         testExtract("remind me to call mom Thursday morning at 7 o'clock",
@@ -384,6 +424,8 @@ class TestNormalize(unittest.TestCase):
                     "2017-06-29 00:00:00", "begin invasion")
         testExtract("Begin the invasion on Thursday at 0500",
                     "2017-06-29 05:00:00", "begin invasion")
+        testExtract("Begin the invasion at 0500 one day after Monday",
+                    "2017-07-04 05:00:00", "begin invasion")
         testExtract("remind me to wake up in 4 years",
                     "2021-06-27 00:00:00", "remind me to wake up")
         testExtract("remind me to wake up in 4 years and 4 days",
@@ -416,6 +458,8 @@ class TestNormalize(unittest.TestCase):
                     "2017-06-28 20:00:00", "set alarm")
         testExtract("set an alarm for wednesday at 3 o'clock in the afternoon",
                     "2017-06-28 15:00:00", "set alarm")
+        testExtract("set an alarm for wednesday at 3:00 in the afternoon",
+                    "2017-06-28 15:00:00", "set alarm")
         testExtract("set an alarm for wednesday at 3 o'clock in the morning",
                     "2017-06-28 03:00:00", "set alarm")
         testExtract("set an alarm for wednesday morning at 7 o'clock",
@@ -424,13 +468,31 @@ class TestNormalize(unittest.TestCase):
                     "2017-06-27 19:00:00", "set alarm")
         testExtract("set an alarm for this evening at 7 o'clock",
                     "2017-06-27 19:00:00", "set alarm")
+        testExtract("set an alarm for 7:00 in the evening",
+                    "2017-06-27 19:00:00", "set alarm")
+        testExtract("set an alarm for 7:00 this evening",
+                    "2017-06-27 19:00:00", "set alarm")
         # TODO: This test is imperfect due to the "at 7:00" still in the
         #       remainder.  But let it pass for now since time is correct
         testExtract("set an alarm for this evening at 7:00",
                     "2017-06-27 19:00:00", "set alarm at 7:00")
+        testExtract("set an alarm for 7:00 this afternoon",
+                    "2017-06-27 19:00:00", "set alarm")
+        testExtract("set an alarm for 7:00 this morning",
+                    "2017-06-27 07:00:00", "set alarm")
+        testExtract("set an alarm for 7:00 at night",
+                    "2017-06-27 19:00:00", "set alarm")
+        testExtract("set an alarm for 4:00 at night",
+                    "2017-06-27 16:00:00", "set alarm")
         testExtract("on the evening of june 5th 2017 remind me to" +
                     " call my mother",
                     "2017-06-05 19:00:00", "remind me to call my mother")
+        testExtract("on the evening of aug 5th 2017 remind me to" +
+                    " call my mother",
+                    "2017-08-05 19:00:00", "remind me to call my mother")
+        testExtract("on the evening of 5 august 2017 remind me to" +
+                    " call my mother",
+                    "2017-08-05 19:00:00", "remind me to call my mother")
         # TODO: This test is imperfect due to the missing "for" in the
         #       remainder.  But let it pass for now since time is correct
         testExtract("update my calendar for a morning meeting with julius" +
@@ -451,6 +513,8 @@ class TestNormalize(unittest.TestCase):
                     "2017-09-27 00:00:00", "remind me to call mom")
         testExtract("remind me to call mom in 2 years and 2 days",
                     "2019-06-29 00:00:00", "remind me to call mom")
+        testExtract("i should have called mom last week",
+                    "2017-06-20 00:00:00", "i should have called mom")
         testExtract("remind me to call mom next week",
                     "2017-07-04 00:00:00", "remind me to call mom")
         testExtract("remind me to call mom at 10am on saturday",
@@ -461,6 +525,14 @@ class TestNormalize(unittest.TestCase):
                     "2017-07-01 10:00:00", "remind me to call mom")
         testExtract("remind me to call mom at 10am next saturday",
                     "2017-07-01 10:00:00", "remind me to call mom")
+        testExtract("i should have called mom last month",
+                    "2017-05-27 00:00:00", "i should have called mom")
+        testExtract("remind me to call mom next month",
+                    "2017-07-27 00:00:00", "remind me to call mom")
+        testExtract("i should have called mom last year",
+                    "2016-06-27 00:00:00", "i should have called mom")
+        testExtract("remind me to call mom next year",
+                    "2018-06-27 00:00:00", "remind me to call mom")
         # Below two tests, ensure that time is picked
         # even if no am/pm is specified
         # in case of weekdays/tonight


### PR DESCRIPTION
- Remove unreachable conditions from parse_en:1122-1133
  - input string passed through clean_string() on line 763
  - articles stripped from input before line 1122
  - removed conditions relied on presence of "the" in input
- Improved test coverage on parse_en.py by approx 65 statements
  - Directly test certain helper functions which are difficult to
invoke indirectly
  - Add tests for certain missed conditions
  - Approx. 20 uncovered statements remain

## Contributor license agreement signed?
CLA [yes] 