### PR TITLE
Fix reference leak when using bus.remove_all_listeners

### DIFF
--- a/mycroft/enclosure/gui.py
+++ b/mycroft/enclosure/gui.py
@@ -266,3 +266,12 @@ class SkillGUI:
         self.clear()
         self["url"] = url
         self.show_page("SYSTEM_UrlFrame.qml", override_idle)
+
+    def shutdown(self):
+        """Shutdown gui interface.
+
+        Clear pages loaded through this interface and remove the skill
+        reference to make ref counting warning more precise.
+        """
+        self.clear()
+        self.skill = None

--- a/mycroft/messagebus/client/threaded_event_emitter.py
+++ b/mycroft/messagebus/client/threaded_event_emitter.py
@@ -55,3 +55,11 @@ class ThreadedEventEmitter(EventEmitter):
                 return super().remove_listener(event_name, w[1])
         # if no wrapper exists try removing the function
         return super().remove_listener(event_name, func)
+
+    def remove_all_listeners(self, event_name):
+        """Remove all listeners with name.
+
+        event_name: identifier of event handler
+        """
+        super().remove_all_listeners(event_name)
+        self.wrappers.pop(event_name)

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1209,6 +1209,9 @@ class MycroftSkill:
         except Exception as e:
             LOG.error('Skill specific shutdown function encountered '
                       'an error: {}'.format(repr(e)))
+
+        self.settings_change_callback = None
+
         # Store settings
         if self.settings != self._initial_settings:
             save_settings(self.root_dir, self.settings)
@@ -1217,7 +1220,8 @@ class MycroftSkill:
             self.settings_meta.stop()
 
         # Clear skill from gui
-        self.gui.clear()
+        self.gui.shutdown()
+        self.settings.shutdown()
 
         # removing events
         self.event_scheduler.shutdown()

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -444,3 +444,7 @@ class Settings:
 
     def as_dict(self):
         return self._settings
+
+    def shutdown(self):
+        """Shutdown the Settings object removing any references."""
+        self._skill = None

--- a/test/unittests/skills/test_event_scheduler.py
+++ b/test/unittests/skills/test_event_scheduler.py
@@ -6,7 +6,10 @@ import unittest
 import time
 
 from unittest.mock import MagicMock, patch
-from mycroft.skills.event_scheduler import EventScheduler
+from mycroft.messagebus.client.threaded_event_emitter import (
+        ThreadedEventEmitter)
+from mycroft.skills.event_scheduler import (EventScheduler,
+                                            EventSchedulerInterface)
 
 
 class TestEventScheduler(unittest.TestCase):
@@ -98,3 +101,24 @@ class TestEventScheduler(unittest.TestCase):
         self.assertEquals(emitter.emit.call_args[0][0].msg_type, 'test')
         self.assertEquals(emitter.emit.call_args[0][0].data, {})
         es.shutdown()
+
+
+class TestEventSchedulerInterface(unittest.TestCase):
+    def test_shutdown(self):
+        def f(message):
+            print('TEST FUNC')
+
+        bus = ThreadedEventEmitter()
+
+        es = EventSchedulerInterface('tester')
+        es.set_bus(bus)
+        es.set_id('id')
+
+        # Schedule a repeating event
+        es.schedule_repeating_event(f, None, 10, name='f')
+        es.shutdown()
+
+        # Check that the reference to the function has been removed from the
+        # bus emitter
+        self.assertTrue(len(bus.wrappers) == 0)
+        self.assertTrue(len(bus._events['id:f']) == 0)


### PR DESCRIPTION
## Description
The remove_all_listeners did not remove the appropriate wrapper mapping leaving trailing references to skills if a scheduled repeating event was used.

This also removes a couple of circular references (doing no real harm) to get the ref-count debug code to report correctly.

## How to test
See the new test case.

## Contributor license agreement signed?
CLA [ Yes ]
