### PR TITLE
frames to read must be greater than 0

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -92,7 +92,7 @@ class MutableStream:
 
                 to_read = min(self.wrapped_stream.get_read_available(),
                               remaining)
-                if to_read == 0:
+                if to_read <= 0:
                     sleep(.01)
                     continue
                 result = self.wrapped_stream.read(to_read,


### PR DESCRIPTION
## Description
Received the following error on a Mark 1:
```
2019-10-22 00:31:53.324 | INFO     |   826 | mycroft.messagebus.client.client:on_open:67 | Connected
ALSA lib pcm.c:7843:(snd_pcm_recover) overrun occurred
ALSA lib pcm.c:7846:(snd_pcm_recover) cannot recovery from overrun, prepare failed: Input/output error
Expression 'alsa_snd_pcm_prepare( stream->capture.pcm )' failed in 'src/hostapi/alsa/pa_linux_alsa.c', line: 2932
Expression 'AlsaStart( stream, 0 )' failed in 'src/hostapi/alsa/pa_linux_alsa.c', line: 3246
Expression 'AlsaRestart( self )' failed in 'src/hostapi/alsa/pa_linux_alsa.c', line: 3313
Expression 'PaAlsaStream_HandleXrun( stream )' failed in 'src/hostapi/alsa/pa_linux_alsa.c', line: 4503
2019-10-30 04:41:05.137 | ERROR    |   826 | mycroft.client.speech.listener:run:108 | Exception in AudioProducer
Traceback (most recent call last):
  File "/opt/venvs/mycroft-core/lib/python3.4/site-packages/mycroft/client/speech/listener.py", line 84, in run
    self.stream_handler)
  File "/opt/venvs/mycroft-core/lib/python3.4/site-packages/mycroft/client/speech/mic.py", line 594, in listen
    ww_frames = self._wait_until_wake_word(source, sec_per_buffer)
  File "/opt/venvs/mycroft-core/lib/python3.4/site-packages/mycroft/client/speech/mic.py", line 478, in _wait_until_wake_word
    chunk = self.record_sound_chunk(source)
  File "/opt/venvs/mycroft-core/lib/python3.4/site-packages/mycroft/client/speech/mic.py", line 253, in record_sound_chunk
    return source.stream.read(source.CHUNK, self.overflow_exc)
  File "/opt/venvs/mycroft-core/lib/python3.4/site-packages/mycroft/client/speech/mic.py", line 99, in read
    exception_on_overflow=of_exc)
  File "/opt/venvs/mycroft-core/lib/python3.4/site-packages/pyaudio.py", line 608, in read
    return pa.read_stream(self._stream, num_frames, exception_on_overflow)
ValueError: Invalid number of frames
```

Currently unable to replicate the error consistently, however digging into the [pyaudio code](https://github.com/jleb/pyaudio/blob/0109cc46cac6a3c404050f4ba11752e51aeb1fda/src/_portaudiomodule.c#L2432) the exception is raised if  `num_frames` being passed to `pa.read_stream()` is less than 0.

In [MutableStream.read()](https://github.com/MycroftAI/mycroft-core/blob/024274a5caaa995f22b2334512865f96be3588b9/mycroft/client/speech/mic.py#L93) it seems plausible that 
`to_read = min(self.wrapped_stream.get_read_available(), remaining)` 
could assign a negative number.

Hence this change to not only prevent passing a `0` value, but also that the number is not negative.

## How to test
- Unable to consistently replicate issue.
- Mycroft-core unit tests continue to pass.
- Ensure that mic stream is still read correctly

## Contributor license agreement signed?
- [x] CLA
