### PR TITLE
Upgrade readthedocs build

### DIFF
--- a/.readthedocs
+++ b/.readthedocs
@@ -1,0 +1,19 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# Build all formats
+formats: all
+
+# Set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: docs/requirements.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python2
-# -*- coding: utf-8 -*-
 #
 # Copyright 2017 Mycroft AI Inc.
 #

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,2 @@
-sphinx>= 1.8.1
-sphinx_rtd_theme>=0.4.2
+sphinx>= 2.2.1
+sphinx_rtd_theme>=0.4.3


### PR DESCRIPTION
## Description
- Add .readthedocs file
- Update sphinx version
- Remove python2 version from conf.py (spotted by @maxbachmann)

## How to test
Check that the docs at https://mycroft-core.readthedocs.io/en/feature-dot-readthedocs/ looks ok.

## Contributor license agreement signed?
CLA [ Yes ]
