### PR TITLE
mark1/fix display big images

### DIFF
--- a/mycroft/client/enclosure/mark1/mouth.py
+++ b/mycroft/client/enclosure/mark1/mouth.py
@@ -108,11 +108,8 @@ class EnclosureMouth:
         message = "mouth.icon=" + x_offset + y_offset + clear_previous + code
         # Check if message exceeds Arduino's serial buffer input limit 64 bytes
         if len(message) > 60:
-            message1 = message[:31]
-            message2 = message[31:]
-            message1 += "$"
-            message2 += "$"
-            message2 = "mouth.icon=" + message2
+            message1 = message[:31] + "$"
+            message2 = "mouth.icon=$" + message[31:]
             self.writer.write(message1)
             time.sleep(0.25)  # writer bugs out if sending messages too rapidly
             self.writer.write(message2)


### PR DESCRIPTION
i have been having trouble with things not rendering in the faceplate, after a lot of frustration after some digging i found this

https://github.com/MycroftAI/enclosure-mark1/blob/master/protocols.txt#L141

according to the spec there is a bug, i have not tested this however (mark1 is not dev friendly!)

i have a game of life skill and some other [goodies](https://github.com/OpenJarbas/jarbas_utils/tree/dev/jarbas_utils/mark1) waiting on this :)

NOTE: pr made directly in browser, sorry if something is messed up