### PR TITLE
make stop-mycroft.sh also stop if skills are started from other module.

### DIFF
--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -106,7 +106,7 @@ function launch-process() {
 function require-process() {
     # Launch process if not found
     name-to-script-path ${1}
-    if ! pgrep -f "python3 -m ${_module}" > /dev/null ; then
+    if ! pgrep -f "python3 (.*) -m ${_module}" > /dev/null ; then
         # Start required process
         launch-background ${1}
     fi
@@ -117,7 +117,7 @@ function launch-background() {
 
     # Check if given module is running and start (or restart if running)
     name-to-script-path ${1}
-    if pgrep -f "python3 -m ${_module}" > /dev/null ; then
+    if pgrep -f "python3 (.*) -m ${_module}" > /dev/null ; then
         if ($_force_restart) ; then
             echo "Restarting: ${1}"
             "${DIR}/stop-mycroft.sh" ${1}

--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -106,7 +106,7 @@ function launch-process() {
 function require-process() {
     # Launch process if not found
     name-to-script-path ${1}
-    if ! pgrep -f "python3 (.*) -m ${_module}" > /dev/null ; then
+    if ! pgrep -f "python3 (.*)-m ${_module}" > /dev/null ; then
         # Start required process
         launch-background ${1}
     fi
@@ -117,7 +117,7 @@ function launch-background() {
 
     # Check if given module is running and start (or restart if running)
     name-to-script-path ${1}
-    if pgrep -f "python3 (.*) -m ${_module}" > /dev/null ; then
+    if pgrep -f "python3 (.*)-m ${_module}" > /dev/null ; then
         if ($_force_restart) ; then
             echo "Restarting: ${1}"
             "${DIR}/stop-mycroft.sh" ${1}

--- a/stop-mycroft.sh
+++ b/stop-mycroft.sh
@@ -41,7 +41,7 @@ function help() {
 }
 
 function process-running() {
-    if [[ $( pgrep -f "python3 -m mycroft.*${1}" ) ]] ; then
+    if [[ $( pgrep -f "python3 (.*) -m mycroft.*${1}" ) ]] ; then
         return 0
     else
         return 1
@@ -51,7 +51,7 @@ function process-running() {
 function end-process() {
     if process-running $1 ; then
         # Find the process by name, only returning the oldest if it has children
-        pid=$( pgrep -o -f "python3 -m mycroft.*${1}" )
+        pid=$( pgrep -o -f "python3 (.*) -m mycroft.*${1}" )
         echo -n "Stopping $1 (${pid})..."
         kill -SIGINT ${pid}
 
@@ -68,7 +68,7 @@ function end-process() {
 
         if process-running $1 ; then
             echo "failed to stop."
-            pid=$( pgrep -o -f "python3 -m mycroft.*${1}" )            
+            pid=$( pgrep -o -f "python3 (.*) -m mycroft.*${1}" )            
             echo -n "  Killing $1 (${pid})..."
             kill -9 ${pid}
             echo "killed."

--- a/stop-mycroft.sh
+++ b/stop-mycroft.sh
@@ -41,7 +41,7 @@ function help() {
 }
 
 function process-running() {
-    if [[ $( pgrep -f "python3 (.*) -m mycroft.*${1}" ) ]] ; then
+    if [[ $( pgrep -f "python3 (.*)-m mycroft.*${1}" ) ]] ; then
         return 0
     else
         return 1
@@ -51,7 +51,7 @@ function process-running() {
 function end-process() {
     if process-running $1 ; then
         # Find the process by name, only returning the oldest if it has children
-        pid=$( pgrep -o -f "python3 (.*) -m mycroft.*${1}" )
+        pid=$( pgrep -o -f "python3 (.*)-m mycroft.*${1}" )
         echo -n "Stopping $1 (${pid})..."
         kill -SIGINT ${pid}
 
@@ -68,7 +68,7 @@ function end-process() {
 
         if process-running $1 ; then
             echo "failed to stop."
-            pid=$( pgrep -o -f "python3 (.*) -m mycroft.*${1}" )            
+            pid=$( pgrep -o -f "python3 (.*)-m mycroft.*${1}" )            
             echo -n "  Killing $1 (${pid})..."
             kill -9 ${pid}
             echo "killed."


### PR DESCRIPTION
## Description
Make stop-mycroft.sh also stop if skills are started from other module.
If mycroft.skills are started from other module like ptvsd this make the stop function still posible to stop the skills service.

This is needed if running ptvsd remote debug to make sure skills are stoped as usal even though the proces is
```
python3 -m ptvsd --host 0.0.0.0 --port 5678 -m mycroft.skills
```
and not as normal
```
python3 -m mycroft.skills
```

## How to test
Starting and stopping and restarting skills should still work as usal

## Contributor license agreement signed?
CLA [ X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
