### PR TITLE
Add self.root_dir to readthedocs documentation

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -130,7 +130,10 @@ class MycroftSkill:
         self.resting_name = None
         self.skill_id = ''  # will be set from the path, so guaranteed unique
         self.settings_meta = None  # set when skill is loaded in SkillLoader
+
         # Get directory of skill
+        #: Member variable containing the absolute path of the skill's root
+        #: directory. E.g. /opt/mycroft/skills/my-skill.me/
         self.root_dir = dirname(abspath(sys.modules[self.__module__].__file__))
         if use_settings:
             self.settings = Settings(self)


### PR DESCRIPTION
## Description
Add description for MycroftSkill.root_dir to readthedocs api documentation.

## How to test
build the documentation
```
cd doc
make html
```

and open `doc/_build/html/index.html` in a webbrowser and check that root_dir exists under the MycroftSkill section and that it looks decent.  

## Contributor license agreement signed?
CLA [ Yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)