### PR TITLE
Make skill's logging visible in tester

### DIFF
--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -45,6 +45,7 @@ from mycroft.skills.core import MycroftSkill, FallbackSkill
 from mycroft.skills.settings import Settings
 from mycroft.skills.skill_loader import SkillLoader
 from mycroft.configuration import Configuration
+from mycroft.util.log import LOG
 
 from logging import StreamHandler
 from io import StringIO
@@ -143,6 +144,11 @@ def load_skills(emitter, skills_root):
             skill_loader.skill_id = skill_id
             skill_loader.load()
             skill_list.append(skill_loader.instance)
+
+        # Restore skill logger since it was created with the temporary handler
+        if skill_loader.instance:
+            skill_loader.instance.log = LOG.create_logger(
+                skill_loader.instance.name)
         log[path] = buf.getvalue()
 
     return skill_list, log


### PR DESCRIPTION
## Description
The skill logger was still set to the temporary logger, this resets it
to the intented logger name and handler

## How to test
The skill tester is running off of the branch. Check the output of the mycroft-skills skill tester that log info from the skill is shown.

## Contributor license agreement signed?
CLA [ Yes ]
