### PR TITLE
Disregard DEBUG entry in CLI filter

### DIFF
--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -62,7 +62,7 @@ log_lock = Lock()
 max_log_lines = 5000
 mergedLog = []
 filteredLog = []
-default_log_filters = ["mouth.viseme", "mouth.display", "mouth.icon", "DEBUG"]
+default_log_filters = ["mouth.viseme", "mouth.display", "mouth.icon"]
 log_filters = list(default_log_filters)
 log_files = []
 find_str = None
@@ -175,7 +175,8 @@ def load_settings():
         with io.open(config_file, 'r') as f:
             config = json.load(f)
         if "filters" in config:
-            log_filters = config["filters"]
+            # Disregard the filtering of DEBUG messages
+            log_filters = [f for f in config["filters"] if f != "DEBUG"]
         if "cy_chat_area" in config:
             cy_chat_area = config["cy_chat_area"]
         if "show_last_key" in config:


### PR DESCRIPTION
## Description
The DEBUG, has been filtered by default. This will disregard the DEBUG
filter completely since the same effect can be achieved by setting the
debug level using ":log level debug".

Should resolve #2420 

## How to test
Add "DEBUG" to the "filters" list in `~/.mycroft_cli.conf` and ensure that setting the log level in the cli using `:log level debug` will show the debug messages.

## Contributor license agreement signed?
CLA [ Yes ]
