### PR TITLE
Fix broken test case on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,6 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-jobs:
-  allow_failures:
-    - python: "3.8"
 # don't rebuild pocketsphinx for every build
 cache:
   - pip

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -183,10 +183,21 @@ class TestNormalize(unittest.TestCase):
         # invoke helper functions directly to test certain conditions which are
         # difficult to trigger on purpose.
         replaceable = _ReplaceableNumber(1, ["test_token"])
-        self.assertRaises(AttributeError, setattr(replaceable, "key", None))
+
+        # Check that built in members can't be changed
         with self.assertRaises(Exception) as error:
-            setattr(replaceable, "key", type(None))
+            replaceable.value = 42
             self.assertEqual(error.message, "Immutable!")
+        with self.assertRaises(Exception) as error:
+            replaceable.tokens = ["flowerpot", "whale"]
+            self.assertEqual(error.message, "Immutable!")
+
+        # Check that new member can be added but not modified
+        replaceable.key = "exist"
+        with self.assertRaises(Exception) as error:
+            replaceable.key = "exists?"
+            self.assertEqual(error.message, "Immutable!")
+
         self.assertEqual(str(replaceable), "(1, ['test_token'])")
         self.assertEqual(repr(replaceable),
                          "_ReplaceableNumber(1, ['test_token'])")


### PR DESCRIPTION
## Description
- Change the check for attribute key to use dir instad of an
AttributeError using setattr. in test_parse.py
- Add python 3.8 to mandatory test cases for travis

## How to test
Check that travis passes

## Contributor license agreement signed?
CLA [ Yes ]
