### PR TITLE
BUGFIX parsing of "this quarter of an hour"

### DIFF
--- a/mycroft/util/lang/parse_en.py
+++ b/mycroft/util/lang/parse_en.py
@@ -1043,8 +1043,6 @@ def extract_datetime_en(string, dateNow, default_time):
                 minOffset = 15
                 if idx > 2 and words[idx - 3] in markers:
                     words[idx - 3] = ""
-                    if words[idx - 3] == "this":
-                        daySpecified = True
                 words[idx - 2] = ""
             elif wordPrev == "within":
                 hrOffset = 1


### PR DESCRIPTION
The test for "this" was occurring after the word had been wiped from the array.  It's a weird
and somewhat awkward edge case, but it could have resulted in the parse returning the date
of the following day rather than the current day.
