### PR TITLE
Send mycroft.audio.queue_end

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -193,12 +193,19 @@ class AudioService:
         self.bus.on('recognizer_loop:record_end', self._restore_volume)
 
     def track_start(self, track):
+        """Callback method called from the services to indicate start of
+        playback of a track or end of playlist.
         """
-            Callback method called from the services to indicate start of
-            playback of a track.
-        """
-        self.bus.emit(Message('mycroft.audio.playing_track',
-                              data={'track': track}))
+        if track:
+            # Inform about the track about to start.
+            LOG.debug('New track coming up!')
+            self.bus.emit(Message('mycroft.audio.playing_track',
+                                  data={'track': track}))
+        else:
+            # If no track is about to start last track of the queue has been
+            # played.
+            LOG.debug('End of playlist!')
+            self.bus.emit(Message('mycroft.audio.queue_end'))
 
     def _pause(self, message=None):
         """

--- a/mycroft/audio/services/simple/__init__.py
+++ b/mycroft/audio/services/simple/__init__.py
@@ -139,6 +139,7 @@ class SimpleAudioService(AudioBackend):
             self.bus.emit(Message('SimpleAudioServicePlay',
                                   {'repeat': repeat}))
         else:
+            self._track_start_callback(None)
             self._is_playing = False
             self._paused = False
 

--- a/mycroft/audio/services/vlc/__init__.py
+++ b/mycroft/audio/services/vlc/__init__.py
@@ -28,8 +28,11 @@ class VlcService(AudioBackend):
         self.track_list = self.instance.media_list_new()
         self.list_player.set_media_list(self.track_list)
         self.vlc_events = self.player.event_manager()
+        self.vlc_list_events = self.list_player.event_manager()
         self.vlc_events.event_attach(vlc.EventType.MediaPlayerPlaying,
                                      self.track_start, 1)
+        self.vlc_list_events.event_attach(vlc.EventType.MediaListPlayerPlayed,
+                                          self.queue_ended, 0)
         self.config = config
         self.bus = bus
         self.name = name
@@ -39,6 +42,11 @@ class VlcService(AudioBackend):
     def track_start(self, data, other):
         if self._track_start_callback:
             self._track_start_callback(self.track_info()['name'])
+
+    def queue_ended(self, data, other):
+        LOG.debug('Queue ended')
+        if self._track_start_callback:
+            self._track_start_callback(None)
 
     def supported_uris(self):
         return ['file', 'http', 'https']

--- a/test/unittests/audio/test_service.py
+++ b/test/unittests/audio/test_service.py
@@ -86,6 +86,25 @@ class TestService(unittest.TestCase):
         self.assertTrue(second_backend.shutdown.called)
 
     @mock.patch('mycroft.audio.audioservice.load_services')
+    def test_audio_service_track_start(self, mock_load_services):
+        """Test start of new track messages."""
+        backend, second_backend = setup_mock_backends(mock_load_services,
+                                                      self.emitter)
+        service = audio_service.AudioService(self.emitter)
+        service.load_services_callback()
+        service.default = backend
+
+        self.emitter.reset()
+        service.track_start('The universe song')
+        service.track_start(None)
+        self.assertEqual(self.emitter.types, ['mycroft.audio.playing_track',
+                                              'mycroft.audio.queue_end'])
+        self.assertEqual(self.emitter.results,
+                         [{'track': 'The universe song'}, {}])
+
+        service.shutdown()
+
+    @mock.patch('mycroft.audio.audioservice.load_services')
     def test_audio_service_methods_not_playing(self, mock_load_services):
         """Check that backend methods aren't called when stopped."""
         backend, second_backend = setup_mock_backends(mock_load_services,


### PR DESCRIPTION
## Description
The message is sent when there are no more tracks in the queue and
playback has stopped.

The intended use of this is for example restore the resting screen on the Mark-2 after a playlist has been completely played.

## How to test
Use the feature/restore-resting branch of the playback-control skill and make sure the log message is printed in the CLI when for example the news ends.

## Contributor license agreement signed?
CLA [ Yes ]
