### PR TITLE
Restore Ctrl+C exit of simple CLI

### DIFF
--- a/mycroft/client/text/__main__.py
+++ b/mycroft/client/text/__main__.py
@@ -13,13 +13,15 @@
 # limitations under the License.
 #
 import sys
+import signal
 import io
 import os.path
 import curses
 from mycroft.util import get_ipc_directory
 from .text_client import (
         load_settings, save_settings, simple_cli, gui_main,
-        start_log_monitor, start_mic_monitor, connect_to_mycroft
+        start_log_monitor, start_mic_monitor, connect_to_mycroft,
+        ctrl_c_handler
     )
 from mycroft.configuration import Configuration
 
@@ -57,6 +59,8 @@ def main():
         sys.stderr = sys.__stderr__
         simple_cli()
     else:
+        # Special signal handler allows a clean shutdown of the GUI
+        signal.signal(signal.SIGINT, ctrl_c_handler)
         load_settings()
         curses.wrapper(gui_main)
         curses.endwin()

--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -14,7 +14,6 @@
 #
 import sys
 import io
-import signal
 from math import ceil
 
 from .gui_server import start_qml_gui
@@ -119,9 +118,6 @@ def ctrl_c_pressed():
         return True
     else:
         return False
-
-
-signal.signal(signal.SIGINT, ctrl_c_handler)
 
 
 ##############################################################################


### PR DESCRIPTION
At some point during refactoring the ability to hit Ctrl+C to exit the basic CLI was lost.

## How to test
Run:
```mycroft-cli-client --simple```
Then hit Ctrl+C.  Before this change nothing happens (you just see the "^C" printed out).  After the change it exits as expected.
