### PR TITLE
Fix extractnumber_es, add extract_numbers_es

### DIFF
--- a/mycroft/util/lang/parse_es.py
+++ b/mycroft/util/lang/parse_es.py
@@ -20,7 +20,8 @@
 """
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
-from mycroft.util.lang.parse_common import is_numeric, look_for_fractions
+from mycroft.util.lang.format_es import pronounce_number_es
+from mycroft.util.lang.parse_common import *
 
 # Undefined articles ["un", "una", "unos", "unas"] can not be supressed,
 # in Spanish, "un caballo" means "a horse" or "one horse".
@@ -126,7 +127,12 @@ def isFractional_es(input_str):
     return False
 
 
-def extractnumber_es(text):
+# TODO: short_scale and ordinals don't do anything here.
+# The parameters are present in the function signature for API compatibility
+# reasons.
+#
+# Returns incorrect output on certain fractional phrases like, "cuarto de dos"
+def extractnumber_es(text, short_scale=True, ordinals=False):
     """
     This function prepares the given text for parsing by making
     numbers consistent, getting rid of contractions, etc.
@@ -177,7 +183,7 @@ def extractnumber_es(text):
                 result = 0
             # handle fractions
             if next_word != "avos":
-                result += val
+                result = val
             else:
                 result = float(result) / float(val)
 
@@ -255,6 +261,24 @@ def extractnumber_es(text):
             result = int(integer)
 
     return result
+
+
+def extract_numbers_es(text, short_scale=True, ordinals=False):
+    """
+        Takes in a string and extracts a list of numbers.
+
+    Args:
+        text (str): the string to extract a number from
+        short_scale (bool): Use "short scale" or "long scale" for large
+            numbers -- over a million.  The default is short scale, which
+            is now common in most English speaking countries.
+            See https://en.wikipedia.org/wiki/Names_of_large_numbers
+        ordinals (bool): consider ordinal numbers, e.g. third=3 instead of 1/3
+    Returns:
+        list: list of extracted numbers as floats
+    """
+    return extract_numbers_generic(text, pronounce_number_es, extractnumber_es,
+                                   short_scale=short_scale, ordinals=ordinals)
 
 
 def es_number_parse(words, i):

--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -129,6 +129,8 @@ def extract_numbers(text, short_scale=True, ordinals=False, lang=None):
         return extract_numbers_it(text, short_scale, ordinals)
     elif lang_code == "da":
         return extract_numbers_da(text, short_scale, ordinals)
+    elif lang_code == "es":
+        return extract_numbers_es(text, short_scale, ordinals)
     return []
 
 

--- a/test/unittests/util/test_parse_es.py
+++ b/test/unittests/util/test_parse_es.py
@@ -16,13 +16,14 @@
 #
 import unittest
 
-from mycroft.util.parse import normalize
+from mycroft.util.parse import normalize, extract_numbers, extract_number
 
 
 class TestNormalize(unittest.TestCase):
     """
         Test cases for Spanish parsing
     """
+
     def test_articles_es(self):
         self.assertEqual(normalize("esta es la prueba", lang="es",
                                    remove_articles=True),
@@ -75,6 +76,15 @@ class TestNormalize(unittest.TestCase):
             u"novecientos noventa y nueve mil novecientos noventa y nueve",
             lang="es"),
             "999999")
+
+    def test_extract_number_es(self):
+        self.assertEqual(sorted(extract_numbers(
+            "1 7 cuatro catorce ocho 157", lang='es')), [1, 4, 7, 8, 14, 157])
+        self.assertEqual(sorted(extract_numbers(
+            "1 7 cuatro albuquerque naranja John Doe catorce ocho 157",
+            lang='es')), [1, 4, 7, 8, 14, 157])
+        self.assertEqual(extract_number("seis punto dos", lang='es'), 6.2)
+        self.assertEqual(extract_numbers("un medio", lang='es'), [0.5])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Fix bug causing extractnumber_es to return a sum instead of a list
- Add Spanish parser to extract_numbers and extract_number

==== Fixed Issues ====
Closes #2310

====  Tech Notes ====
Further obscures #2056: short_scale and ordinals parameters added to the
Spanish parsers, but they don't do anything. Present for compat only.
There is a TODO for this.

==== Localization Notes ====
It's all Spanish stuff!

This will require a native Spanish speaker to analyze the relationship
between extractnumber and isFractional, and determine why certain
fractions do not parse correctly. There is a TODO for this.

## How to test
I've added a handful of unit tests.

## Contributor license agreement signed?
CLA [ yes ]
