### PR TITLE
Fix using of hotword structure for custom wakeword

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -312,6 +312,7 @@ class RecognizerLoop(EventEmitter):
         # Create a local recognizer to hear the wakeup word, e.g. 'Hey Mycroft'
         LOG.info("creating wake word engine")
         word = self.config.get("wake_word", "hey mycroft")
+
         # TODO remove this, only for server settings compatibility
         phonemes = self.config.get("phonemes")
         thresh = self.config.get("threshold")
@@ -319,16 +320,18 @@ class RecognizerLoop(EventEmitter):
         # Since we're editing it for server backwards compatibility
         # use a copy so we don't alter the hash of the config and
         # trigger a reload.
-        config = deepcopy(self.config_core.get("hotwords", {word: {}}))
-
+        config = deepcopy(self.config_core.get("hotwords", {}))
         if word not in config:
+            # Fallback to using config from "listener" block
+            LOG.warning('Wakeword doesn\'t have an entry falling back'
+                        'to old listener config')
             config[word] = {'module': 'precise'}
-        if phonemes:
-            config[word]["phonemes"] = phonemes
-        if thresh:
-            config[word]["threshold"] = thresh
-        if phonemes is None or thresh is None:
-            config = None
+            if phonemes:
+                config[word]["phonemes"] = phonemes
+            if thresh:
+                config[word]["threshold"] = thresh
+            if phonemes is None or thresh is None:
+                config = None
         return HotWordFactory.create_hotword(
             word, config, self.lang, loop=self
         )


### PR DESCRIPTION
## Description
Fixes overriding settings from listener config

## How to test
- Make sure a the default wakeword works

- Make sure a change on home.mycroft.ai to "Hey Ezra" or "Cristopher" works.

- Make sure a custom entry works:

```json
  "listener": {
    "wake_word": "andromeda"
  },
  "hotwords": {
    "andromeda": {
      "module": "pocketsphinx",
      "phonemes": "AE N D R AA M AH D AH .",
      "sample_rate": 16000,
      "threshold": "1e-25",
      "lang": "en-us"
    }
  }
```

## Contributor license agreement signed?
CLA [ Yes ]
