### PR TITLE
use default python version on redhat

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -298,7 +298,7 @@ function os_is_like() {
 }
 
 function redhat_common_install() {
-    $SUDO yum install -y cmake gcc-c++ git python34 python34-devel libtool libffi-devel openssl-devel autoconf automake bison swig portaudio-devel mpg123 flac curl libicu-devel python34-pkgconfig libjpeg-devel fann-devel python34-libs pulseaudio
+    $SUDO yum install -y cmake gcc-c++ git python3-devel libtool libffi-devel openssl-devel autoconf automake bison swig portaudio-devel mpg123 flac curl libicu-devel libjpeg-devel fann-devel pulseaudio
     git clone https://github.com/libfann/fann.git
     cd fann
     git checkout b211dc3db3a6a2540a34fbe8995bf2df63fc9939


### PR DESCRIPTION
## Description
Fixes https://github.com/MycroftAI/mycroft-core/issues/2407
right now the python version is hardcoded to 3.4.
This PR replaces this with python3-devel, which includes all the other packages that are removed.
I only tested this in a centos7/8 docker container and not with redhat


## How to test
Test whether dev_setup.sh runs fine on centos and redhat

## Contributor license agreement signed?
CLA [Yes ]