### PR TITLE
Fix documentation mistake

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -22,7 +22,7 @@
   // TODO: save unmodified, lowercase upon demand
   "lang": "en-us",
 
-  // Measurement units, either 'metric' or 'english'
+  // Measurement units, either 'metric' or 'imperial'
   // Override: REMOTE
   "system_unit": "metric",
 


### PR DESCRIPTION
## Description
https://account.mycroft.ai/devices/preferences will set system_unit to either metric or imperial. Never to any other value.

## How to test
Change your Measurement System settings and check the value of the system_unit variable.

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
