### PR TITLE
Fix Shutdown of removed skills

### DIFF
--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -97,17 +97,18 @@ def save_settings(skill_dir, skill_settings):
     else:
         settings_to_save = skill_settings
     settings_path = Path(skill_dir).joinpath('settings.json')
-    with open(str(settings_path), 'w') as settings_file:
-        try:
-            json.dump(settings_to_save, settings_file)
-        except Exception:
-            LOG.exception(
-                'error saving skill settings to ' + str(settings_path)
-            )
-        else:
-            LOG.info(
-                'Skill settings successfully saved to ' + str(settings_path)
-            )
+    if Path(skill_dir).exists():
+        with open(str(settings_path), 'w') as settings_file:
+            try:
+                json.dump(settings_to_save, settings_file)
+            except Exception:
+                LOG.exception('error saving skill settings to '
+                              '{}'.format(settings_path))
+            else:
+                LOG.info('Skill settings successfully saved to '
+                         '{}' .format(settings_path))
+    else:
+        LOG.info('Skill folder no longer exists, can\'t save settings.')
 
 
 def get_display_name(skill_name: str):


### PR DESCRIPTION
## Description
Verify that skill directory exists before writing to ensure that the
shutdown method doesn't throw exception if a skill is unloaded due to
being removed.

## How to test
Start the skill process, remove a skill while core is running (rm -rf /opt/mycroft/skills/skill-folder) Make sure there is no exception logged.

## Contributor license agreement signed?
CLA [ Yes ]
