### PR TITLE
Fixing dev_setup.sh for Arch Linux

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -305,10 +305,6 @@ function open_suse_install() {
 function arch_install() {
     $SUDO pacman -S --needed --noconfirm git python python-pip python-setuptools python-virtualenv python-gobject libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq pulseaudio pulseaudio-alsa
 
-    command -v virtualenv &> /dev/null || (
-        $SUDO pacman -S --needed --noconfirm python-virtualenvwrapper
-    )
-
     pacman -Qs '^fann$' &> /dev/null || (
         git clone  https://aur.archlinux.org/fann.git
         cd fann

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -303,7 +303,12 @@ function open_suse_install() {
 
 
 function arch_install() {
-    $SUDO pacman -S --needed --noconfirm git python python-pip python-setuptools python-virtualenv python-gobject python-virtualenvwrapper libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq pulseaudio pulseaudio-alsa
+    $SUDO pacman -S --needed --noconfirm git python python-pip python-setuptools python-virtualenv python-gobject libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq pulseaudio pulseaudio-alsa
+
+    command -v virtualenv &> /dev/null || (
+        $SUDO pacman -S --needed --noconfirm python-virtualenvwrapper
+    )
+
     pacman -Qs '^fann$' &> /dev/null || (
         git clone  https://aur.archlinux.org/fann.git
         cd fann


### PR DESCRIPTION
## Description
When you have `virtualenv` installed trough `pip` in Arch Linux, the `./dev_setup.sh` script does not works. The installation of `python-virtualenvwrapper` breaks because the files already exists. The ideal solution is to fix `python-virtualenvwrapper` installation for Arch. ~~For now, the Mycroft setup script can check if the lib is already installed and skip it.~~

_**Update:**_

Actually, we do not need virtualenv anymore for Mycroft, the ideal solution is to remove this dependency.

This is related to _"Error installing dependencies using pacman on Arch linux" #1967_

## How to test

### Simulating the error
Create a `Dockerfile` with the following code:
```
FROM archlinux:20191105
RUN pacman -Sy --needed --noconfirm python python-pip
RUN pip install virtualen
RUN pacman -S --needed --noconfirm python-virtualenvwrapper
```

Try to build the Dockerfile with `docker build .`. You should see something like:
```
python-virtualenv: /usr/bin/virtualenv exists in filesystem
python-virtualenv: /usr/lib/python3.8/site-packages/__pycache__/virtualenv.cpython-38.pyc exists in filesystem
python-virtualenv: /usr/lib/python3.8/site-packages/virtualenv.py exists in filesystem
python-virtualenv: /usr/lib/python3.8/site-packages/virtualenv_support/__init__.py exists in filesystem
python-virtualenv: /usr/lib/python3.8/site-packages/virtualenv_support/__pycache__/__init__.cpython-38.pyc exists in filesystem
Errors occurred, no packages were upgraded.
The command '/bin/sh -c pacman -S --needed --noconfirm python-virtualenvwrapper' returned a non-zero code: 1
```

### ~~Simulating the solution~~

~~Create a `Dockerfile` with the following code:~~
```
FROM archlinux:20191105
RUN pacman -Sy --needed --noconfirm python python-pip
RUN pip install virtualenv

RUN command -v virtualenv &> /dev/null || ( \
		pacman -S --needed --noconfirm python-virtualenvwrapper\
	)

RUN virtualenv --version

```
~~Try to build the Dockerfile with `docker build .`. You should see something like:~~
```
 ---> Running in 0f04d3148914
16.7.8
Removing intermediate container 0f04d3148914
 ---> c14897eb88c1
Successfully built c14897eb88c1
```

~~The `16.7.8` message shows that the `virtualenv` is instaled in the version 16.7.8.~~

### Real testing

Using an Arch Linux installation, install the `virtualenv` with `pip` running `pip install virtualenv`. Try to run the `./dev_setup.sh` after that. The setup should finish with success, and you should be able to start Mycroft. I have tested the solution on my machine (Manjaro Linux) and works ok.