### PR TITLE
fix bug in isFractional_es and improve coverage

### DIFF
--- a/mycroft/util/lang/parse_es.py
+++ b/mycroft/util/lang/parse_es.py
@@ -107,15 +107,14 @@ def isFractional_es(input_str):
     if input_str.endswith('s', -1):
         input_str = input_str[:len(input_str) - 1]  # e.g. "fifths"
 
-    aFrac = ["medio", "media", "tercio", "cuarto", "cuarta", "quinto",
-             "quinta", "sexto", "sexta", u"séptimo", u"séptima", "octavo",
-             "octava", "noveno", "novena", u"décimo", u"décima", u"onceavo",
-             u"onceava", u"doceavo", u"doceava"]
+    aFrac = {"medio": 2, "media": 2, "tercio": 3, "cuarto": 4,
+             "cuarta": 4, "quinto": 5, "quinta": 5, "sexto": 6, "sexta": 6,
+             u"séptimo": 7, u"séptima": 7, "octavo": 8, "octava": 8,
+             "noveno": 9, "novena": 9, u"décimo": 10, u"décima": 10,
+             u"onceavo": 11, u"onceava": 11, u"doceavo": 12, u"doceava": 12}
 
     if input_str.lower() in aFrac:
-        return 1.0 / (aFrac.index(input_str) + 2)
-    if (input_str == "cuarto" or input_str == "cuarta"):
-        return 1.0 / 4
+        return 1.0 / aFrac[input_str]
     if (input_str == u"vigésimo" or input_str == u"vigésima"):
         return 1.0 / 20
     if (input_str == u"trigésimo" or input_str == u"trigésima"):
@@ -281,6 +280,7 @@ def extract_numbers_es(text, short_scale=True, ordinals=False):
                                    short_scale=short_scale, ordinals=ordinals)
 
 
+# TODO Not parsing 'cero'
 def es_number_parse(words, i):
     def es_cte(i, s):
         if i < len(words) and s == words[i]:
@@ -384,6 +384,7 @@ def normalize_es(text, remove_articles):
     return normalized[1:]  # strip the initial space
 
 
+# TODO MycroftAI/mycroft-core#2348
 def extract_datetime_es(input_str, currentDate=None, default_time=None):
     def clean_string(s):
         # cleans the input string of unneeded punctuation and capitalization
@@ -408,12 +409,12 @@ def extract_datetime_es(input_str, currentDate=None, default_time=None):
             " ").replace(
             "_",
             "")
-        # handle synonims and equivalents, "tomorrow early = tomorrow morning
-        synonims = {u"mañana": ["amanecer", "temprano", "muy temprano"],
+        # handle synonyms and equivalents, "tomorrow early = tomorrow morning
+        synonyms = {u"mañana": ["amanecer", "temprano", "muy temprano"],
                     "tarde": ["media tarde", "atardecer"],
                     "noche": ["anochecer", "tarde"]}
-        for syn in synonims:
-            for word in synonims[syn]:
+        for syn in synonyms:
+            for word in synonyms[syn]:
                 s = s.replace(" " + word + " ", " " + syn + " ")
         # relevant plurals, cant just extract all s in pt
         wordlist = [u"mañanas", "tardes", "noches", u"días", "semanas",

--- a/test/unittests/util/test_parse_es.py
+++ b/test/unittests/util/test_parse_es.py
@@ -15,11 +15,13 @@
 # limitations under the License.
 #
 import unittest
+from datetime import datetime
 
-from mycroft.util.parse import normalize, extract_numbers, extract_number
+from mycroft.util.parse import normalize, extract_numbers, extract_number, \
+    extract_datetime, extract_datetime_es, isFractional_es
 
 
-class TestNormalize(unittest.TestCase):
+class TestNormalize_es(unittest.TestCase):
     """
         Test cases for Spanish parsing
     """
@@ -85,6 +87,134 @@ class TestNormalize(unittest.TestCase):
             lang='es')), [1, 4, 7, 8, 14, 157])
         self.assertEqual(extract_number("seis punto dos", lang='es'), 6.2)
         self.assertEqual(extract_numbers("un medio", lang='es'), [0.5])
+        self.assertEqual(extract_number("cuarto", lang='es'), 0.25)
+
+        self.assertEqual(extract_number("2.0", lang='es'), 2.0)
+        self.assertEqual(extract_number("1/4", lang='es'), 0.25)
+
+        self.assertEqual(extract_number("dos e media", lang='es'), 2.5)
+        self.assertEqual(extract_number(
+            "catorce e milésima", lang='es'), 14.001)
+
+        self.assertEqual(extract_number("dos punto cero dos", lang='es'), 2.02)
+
+    def test_isFraction_es(self):
+        self.assertEqual(isFractional_es("vigésimo"), 1.0 / 20)
+        self.assertEqual(isFractional_es("trigésimo"), 1.0 / 30)
+        self.assertEqual(isFractional_es("centésima"), 1.0 / 100)
+        self.assertEqual(isFractional_es("milésima"), 1.0 / 1000)
+
+
+class TestDatetime_es(unittest.TestCase):
+
+    def test_datetime_by_date_es(self):
+        # test currentDate==None
+        _now = datetime.now()
+        relative_year = _now.year if _now.day == 1 else (_now.year + 1)
+        self.assertEqual(extract_datetime_es("11 ene")[0],
+                         datetime(relative_year, 1, 11))
+
+        # test months
+
+        self.assertEqual(extract_datetime(
+            "11 ene", lang='es', anchorDate=datetime(1998, 1, 1))[0],
+            datetime(1998, 1, 11))
+        self.assertEqual(extract_datetime(
+            "11 feb", lang='es', anchorDate=datetime(1998, 2, 1))[0],
+            datetime(1998, 2, 11))
+        self.assertEqual(extract_datetime(
+            "11 mar", lang='es', anchorDate=datetime(1998, 3, 1))[0],
+            datetime(1998, 3, 11))
+        self.assertEqual(extract_datetime(
+            "11 abr", lang='es', anchorDate=datetime(1998, 4, 1))[0],
+            datetime(1998, 4, 11))
+        self.assertEqual(extract_datetime(
+            "11 may", lang='es', anchorDate=datetime(1998, 5, 1))[0],
+            datetime(1998, 5, 11))
+        # there is an issue with the months of june through september (below)
+        # hay un problema con las meses junio hasta septiembre (lea abajo)
+        self.assertEqual(extract_datetime(
+            "11 oct", lang='es', anchorDate=datetime(1998, 10, 1))[0],
+            datetime(1998, 10, 11))
+        self.assertEqual(extract_datetime(
+            "11 nov", lang='es', anchorDate=datetime(1998, 11, 1))[0],
+            datetime(1998, 11, 11))
+        self.assertEqual(extract_datetime(
+            "11 dic", lang='es', anchorDate=datetime(1998, 12, 1))[0],
+            datetime(1998, 12, 11))
+
+        self.assertEqual(extract_datetime("", lang='es'), None)
+
+    # TODO fix bug causing these tests to fail (MycroftAI/mycroft-core#2348)
+    #         reparar error de traducción preveniendo las funciones abajo de
+    #         retornar correctamente
+    #         (escribido con disculpas por un Inglés hablante)
+    #      further broken tests are below their respective working tests.
+    @unittest.skip("currently processing these months incorrectly")
+    def test_bugged_output_wastebasket(self):
+        self.assertEqual(extract_datetime(
+            "11 jun", lang='es', anchorDate=datetime(1998, 6, 1))[0],
+            datetime(1998, 6, 11))
+        self.assertEqual(extract_datetime(
+            "11 junio", lang='es', anchorDate=datetime(1998, 6, 1))[0],
+            datetime(1998, 6, 11))
+        self.assertEqual(extract_datetime(
+            "11 jul", lang='es', anchorDate=datetime(1998, 7, 1))[0],
+            datetime(1998, 7, 11))
+        self.assertEqual(extract_datetime(
+            "11 ago", lang='es', anchorDate=datetime(1998, 8, 1))[0],
+            datetime(1998, 8, 11))
+        self.assertEqual(extract_datetime(
+            "11 sep", lang='es', anchorDate=datetime(1998, 9, 1))[0],
+            datetime(1998, 9, 11))
+
+        # It's also failing on years
+        self.assertEqual(extract_datetime(
+            "11 ago 1998", lang='es')[0], datetime(1998, 8, 11))
+
+    def test_extract_datetime_relative(self):
+        self.assertEqual(extract_datetime("esta noche", anchorDate=datetime(
+            1998, 1, 1), lang='es'),
+            [datetime(1998, 1, 1, 21, 0, 0), 'esta'])
+        self.assertEqual(extract_datetime(
+            "ayer noche", anchorDate=datetime(1998, 1, 1),
+            lang='es')[0], datetime(1997, 12, 31, 21))
+        self.assertEqual(extract_datetime(
+            "el noche anteayer", anchorDate=datetime(1998, 1, 1),
+            lang='es')[0], datetime(1997, 12, 30, 21))
+        self.assertEqual(extract_datetime(
+            "el noche ante ante ayer", anchorDate=datetime(1998, 1, 1),
+            lang='es')[0], datetime(1997, 12, 29, 21))
+        self.assertEqual(extract_datetime(
+            "mañana en la mañana", anchorDate=datetime(1998, 1, 1),
+            lang='es')[0], datetime(1998, 1, 2, 8))
+        self.assertEqual(extract_datetime(
+            "ayer en la tarde", anchorDate=datetime(1998, 1, 1),
+            lang='es')[0], datetime(1997, 12, 31, 15))
+
+        self.assertEqual(extract_datetime(
+            "que año es", anchorDate=datetime(1998, 1, 1),
+            lang='es')[0], datetime(1998, 1, 1))
+
+        self.assertEqual(extract_datetime("hoy 2 a.m.", lang='es',
+                                          anchorDate=datetime(1998, 1, 1))[0],
+                         datetime(1998, 1, 1, 2))
+        self.assertEqual(extract_datetime("hoy 2 am", lang='es',
+                                          anchorDate=datetime(1998, 1, 1))[0],
+                         datetime(1998, 1, 1, 2))
+        self.assertEqual(extract_datetime("hoy 2 p.m.", lang='es',
+                                          anchorDate=datetime(1998, 1, 1))[0],
+                         datetime(1998, 1, 1, 14))
+        self.assertEqual(extract_datetime("hoy 2 pm", lang='es',
+                                          anchorDate=datetime(1998, 1, 1))[0],
+                         datetime(1998, 1, 1, 14))
+
+    @unittest.skip("These phrases are not parsing correctly.")
+    # parses as "morning" and returns 8:00 on anchorDate
+    def test_extract_datetime_relative_failing(self):
+        self.assertEqual(extract_datetime(
+            "mañana", anchorDate=datetime(1998, 1, 1), lang='es')[0],
+            datetime(1998, 1, 2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Fix: isFractional_es() parsed fractions incorrectly
- Update: earlier commit msg suggested another fix:
  - Month parsing **not** fixed
  - Several failing tests (skipped) document problem
  - A TODO and an issue also created
- Substantially improve parse_es.py test coverage
- TODO or comment several found bugs
  - Many lines remain uncovered, incl possible bugs

## Description
parse_es.isFractional_es() was pulling the wrong indices
from an array, due to old logic expecting array indices to
correspond to the Spanish words for fractions. The array
has been replaced with a dictionary, and the call to the
array reflects this.

## How to test
See Coveralls.

## Contributor license agreement signed?
CLA [ yes ]
