### PR TITLE
Bug/audio end missing arg

### DIFF
--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -211,7 +211,7 @@ class TTS(metaclass=ABCMeta):
         # Create signals informing start of speech
         self.bus.emit(Message("recognizer_loop:audio_output_start"))
 
-    def end_audio(self, listen):
+    def end_audio(self, listen=False):
         """Helper function for child classes to call in execute().
 
         Sends the recognizer_loop:audio_output_end message (indicating

--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -118,7 +118,7 @@ class PlaybackThread(Thread):
                 send_playback_metric(stopwatch, ident)
 
                 if self.queue.empty():
-                    self.tts.end_audio()
+                    self.tts.end_audio(listen)
                     self._processing_queue = False
                 self.blink(0.2)
             except Empty:


### PR DESCRIPTION
## Description
While re-pairing my VM Mycroft I noticed exceptions that the `listen` argument was missing from the call to `end_audio()`. This just adds that missing argument and defaults `listen=False` so that other implementations that call it without argument will continue to work as expected. 

## How to test
Tail the audio.log when pairing and look for errors after speaking pairing code. 

## Contributor license agreement signed?
CLA [Yes] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
