### PR TITLE
Add setting for padatious single_thread in mycroft.conf

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -22,7 +22,7 @@
   // TODO: save unmodified, lowercase upon demand
   "lang": "en-us",
 
-  // Measurement units, either 'metric' or 'imperial'
+  // Measurement units, either 'metric' or 'english'
   // Override: REMOTE
   "system_unit": "metric",
 
@@ -295,7 +295,8 @@
 
   "padatious": {
     "intent_cache": "~/.mycroft/intent_cache",
-    "train_delay": 4
+    "train_delay": 4,
+    "single_thread": false
   },
 
   "Audio": {

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -18,7 +18,6 @@ from threading import Event
 from time import time as get_time, sleep
 
 from os.path import expanduser, isfile
-from pkg_resources import get_distribution
 
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
@@ -78,12 +77,14 @@ class PadatiousService(FallbackSkill):
         self.registered_intents = []
 
     def train(self, message=None):
-        padatious_single_thread = Configuration.get()['padatious']['single_thread']
+        padatious_single_thread = Configuration.get()[
+            'padatious']['single_thread']
         if message is None:
             single_thread = padatious_single_thread
         else:
-            single_thread = message.data.get('single_thread', padatious_single_thread)
-       
+            single_thread = message.data.get('single_thread',
+                                             padatious_single_thread)
+
         self.finished_training_event.clear()
 
         LOG.info('Training... (single_thread={})'.format(single_thread))

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -78,10 +78,12 @@ class PadatiousService(FallbackSkill):
         self.registered_intents = []
 
     def train(self, message=None):
+        padatious_single_thread = Configuration.get()['padatious']['single_thread']
         if message is None:
-            single_thread = False
+            single_thread = padatious_single_thread
         else:
-            single_thread = message.data.get('single_thread', False)
+            single_thread = message.data.get('single_thread', padatious_single_thread)
+       
         self.finished_training_event.clear()
 
         LOG.info('Training... (single_thread={})'.format(single_thread))


### PR DESCRIPTION
## Description
* Adding a setting in mycroft.conf for padatious single:thread
* adding use of setting in padatious 

To make it posible to use remote debugging there is need for at setting to turn off and on singlethread in padatious. This I think were done best by a mycroft.conf setting.

When (if) this is merged I have a remote-debug skill that uses PTVSD to enable remote debug :) 

## How to test
Change setting for padatious single_thread in mycroft.conf and see that it changes how padatios run.

Se in log that single_thread is true or fals acording to setting in mycroft.conf
```
 19:40:43.542 | INFO     | 20607 | mycroft.skills.padatious_service:train:89 | Training... (single_thread=True)               
```
## Contributor license agreement signed?
CLA [ x ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
