### PR TITLE
Added "found_wakeword" event to message bus

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -185,12 +185,6 @@ class AudioConsumer(Thread):
 
     # TODO: Localization
     def process(self, audio):
-        SessionManager.touch()
-        payload = {
-            'utterance': self.wakeword_recognizer.key_phrase,
-            'session': SessionManager.get().session_id,
-        }
-        self.emitter.emit("recognizer_loop:wakeword", payload)
 
         if self._audio_length(audio) >= self.MIN_AUDIO_SIZE:
             stopwatch = Stopwatch()


### PR DESCRIPTION
## Description
Added an event to the message bus that will be sent when the wakeword
is found and before the notification sound is played

## How to test
Connect to the message bus and output all of the messages. Say the wakeword. You should see the "found_wakeword" message, 

## Contributor license agreement signed?
Yes
