### PR TITLE
Make venv-activate.sh compatible with sh and zsh

### DIFF
--- a/venv-activate.sh
+++ b/venv-activate.sh
@@ -51,7 +51,7 @@ function main() {
        esac
     done
 
-    if [ "$0" == "$BASH_SOURCE" ] ; then
+    if [[ "$0" == "$BASH_SOURCE" ]] ; then
         # Prevent running in script then exiting immediately
         echo "ERROR: Invoke with 'source venv-activate.sh' or '. venv-activate.sh'"
     else


### PR DESCRIPTION
## Description
Make venv-activate.sh compatible with sh and zsh

## How to test
$  if [ "$0" == "$BASH_SOURCE" ]; then echo "a"; fi
Error: sh: 1: [: sh: unexpected operator

$  if [[ "$0" == "$BASH_SOURCE" ]]; then echo "a"; fi
Succed

## Contributor license agreement signed?
CLA [X] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
