### PR TITLE
Speed up the send command

### DIFF
--- a/mycroft/messagebus/__init__.py
+++ b/mycroft/messagebus/__init__.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 from .client.client import MessageBusClient
 from .message import Message
-from .send import send
+from .send_func import send
 from .service.event_handler import MessageBusEventHandler

--- a/mycroft/messagebus/send.py
+++ b/mycroft/messagebus/send.py
@@ -17,7 +17,9 @@ import json
 
 from websocket import create_connection
 
-from mycroft.configuration import ConfigurationManager
+from mycroft.configuration import Configuration
+from mycroft.configuration.locations import (DEFAULT_CONFIG, SYSTEM_CONFIG,
+                                             USER_CONFIG)
 from mycroft.messagebus.client import MessageBusClient
 from mycroft.messagebus.message import Message
 
@@ -66,7 +68,11 @@ def send(message_to_send, data_to_send=None):
     data_to_send = data_to_send or {}
 
     # Calculate the standard Mycroft messagebus websocket address
-    config = ConfigurationManager.get().get("websocket")
+    config = Configuration.get([DEFAULT_CONFIG,
+                                SYSTEM_CONFIG,
+                                USER_CONFIG],
+                               cache=False)
+    config = config.get("websocket")
     url = MessageBusClient.build_url(
         config.get("host"),
         config.get("port"),

--- a/mycroft/messagebus/send.py
+++ b/mycroft/messagebus/send.py
@@ -15,13 +15,7 @@
 import sys
 import json
 
-from websocket import create_connection
-
-from mycroft.configuration import Configuration
-from mycroft.configuration.locations import (DEFAULT_CONFIG, SYSTEM_CONFIG,
-                                             USER_CONFIG)
-from mycroft.messagebus.client import MessageBusClient
-from mycroft.messagebus.message import Message
+from .send_func import send
 
 
 def main():
@@ -55,36 +49,6 @@ def main():
         exit()
 
     send(message_to_send, data_to_send)
-
-
-def send(message_to_send, data_to_send=None):
-    """Send a single message over the websocket.
-
-    Args:
-        message_to_send (str): Message to send
-        data_to_send (dict): data structure to go along with the
-            message, defaults to empty dict.
-    """
-    data_to_send = data_to_send or {}
-
-    # Calculate the standard Mycroft messagebus websocket address
-    config = Configuration.get([DEFAULT_CONFIG,
-                                SYSTEM_CONFIG,
-                                USER_CONFIG],
-                               cache=False)
-    config = config.get("websocket")
-    url = MessageBusClient.build_url(
-        config.get("host"),
-        config.get("port"),
-        config.get("route"),
-        config.get("ssl")
-    )
-
-    # Send the provided message/data
-    ws = create_connection(url)
-    packet = Message(message_to_send, data_to_send).serialize()
-    ws.send(packet)
-    ws.close()
 
 
 if __name__ == '__main__':

--- a/mycroft/messagebus/send_func.py
+++ b/mycroft/messagebus/send_func.py
@@ -1,0 +1,51 @@
+# Copyright 2019 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from websocket import create_connection
+
+from mycroft.configuration import Configuration
+from mycroft.configuration.locations import (DEFAULT_CONFIG, SYSTEM_CONFIG,
+                                             USER_CONFIG)
+from mycroft.messagebus.client import MessageBusClient
+from mycroft.messagebus.message import Message
+
+
+def send(message_to_send, data_to_send=None):
+    """Send a single message over the websocket.
+
+    Args:
+        message_to_send (str): Message to send
+        data_to_send (dict): data structure to go along with the
+            message, defaults to empty dict.
+    """
+    data_to_send = data_to_send or {}
+
+    # Calculate the standard Mycroft messagebus websocket address
+    config = Configuration.get([DEFAULT_CONFIG,
+                                SYSTEM_CONFIG,
+                                USER_CONFIG],
+                               cache=False)
+    config = config.get("websocket")
+    url = MessageBusClient.build_url(
+        config.get("host"),
+        config.get("port"),
+        config.get("route"),
+        config.get("ssl")
+    )
+
+    # Send the provided message/data
+    ws = create_connection(url)
+    packet = Message(message_to_send, data_to_send).serialize()
+    ws.send(packet)
+    ws.close()


### PR DESCRIPTION
## Description
The `mycroft.messagebus.send` utility is used to send simple messages to the messagebus, but running is unnecessarily slow and affects the commandline tools `mycroft-speak` and `mycroft-say-to`.

This PR removes the fetch of configuration from the backend since the backend should never provide any information on the messagebus setup.

Timing from dev:
```
 $ time python -m mycroft.messagebus.send "speak" "{\"utterance\": \"hello\"}"

real    0m2,700s
user    0m1,000s
sys     0m0,266s
```

Timing from PR branch:
```
 $ time python -m mycroft.messagebus.send "speak" "{\"utterance\": \"hello\"}"

real    0m0,977s
user    0m0,871s
sys     0m0,299s
```

I also added a bit of restructuring removing the annoying warning

```
/usr/lib/python3.6/runpy.py:125: RuntimeWarning: 'mycroft.messagebus.send' found in sys.modules after import of package 'mycroft.messagebus', but prior to execution of 'mycroft.messagebus.send'; this may result in unpredictable behaviour
  warn(RuntimeWarning(msg))
```

I couldn't come up with a better name than `_send.py` but I'll happily accept suggestions.

## How to test
Check out run a send command and verify that things still work as intended.

## Contributor license agreement signed?
CLA [ Yes ]
