### PR TITLE
Fallback to 'en-us' when resource fails

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -675,9 +675,22 @@ class MycroftSkill:
         Returns:
             string: The full path to the resource file or None if not found
         """
+        result = self._find_resource(res_name, self.lang, res_dirname)
+        if not result and self.lang != 'en-us':
+            # when resource not found try fallback to en-us
+            LOG.warning(
+                "Resource '{}' for lang '{}' not found: trying 'en-us'"
+                .format(res_name, self.lang)
+            )
+            result = self._find_resource(res_name, 'en-us', res_dirname)
+        return result
+
+    def _find_resource(self, res_name, lang, res_dirname=None):
+        """Finds a resource by name, lang and dir
+        """
         if res_dirname:
             # Try the old translated directory (dialog/vocab/regex)
-            path = join(self.root_dir, res_dirname, self.lang, res_name)
+            path = join(self.root_dir, res_dirname, lang, res_name)
             if exists(path):
                 return path
 
@@ -687,7 +700,7 @@ class MycroftSkill:
                 return path
 
         # New scheme:  search for res_name under the 'locale' folder
-        root_path = join(self.root_dir, 'locale', self.lang)
+        root_path = join(self.root_dir, 'locale', lang)
         for path, _, files in walk(root_path):
             if res_name in files:
                 return join(path, res_name)


### PR DESCRIPTION
## Description
Rebase of #2379 , without the last dialog change.

When mycroft_skill.find_resource fails to load a resource for self.lang
fall back to lang 'en-us'
as most skills/resources are available in english by default.

Resolves #2110

## Contributor license agreement signed?
CLA [ Yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
