### PR TITLE
Fix typo in MycroftSkill documentation

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -118,7 +118,7 @@ class MycroftSkill:
     to all Skill implementations.
 
     For information on how to get started with creating mycroft skills see
-    https://https://mycroft.ai/documentation/skills/introduction-developing-skills/
+    https://mycroft.ai/documentation/skills/introduction-developing-skills/
 
     Arguments:
         name (str): skill name


### PR DESCRIPTION
## Description
This fixes a link in the documentation of MycroftSkill, namely a double `https://`.

## How to test
Rebuild the documentation and check the link in the `mycroft.MycroftSkill` documentation.

## Contributor license agreement signed?
CLA [ yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
