### PR TITLE
Upgrade to latest pip version

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -415,7 +415,7 @@ function install_venv() {
     # Force version of pip for reproducability, but there is nothing special
     # about this version.  Update whenever a new version is released and
     # verified functional.
-    curl https://bootstrap.pypa.io/3.3/get-pip.py | "${VIRTUALENV_ROOT}/bin/python" - 'pip==18.0.0'
+    curl https://bootstrap.pypa.io/get-pip.py | "${VIRTUALENV_ROOT}/bin/python" - 'pip==20.0.2'
     # Function status depending on if pip exists
     [[ -x ${VIRTUALENV_ROOT}/bin/pip ]]
 }


### PR DESCRIPTION
## Description
Time has come (or is quite overdue) to update to the latest pip version. The reasons for keeping a locked pip version is that pip historically a pip version update has broken the dev-setup a number of times.

Fixes #2456.

## How to test
Make sure a new venv can be built without issues and Mycroft can be run.

## Contributor license agreement signed?
CLA [ Yes ]
