### PR TITLE
Remove event before running event handler

### DIFF
--- a/mycroft/skills/mycroft_skill/event_container.py
+++ b/mycroft/skills/mycroft_skill/event_container.py
@@ -132,8 +132,8 @@ class EventContainer:
         def once_wrapper(message):
             # Remove registered one-time handler before invoking,
             # allowing them to re-schedule themselves.
-            handler(message)
             self.remove(name)
+            handler(message)
 
         if handler:
             if once:


### PR DESCRIPTION
# Description
Allow events to reschedule themselves.
The reference was removed before the handler is executed to not remove anything added by the handler. This performes a slight restructuring clearing the event reference before the handler is called so any new reference set by the handler remains intact.

## How to test
Create a scheduled event that reschedules itself.

## Contributor license agreement signed?
CLA [ Yes ]
