### PR TITLE
Issue 2120 - Fallback to 'en-us' when resource loading fails

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -676,7 +676,7 @@ class MycroftSkill:
             string: The full path to the resource file or None if not found
         """
         result = self._find_resource(res_name, self.lang, res_dirname)
-        if not result:
+        if not result and self.lang != 'en-us':
             # when resource not found try fallback to en-us
             LOG.warning(
                 "Resource '{}' for lang '{}' not found: trying 'en-us'"

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -675,9 +675,22 @@ class MycroftSkill:
         Returns:
             string: The full path to the resource file or None if not found
         """
+        result = self._find_resource(res_name, self.lang, res_dirname)
+        if not result:
+            # when resource not found try fallback to en-us
+            LOG.warning(
+                "Resource '{}' for lang '{}' not found: trying 'en-us'"
+                .format(res_name, self.lang)
+            )
+            result = self._find_resource(res_name, 'en-us', res_dirname)
+        return result
+
+    def _find_resource(self, res_name, lang, res_dirname=None):
+        """Find resource by name, lang and dir
+        """
         if res_dirname:
             # Try the old translated directory (dialog/vocab/regex)
-            path = join(self.root_dir, res_dirname, self.lang, res_name)
+            path = join(self.root_dir, res_dirname, lang, res_name)
             if exists(path):
                 return path
 
@@ -687,7 +700,7 @@ class MycroftSkill:
                 return path
 
         # New scheme:  search for res_name under the 'locale' folder
-        root_path = join(self.root_dir, 'locale', self.lang)
+        root_path = join(self.root_dir, 'locale', lang)
         for path, _, files in walk(root_path):
             if res_name in files:
                 return join(path, res_name)

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -686,7 +686,7 @@ class MycroftSkill:
         return result
 
     def _find_resource(self, res_name, lang, res_dirname=None):
-        """Find resource by name, lang and dir
+        """Finds a resource by name, lang and dir
         """
         if res_dirname:
             # Try the old translated directory (dialog/vocab/regex)


### PR DESCRIPTION
## Description
When mycroft_skill.find_resource fails to load a resource for self.lang fall back to lang 'en-us' as most skills/resources are available in english by default.

==== Fixed Issues ====
MycroftAI#2120

## How to test
There are several skills missing some intent-files for 'de-de' (among them is the mycroft-weather skill). Without this PR loading of these skills will fail. When PR is applied all skills will load, but some WARNINGs will be logged.

## Contributor license agreement signed?
CLA [X] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
