### PR TITLE
Feature/restart mic

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -86,6 +86,8 @@ class AudioProducer(Thread):
                     # input buffer overflow IOErrors due to not consuming the
                     # buffers quickly enough will be silently ignored.
                     LOG.exception('IOError Exception in AudioProducer')
+                    LOG.info('Restarting the microphone...')
+                    source.restart()
                 except Exception:
                     LOG.exception('Exception in AudioProducer')
                     raise


### PR DESCRIPTION
## Description
- Restarts the mic in case of an error accessing the input stream.
- Ignores the overflow as indicated by the previous comment
- A simple restart attempt counter is used to limit the number of retries. Currently set to 20. Counter is reset on successful wakeword fetch. (Not optimal, but works for the most common situations)

## How to test
Stop the stream and trigger the read, cherry-pick the head of test/mic-restart onto the branch and send the `kaboooom` message to trigger the exception.

## Contributor license agreement signed?
CLA [ Yes ]
