### PR TITLE
Stabilize skill settings download

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -174,6 +174,12 @@ class SettingsMetaUploader:
 
         return self._msm
 
+    def get_local_skills(self):
+        return {
+            skill.path: skill for skill in
+            self.msm.local_skills.values()
+        }
+
     @property
     def skill_gid(self):
         """Skill identifier recognized by backend and core.
@@ -186,16 +192,18 @@ class SettingsMetaUploader:
         The device ID is known to this class.  To "finalize" the skill_gid,
         insert the device ID between the "@" and the "|"
         """
-        if self.api and self.api.identity.uuid:
-            skills = {
-                skill.path: skill for skill in
-                self.msm.local_skills.values()
-            }
-            skill = skills[str(self.skill_directory)]
+        api = self.api or DeviceApi()
+        if api.identity.uuid:
+            skills = self.get_local_skills()
+            skill_dir = str(self.skill_directory)
+            if skill_dir not in skills:
+                self.msm.clear_cache()
+                skills = self.get_local_skills()
+            skill = skills[skill_dir]
             # If modified prepend the device uuid
             self._skill_gid = skill.skill_gid.replace(
                 '@|',
-                '@{}|'.format(self.api.identity.uuid)
+                '@{}|'.format(api.identity.uuid)
             )
 
             return self._skill_gid

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -59,7 +59,8 @@ import json
 import os
 import re
 from pathlib import Path
-from threading import Timer
+from queue import Queue, Empty
+from threading import Thread, Timer, Event
 
 from mycroft.api import DeviceApi, is_paired
 from mycroft.configuration import Configuration
@@ -137,6 +138,48 @@ def _extract_settings_from_meta(settings_meta: dict) -> dict:
                 fields[field['name']] = field['value']
 
     return fields
+
+
+class SettingsMetaQueue(Thread):
+    """Queue for sending settings metadata to backend.
+
+    This queue can be used during startup to capture all settingsmeta requests
+    and then processing can be triggered at a later stage.
+
+    After all queued settingsmeta has been processed and the queue is empty
+    the queue will set the self.processed event allowing waiting for
+    processing.
+    """
+    def __init__(self):
+        super().__init__()
+        self._queue = Queue()
+        self.daemon = True
+        self.stopped = False
+        self.processed = Event()
+
+    def run(self):
+        timeout = 5
+        while not self.stopped:
+            try:
+                uploader = self._queue.get(timeout=timeout)
+                if uploader is None:
+                    break
+                else:
+                    uploader.upload()
+            except Empty:
+                # When the queue is empty indicate that everything
+                # sent to it before starting has been processed.
+                timeout = None
+                self.processed.set()
+
+    def stop(self):
+        """Stop the queue processer."""
+        self.stopped = True
+        self._queue.put(None)  # Insert dummy value to trigger a loop.
+
+    def put(self, value):
+        """Append a value to the queue."""
+        self._queue.put(value)
 
 
 class SettingsMetaUploader:

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -57,7 +57,7 @@ def _get_last_modified_time(path):
 
 
 class SkillLoader:
-    def __init__(self, bus, skill_directory):
+    def __init__(self, bus, skill_directory, upload_queue=None):
         self.bus = bus
         self.skill_directory = skill_directory
         self.skill_id = os.path.basename(skill_directory)
@@ -68,6 +68,7 @@ class SkillLoader:
         self.instance = None
         self.active = True
         self.config = Configuration.get()
+        self.upload_queue = upload_queue
 
     @property
     def is_blacklisted(self):
@@ -282,5 +283,6 @@ class SkillLoader:
                 self.skill_directory,
                 self.instance.name
             )
-            settings_meta.upload()
+            if self.upload_queue:
+                self.upload_queue.put(settings_meta)
             self.instance.settings_meta = settings_meta

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -22,6 +22,7 @@ from time import time
 from mycroft.configuration import Configuration
 from mycroft.messagebus import Message
 from mycroft.util.log import LOG
+
 from .settings import SettingsMetaUploader
 
 SKILL_MAIN_MODULE = '__init__.py'
@@ -57,7 +58,7 @@ def _get_last_modified_time(path):
 
 
 class SkillLoader:
-    def __init__(self, bus, skill_directory, upload_queue=None):
+    def __init__(self, bus, skill_directory):
         self.bus = bus
         self.skill_directory = skill_directory
         self.skill_id = os.path.basename(skill_directory)
@@ -68,7 +69,6 @@ class SkillLoader:
         self.instance = None
         self.active = True
         self.config = Configuration.get()
-        self.upload_queue = upload_queue
 
     @property
     def is_blacklisted(self):
@@ -107,11 +107,11 @@ class SkillLoader:
         LOG.info('ATTEMPTING TO RELOAD SKILL: ' + self.skill_id)
         if self.instance:
             self._unload()
-        self._load()
+        return self._load()
 
     def load(self):
         LOG.info('ATTEMPTING TO LOAD SKILL: ' + self.skill_id)
-        self._load()
+        return self._load()
 
     def _unload(self):
         """Remove listeners and stop threads before loading"""
@@ -175,7 +175,14 @@ class SkillLoader:
 
         self.last_loaded = time()
         self._communicate_load_status()
-        self._upload_settings_meta()
+        if self.loaded:
+            self._prepare_settings_meta()
+        return self.loaded
+
+    def _prepare_settings_meta(self):
+        settings_meta = SettingsMetaUploader(self.skill_directory,
+                                             self.instance.name)
+        self.instance.settings_meta = settings_meta
 
     def _prepare_for_load(self):
         self.load_attempted = True
@@ -276,13 +283,3 @@ class SkillLoader:
             )
             self.bus.emit(message)
             LOG.error('Skill {} failed to load'.format(self.skill_id))
-
-    def _upload_settings_meta(self):
-        if self.loaded:
-            settings_meta = SettingsMetaUploader(
-                self.skill_directory,
-                self.instance.name
-            )
-            if self.upload_queue:
-                self.upload_queue.put(settings_meta)
-            self.instance.settings_meta = settings_meta

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -293,6 +293,11 @@ class SkillManager(Thread):
                 LOG.exception('Failed to shutdown skill ' + skill.id)
             del self.skill_loaders[skill_dir]
 
+        # If skills were removed make sure to update the manifest on the
+        # mycroft backend.
+        if removed_skills:
+            self.skill_updater.post_manifest(reload_skills_manifest=True)
+
     def _update_skills(self):
         """Update skills once an hour if update is enabled"""
         do_skill_update = (

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -192,9 +192,7 @@ class SkillUpdater:
         upload_allowed = self.config['skills'].get('upload_skill_manifest')
         if upload_allowed and is_paired():
             if reload_skills_manifest:
-                # TODO: Handle inside msm
-                self.msm._device_skill_state = None
-
+                self.msm.clear_cache()
             try:
                 device_api = DeviceApi()
                 device_api.upload_skills_data(self.msm.device_skill_state)

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ google-api-python-client==1.6.4
 fasteners==0.14.1
 PyYAML==5.1.2
 
-msm==0.8.3
+msm==0.8.4
 msk==0.3.14
 adapt-parser==0.3.4
 padatious==0.4.6


### PR DESCRIPTION
## Description
This adds a queue system to capture the upload of settingsmeta while not paired and start the settings download so it doesn't start before pairing has been checked. A side effect is that skills load much faster into an usable state (though skill + latest settings downloaded from backend) are approximately the same time.

This handles the unpaired case better than the previous linear + start threads if pairing is missing.
It also handles the case where a skill is added through the command line msm application by making sure the skill manifest is updated and the skill cache is cleared.

Additionally removed skills will trigger an update of the home skills list directly.

We should give this a proper shakedown and test it thoroughly. I will complete the PR with a couple of test cases but it can definitely use an ocular review and some additional random testing in the meantime.

## How to test
Start up skills process, make sure it finishes, settingsmeta is uploaded and then downloaded without any errors that "skill_gid is not set" errors.

Install a skill from using the commandline and ensure that no errors occurs.

## Contributor license agreement signed?
CLA [ Yes ]
