### PR TITLE
Drop Python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ before_install:
  - export CC="gcc-4.8"
  - export TMPDIR="/tmp/${TRAVIS_PYTHON_VERSION}"
 python:
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 six==1.10.0
 cryptography==2.6.1
 requests==2.20.0
-gTTS==2.0.3
-gTTS-token==1.1.3
+gTTS==2.0.4
 PyAudio==0.2.11
 pyee==5.0.0
 SpeechRecognition==3.8.1
@@ -15,7 +14,7 @@ pyserial==3.0
 psutil==5.2.1
 pocketsphinx==0.1.0
 inflection==0.3.1
-pillow==4.1.1
+pillow==6.2.1
 python-dateutil==2.6.0
 pychromecast==3.2.2
 python-vlc==1.1.2
@@ -31,6 +30,3 @@ fann2==1.0.7
 padaos==0.1.9
 precise-runner==0.2.1
 petact==0.1.2
-
-# dev setup tools
-pep8==1.7.0


### PR DESCRIPTION
## Description
This drops support for Python 3.4.

- Update *gTTS* to a version that works with python 3.7
- Update *pillow* fixing the security warning regarding specially formatted images crashing it.
- Drop the Python 3.4 Travis test

In addition the pep8 tool is removed from the requirements.txt (test_requirements.txt installs pycodestyle)

## How to test
This branch is running on the Mark-1 unstable repo. Switch to that branch and check functionality.

## Contributor license agreement signed?
CLA [ Yes ]
