### PR TITLE
Remove cryptography dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 six==1.13.0
-cryptography==2.6.1
 requests==2.20.0
 gTTS==2.0.4
 PyAudio==0.2.11


### PR DESCRIPTION
## Description
The dependency was previously added to try to suppress the SSL version
warning on the mark-1. This has been resolved via upgrading the mark-1
so the requirement is not of any importance right now.

## Contributor license agreement signed?
CLA [ Yes ]
