### PR TITLE
Add missing __delitem__ method

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -431,6 +431,9 @@ class Settings:
     def __contains__(self, key):
         return key in self._settings
 
+    def __delitem__(self, item):
+        del self._settings[item]
+
     def store(self, force=False):
         LOG.warning('DEPRECATED - use mycroft.skills.settings.save_settings()')
         save_settings(self._skill.root_dir, self._settings)

--- a/test/unittests/skills/test_settings.py
+++ b/test/unittests/skills/test_settings.py
@@ -314,3 +314,10 @@ class TestSettings(TestCase):
             self.skill_mock.settings_change_callback,
             test_callback
         )
+
+    def test_del_settings_key(self):
+        settings = Settings(self.skill_mock)
+        settings['flowerpot'] = 42
+        settings['whale'] = 43
+        del settings['whale']
+        self.assertDictEqual(settings._settings, {'flowerpot': 42})


### PR DESCRIPTION
## Description
The `__delitem__` method is apparently used, for example by the alarm skill. This will allow the alarm to actually be stopped.

## How to test
Set an alarm and view the CLI, repeatedly screaming stop at the device should stop the deluge of errors and allow interactions again. The mute of output during listening will probably make the alarm be inaudible still...

## Contributor license agreement signed?
CLA [ Yes ]
