### PR TITLE
make os_is_like handle multiple values

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -260,7 +260,7 @@ function os_is() {
 }
 
 function os_is_like() {
-    [[ $(grep "^ID_LIKE=" /etc/os-release | awk -F'=' '/^ID_LIKE/ {print $2}' | sed 's/\"//g') == $1 ]]
+    grep "^ID_LIKE=" /etc/os-release | awk -F'=' '/^ID_LIKE/ {print $2}' | sed 's/\"//g' | grep -P -q '(^|\s)'"$1"'(\s|$)'
 }
 
 function redhat_common_install() {


### PR DESCRIPTION
## Description
With this PR os_is_like is able to handle value like "debian ubuntu"
Fixes #2357 

## How to test
Execute dev_setup.sh with multiple values in your ID_LIKE in `/etc/os-release`.

## Contributor license agreement signed?
CLA [x]
