### PR TITLE
Bugfix/settings sync

### DIFF
--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -207,7 +207,8 @@ class SkillManager(Thread):
                 self._load_new_skills()
                 self._unload_removed_skills()
                 self._update_skills()
-                if is_paired() and len(self.upload_queue) > 0:
+                if (is_paired() and self.upload_queue.started and
+                        len(self.upload_queue) > 0):
                     self.msm.clear_cache()
                     self.skill_updater.post_manifest()
                     self.upload_queue.send()

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -179,7 +179,9 @@ class SkillManager(Thread):
                         log_msg = 'Downloading priority skill: {} failed'
                         LOG.exception(log_msg.format(skill_name))
                         continue
-                self._load_skill(skill.path)
+                loader = self._load_skill(skill.path)
+                if loader:
+                    self.upload_queue.put(loader)
             else:
                 LOG.error(
                     'Priority skill {} can\'t be found'.format(skill_name)

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -13,12 +13,33 @@
 # limitations under the License.
 #
 from os import path
+from unittest import TestCase
 from unittest.mock import Mock, patch
 
 from mycroft.skills.skill_loader import SkillLoader
-from mycroft.skills.skill_manager import SkillManager
+from mycroft.skills.skill_manager import SkillManager, UploadQueue
 from ..base import MycroftUnitTestBase
 from ..mocks import mock_msm
+
+
+class TestUploadQueue(TestCase):
+    def test_upload_queue_create(self):
+        queue = UploadQueue()
+        self.assertFalse(queue.started)
+        queue.start()
+        self.assertTrue(queue.started)
+
+    def test_upload_queue_use(self):
+        queue = UploadQueue()
+        queue.start()
+        # Check that putting items on the queue makes it longer
+        loaders = [Mock(), Mock(), Mock(), Mock()]
+        for i, l in enumerate(loaders):
+            queue.put(l)
+            self.assertEqual(len(queue), i + 1)
+        # Check that sending items empties the queue
+        queue.send()
+        self.assertEqual(len(queue), 0)
 
 
 class TestSkillManager(MycroftUnitTestBase):


### PR DESCRIPTION
## Description
During release testing two issues were identified with regard to settings meta upload
- A race condition between the pairing start of settingsmeta upload and skill loading upload
- Priority skills settingsmeta weren't uploaded

This resolves the first issue by adding a check that the started parameter has been set in the upload queue before attempting to upload settings after skill loading.

The second basically adds the skill loader to the queue when the settingsmeta when loading priority skills.

## Contributor license agreement signed?
CLA [ Yes ]
