### PR TITLE
Speech client error handling

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -402,7 +402,18 @@ class RecognizerLoop(EventEmitter):
         self.state.sleeping = False
 
     def run(self):
-        self.start_async()
+        """Start and reload mic and STT handling threads as needed.
+
+        Wait for KeyboardInterrupt and shutdown cleanly.
+        """
+        try:
+            self.start_async()
+        except Exception:
+            LOG.exception('Starting producer/consumer threads for listener '
+                          'failed.')
+            return
+
+        # Handle reload of consumer / producer if config changes
         while self.state.running:
             try:
                 time.sleep(1)

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -497,7 +497,17 @@ class STTFactory:
 
     @staticmethod
     def create():
-        config = Configuration.get().get("stt", {})
-        module = config.get("module", "mycroft")
-        clazz = STTFactory.CLASSES.get(module)
-        return clazz()
+        try:
+            config = Configuration.get().get("stt", {})
+            module = config.get("module", "mycroft")
+            clazz = STTFactory.CLASSES.get(module)
+            return clazz()
+        except Exception as e:
+            # The STT backend failed to start. Report it and fall back to
+            # default.
+            LOG.exception('The selected STT backend could not be loaded, '
+                          'falling back to default...')
+            if module != 'mycroft':
+                return MycroftSTT()
+            else:
+                raise


### PR DESCRIPTION
## Description
Add extra error handling to speech client

- Catch and log errors starting up the mic / STT threads
- Catch errors creating the STT backend interface
- Catch invalid responses from the server when getting the account id.

## How to test
Make sure the speech client is still usable. Inject an exception in a STT backend interface's `__init__()` and make sure it falls back to MycroftSTT

## Contributor license agreement signed?
CLA [ Yes ]
