### PR TITLE
Fallback to Mimic if launch of TTS fails

### DIFF
--- a/mycroft/tts/__init__.py
+++ b/mycroft/tts/__init__.py
@@ -504,7 +504,19 @@ class TTSFactory:
         tts_module = config.get('tts', {}).get('module', 'mimic')
         tts_config = config.get('tts', {}).get(tts_module, {})
         tts_lang = tts_config.get('lang', lang)
-        clazz = TTSFactory.CLASSES.get(tts_module)
-        tts = clazz(tts_lang, tts_config)
-        tts.validator.validate()
+        try:
+            clazz = TTSFactory.CLASSES.get(tts_module)
+            tts = clazz(tts_lang, tts_config)
+            tts.validator.validate()
+        except Exception as e:
+            # Fallback to mimic if an error occurs while loading.
+            if tts_module != 'mimic':
+                LOG.exception('The selected TTS backend couldn\'t be loaded. '
+                              'Falling back to Mimic')
+                tts = Mimic(tts_lang, tts_config)
+                tts.validator.validate()
+            else:
+                LOG.exception('The TTS could not be loaded.')
+                raise
+
         return tts


### PR DESCRIPTION
## Description
Logs the exception and fallsback to Mimic as TTS backend if there is an
issue with the selected TTS backend or if the choice is invalid. Resolves #1518.


## How to test
Make sure audio service starts as expected. Trigger an exception in the  `__init__()` or validator of a TTS and verify that it falls back to mimic and logs the issue.

## Contributor license agreement signed?
CLA [ Yes ]
