### PR TITLE
Send listen flag for special picroft case as well

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -90,7 +90,7 @@ def handle_speak(event):
                 except Exception:
                     LOG.error('Error in mute_and_speak', exc_info=True)
         else:
-            mute_and_speak(utterance, ident)
+            mute_and_speak(utterance, ident, listen)
 
         stopwatch.stop()
     report_timing(ident, 'speech', stopwatch, {'utterance': utterance,


### PR DESCRIPTION
## Description
Send listen flag for special picroft case as well

## How to test
Ensure that picroft starts listening automatically after a `get_response()` / speak() with `expect_response=True`

## Contributor license agreement signed?
CLA [ Yes ]
