### PR TITLE
Feat/message targetting

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -44,6 +44,13 @@ def handle_speak(event):
     Configuration.set_config_update_handlers(bus)
     global _last_stop_signal
 
+    # if the message is targeted and audio is not the target don't
+    # don't synthezise speech
+    if (event.context and 'destination' in event.context and
+            event.context['destination'] and
+            'audio' not in event.context['destination']):
+        return
+
     # Get conversation ID
     if event.context and 'ident' in event.context:
         ident = event.context['ident']

--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -46,9 +46,10 @@ def handle_speak(event):
 
     # if the message is targeted and audio is not the target don't
     # don't synthezise speech
-    if (event.context and 'destination' in event.context and
-            event.context['destination'] and
-            'audio' not in event.context['destination']):
+    event.context = event.context or {}
+    if event.context.get('destination') and not \
+            ('debug_cli' in event.context['destination'] or
+             'audio' in event.context['destination']):
         return
 
     # Get conversation ID

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -35,24 +35,32 @@ config = None
 def handle_record_begin():
     """Forward internal bus message to external bus."""
     LOG.info("Begin Recording...")
-    bus.emit(Message('recognizer_loop:record_begin'))
+    context = {'client_name': 'mycroft_listener',
+               'source': 'audio'}
+    bus.emit(Message('recognizer_loop:record_begin', context=context))
 
 
 def handle_record_end():
     """Forward internal bus message to external bus."""
     LOG.info("End Recording...")
-    bus.emit(Message('recognizer_loop:record_end'))
+    context = {'client_name': 'mycroft_listener',
+               'source': 'audio'}
+    bus.emit(Message('recognizer_loop:record_end', context=context))
 
 
 def handle_no_internet():
     LOG.debug("Notifying enclosure of no internet connection")
-    bus.emit(Message('enclosure.notify.no_internet'))
+    context = {'client_name': 'mycroft_listener',
+               'source': 'audio'}
+    bus.emit(Message('enclosure.notify.no_internet', context=context))
 
 
 def handle_awoken():
     """Forward mycroft.awoken to the messagebus."""
     LOG.info("Listener is now Awake: ")
-    bus.emit(Message('mycroft.awoken'))
+    context = {'client_name': 'mycroft_listener',
+               'source': 'audio'}
+    bus.emit(Message('mycroft.awoken', context=context))
 
 
 def handle_wakeword(event):
@@ -72,21 +80,27 @@ def handle_utterance(event):
 
 
 def handle_unknown():
-    bus.emit(Message('mycroft.speech.recognition.unknown'))
+    context = {'client_name': 'mycroft_listener',
+               'source': 'audio'}
+    bus.emit(Message('mycroft.speech.recognition.unknown', context=context))
 
 
 def handle_speak(event):
     """
         Forward speak message to message bus.
     """
-    bus.emit(Message('speak', event))
+    context = {'client_name': 'mycroft_listener',
+               'source': 'audio'}
+    bus.emit(Message('speak', event, context))
 
 
 def handle_complete_intent_failure(event):
     """Extreme backup for answering completely unhandled intent requests."""
     LOG.info("Failed to find intent.")
     data = {'utterance': dialog.get('not.loaded')}
-    bus.emit(Message('speak', data))
+    context = {'client_name': 'mycroft_listener',
+               'source': 'audio'}
+    bus.emit(Message('speak', data, context))
 
 
 def handle_sleep(event):

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -62,7 +62,9 @@ def handle_wakeword(event):
 
 def handle_utterance(event):
     LOG.info("Utterance: " + str(event['utterances']))
-    context = {'client_name': 'mycroft_listener'}
+    context = {'client_name': 'mycroft_listener',
+               'source': 'audio',
+               'destination': ["skills"]}
     if 'ident' in event:
         ident = event.pop('ident')
         context['ident'] = ident

--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -416,6 +416,11 @@ def rebuild_filtered_log():
 
 def handle_speak(event):
     global chat
+    # if the message is targeted and cli is not the target ignore utterance
+    if (event.context and 'destination' in event.context and
+            event.context['destination'] and
+            'cli' not in event.context['destination']):
+        return
     utterance = event.data.get('utterance')
     utterance = TTS.remove_ssml(utterance)
     if bSimple:
@@ -429,6 +434,11 @@ def handle_utterance(event):
     global chat
     global history
     utterance = event.data.get('utterances')[0]
+    # if the message is targeted and cli is not the target ignore utterance
+    if (event.context and 'destination' in event.context and
+            event.context['destination'] and
+            'cli' not in event.context['destination']):
+        return
     history.append(utterance)
     chat.append(utterance)
     set_screen_dirty()
@@ -1319,7 +1329,11 @@ def gui_main(stdscr):
                     # Treat this as an utterance
                     bus.emit(Message("recognizer_loop:utterance",
                                      {'utterances': [line.strip()],
-                                      'lang': config.get('lang', 'en-us')}))
+                                      'lang': config.get('lang', 'en-us')},
+                                     {'client_name': 'mycroft_cli',
+                                      'source': 'cli',
+                                      'destination': ["skills"]}
+                                     ))
                 hist_idx = -1
                 line = ""
             elif code == 16 or code == 545:  # Ctrl+P or Ctrl+Left (Previous)
@@ -1409,7 +1423,10 @@ def simple_cli():
             print("Input (Ctrl+C to quit):")
             line = sys.stdin.readline()
             bus.emit(Message("recognizer_loop:utterance",
-                             {'utterances': [line.strip()]}))
+                             {'utterances': [line.strip()]},
+                             {'client_name': 'mycroft_simple_cli',
+                              'source': 'cli',
+                              'destination': ["skills"]}))
     except KeyboardInterrupt as e:
         # User hit Ctrl+C to quit
         print("")

--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -1321,7 +1321,7 @@ def gui_main(stdscr):
                                      {'utterances': [line.strip()],
                                       'lang': config.get('lang', 'en-us')},
                                      {'client_name': 'mycroft_cli',
-                                      'source': 'cli',
+                                      'source': 'debug_cli',
                                       'destination': ["skills"]}
                                      ))
                 hist_idx = -1
@@ -1415,7 +1415,7 @@ def simple_cli():
             bus.emit(Message("recognizer_loop:utterance",
                              {'utterances': [line.strip()]},
                              {'client_name': 'mycroft_simple_cli',
-                              'source': 'cli',
+                              'source': 'debug_cli',
                               'destination': ["skills"]}))
     except KeyboardInterrupt as e:
         # User hit Ctrl+C to quit

--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -416,11 +416,6 @@ def rebuild_filtered_log():
 
 def handle_speak(event):
     global chat
-    # if the message is targeted and cli is not the target ignore utterance
-    if (event.context and 'destination' in event.context and
-            event.context['destination'] and
-            'cli' not in event.context['destination']):
-        return
     utterance = event.data.get('utterance')
     utterance = TTS.remove_ssml(utterance)
     if bSimple:
@@ -434,11 +429,6 @@ def handle_utterance(event):
     global chat
     global history
     utterance = event.data.get('utterances')[0]
-    # if the message is targeted and cli is not the target ignore utterance
-    if (event.context and 'destination' in event.context and
-            event.context['destination'] and
-            'cli' not in event.context['destination']):
-        return
     history.append(utterance)
     chat.append(utterance)
     set_screen_dirty()

--- a/mycroft/enclosure/api.py
+++ b/mycroft/enclosure/api.py
@@ -55,45 +55,54 @@ class EnclosureAPI:
         Typically this would be represented by the eyes being 'open'
         and the mouth reset to its default (smile or blank).
         """
-        self.bus.emit(Message("enclosure.reset"))
+        self.bus.emit(Message("enclosure.reset",
+                              context={"destination": ["enclosure"]}))
 
     def system_reset(self):
         """The enclosure hardware should reset any CPUs, etc."""
-        self.bus.emit(Message("enclosure.system.reset"))
+        self.bus.emit(Message("enclosure.system.reset",
+                              context={"destination": ["enclosure"]}))
 
     def system_mute(self):
         """Mute (turn off) the system speaker."""
-        self.bus.emit(Message("enclosure.system.mute"))
+        self.bus.emit(Message("enclosure.system.mute",
+                              context={"destination": ["enclosure"]}))
 
     def system_unmute(self):
         """Unmute (turn on) the system speaker."""
-        self.bus.emit(Message("enclosure.system.unmute"))
+        self.bus.emit(Message("enclosure.system.unmute",
+                              context={"destination": ["enclosure"]}))
 
     def system_blink(self, times):
         """The 'eyes' should blink the given number of times.
         Args:
             times (int): number of times to blink
         """
-        self.bus.emit(Message("enclosure.system.blink", {'times': times}))
+        self.bus.emit(Message("enclosure.system.blink", {'times': times},
+                              context={"destination": ["enclosure"]}))
 
     def eyes_on(self):
         """Illuminate or show the eyes."""
-        self.bus.emit(Message("enclosure.eyes.on"))
+        self.bus.emit(Message("enclosure.eyes.on",
+                              context={"destination": ["enclosure"]}))
 
     def eyes_off(self):
         """Turn off or hide the eyes."""
-        self.bus.emit(Message("enclosure.eyes.off"))
+        self.bus.emit(Message("enclosure.eyes.off",
+                              context={"destination": ["enclosure"]}))
 
     def eyes_blink(self, side):
         """Make the eyes blink
         Args:
             side (str): 'r', 'l', or 'b' for 'right', 'left' or 'both'
         """
-        self.bus.emit(Message("enclosure.eyes.blink", {'side': side}))
+        self.bus.emit(Message("enclosure.eyes.blink", {'side': side},
+                              context={"destination": ["enclosure"]}))
 
     def eyes_narrow(self):
         """Make the eyes look narrow, like a squint"""
-        self.bus.emit(Message("enclosure.eyes.narrow"))
+        self.bus.emit(Message("enclosure.eyes.narrow",
+                              context={"destination": ["enclosure"]}))
 
     def eyes_look(self, side):
         """Make the eyes look to the given side
@@ -104,7 +113,8 @@ class EnclosureAPI:
                         'd' for down
                         'c' for crossed
         """
-        self.bus.emit(Message("enclosure.eyes.look", {'side': side}))
+        self.bus.emit(Message("enclosure.eyes.look", {'side': side},
+                              context={"destination": ["enclosure"]}))
 
     def eyes_color(self, r=255, g=255, b=255):
         """Change the eye color to the given RGB color
@@ -114,7 +124,8 @@ class EnclosureAPI:
             b (int): 0-255, blue value
         """
         self.bus.emit(Message("enclosure.eyes.color",
-                              {'r': r, 'g': g, 'b': b}))
+                              {'r': r, 'g': g, 'b': b},
+                              context={"destination": ["enclosure"]}))
 
     def eyes_setpixel(self, idx, r=255, g=255, b=255):
         """Set individual pixels of the Mark 1 neopixel eyes
@@ -127,7 +138,8 @@ class EnclosureAPI:
         if idx < 0 or idx > 23:
             raise ValueError('idx ({}) must be between 0-23'.format(str(idx)))
         self.bus.emit(Message("enclosure.eyes.setpixel",
-                              {'idx': idx, 'r': r, 'g': g, 'b': b}))
+                              {'idx': idx, 'r': r, 'g': g, 'b': b},
+                              context={"destination": ["enclosure"]}))
 
     def eyes_fill(self, percentage):
         """Use the eyes as a type of progress meter
@@ -138,23 +150,27 @@ class EnclosureAPI:
             raise ValueError('percentage ({}) must be between 0-100'.
                              format(str(percentage)))
         self.bus.emit(Message("enclosure.eyes.fill",
-                              {'percentage': percentage}))
+                              {'percentage': percentage},
+                              context={"destination": ["enclosure"]}))
 
     def eyes_brightness(self, level=30):
         """Set the brightness of the eyes in the display.
         Args:
             level (int): 1-30, bigger numbers being brighter
         """
-        self.bus.emit(Message("enclosure.eyes.level", {'level': level}))
+        self.bus.emit(Message("enclosure.eyes.level", {'level': level},
+                              context={"destination": ["enclosure"]}))
 
     def eyes_reset(self):
         """Restore the eyes to their default (ready) state."""
-        self.bus.emit(Message("enclosure.eyes.reset"))
+        self.bus.emit(Message("enclosure.eyes.reset",
+                              context={"destination": ["enclosure"]}))
 
     def eyes_spin(self):
         """Make the eyes 'roll'
         """
-        self.bus.emit(Message("enclosure.eyes.spin"))
+        self.bus.emit(Message("enclosure.eyes.spin",
+                              context={"destination": ["enclosure"]}))
 
     def eyes_timed_spin(self, length):
         """Make the eyes 'roll' for the given time.
@@ -172,31 +188,37 @@ class EnclosureAPI:
         if volume < 0 or volume > 11:
             raise ValueError('volume ({}) must be between 0-11'.
                              format(str(volume)))
-        self.bus.emit(Message("enclosure.eyes.volume", {'volume': volume}))
+        self.bus.emit(Message("enclosure.eyes.volume", {'volume': volume},
+                              context={"destination": ["enclosure"]}))
 
     def mouth_reset(self):
         """Restore the mouth display to normal (blank)"""
-        self.bus.emit(Message("enclosure.mouth.reset"))
+        self.bus.emit(Message("enclosure.mouth.reset",
+                              context={"destination": ["enclosure"]}))
         self.display_manager.set_active(self.name)
 
     def mouth_talk(self):
         """Show a generic 'talking' animation for non-synched speech"""
-        self.bus.emit(Message("enclosure.mouth.talk"))
+        self.bus.emit(Message("enclosure.mouth.talk",
+                              context={"destination": ["enclosure"]}))
         self.display_manager.set_active(self.name)
 
     def mouth_think(self):
         """Show a 'thinking' image or animation"""
-        self.bus.emit(Message("enclosure.mouth.think"))
+        self.bus.emit(Message("enclosure.mouth.think",
+                              context={"destination": ["enclosure"]}))
         self.display_manager.set_active(self.name)
 
     def mouth_listen(self):
         """Show a 'thinking' image or animation"""
-        self.bus.emit(Message("enclosure.mouth.listen"))
+        self.bus.emit(Message("enclosure.mouth.listen",
+                              context={"destination": ["enclosure"]}))
         self.display_manager.set_active(self.name)
 
     def mouth_smile(self):
         """Show a 'smile' image or animation"""
-        self.bus.emit(Message("enclosure.mouth.smile"))
+        self.bus.emit(Message("enclosure.mouth.smile",
+                              context={"destination": ["enclosure"]}))
         self.display_manager.set_active(self.name)
 
     def mouth_viseme(self, start, viseme_pairs):
@@ -217,7 +239,8 @@ class EnclosureAPI:
                                  6 = shape for sounds like 'oy' or 'ao'
         """
         self.bus.emit(Message("enclosure.mouth.viseme_list",
-                              {"start": start, "visemes": viseme_pairs}))
+                              {"start": start, "visemes": viseme_pairs},
+                              context={"destination": ["enclosure"]}))
 
     def mouth_text(self, text=""):
         """Display text (scrolling as needed)
@@ -225,7 +248,8 @@ class EnclosureAPI:
             text (str): text string to display
         """
         self.display_manager.set_active(self.name)
-        self.bus.emit(Message("enclosure.mouth.text", {'text': text}))
+        self.bus.emit(Message("enclosure.mouth.text", {'text': text},
+                              context={"destination": ["enclosure"]}))
 
     def mouth_display(self, img_code="", x=0, y=0, refresh=True):
         """Display images on faceplate. Currently supports images up to 16x8,
@@ -245,7 +269,8 @@ class EnclosureAPI:
                               {'img_code': img_code,
                                'xOffset': x,
                                'yOffset': y,
-                               'clearPrev': refresh}))
+                               'clearPrev': refresh},
+                              context={"destination": ["enclosure"]}))
 
     def mouth_display_png(self, image_absolute_path,
                           invert=False, x=0, y=0, refresh=True):
@@ -267,7 +292,8 @@ class EnclosureAPI:
                                'xOffset': x,
                                'yOffset': y,
                                'invert': invert,
-                               'clearPrev': refresh}))
+                               'clearPrev': refresh},
+                              context={"destination": ["enclosure"]}))
 
     def weather_display(self, img_code, temp):
         """Show a the temperature and a weather icon
@@ -286,12 +312,15 @@ class EnclosureAPI:
         """
         self.display_manager.set_active(self.name)
         self.bus.emit(Message("enclosure.weather.display",
-                              {'img_code': img_code, 'temp': temp}))
+                              {'img_code': img_code, 'temp': temp},
+                              context={"destination": ["enclosure"]}))
 
     def activate_mouth_events(self):
         """Enable movement of the mouth with speech"""
-        self.bus.emit(Message('enclosure.mouth.events.activate'))
+        self.bus.emit(Message('enclosure.mouth.events.activate',
+                              context={"destination": ["enclosure"]}))
 
     def deactivate_mouth_events(self):
         """Disable movement of the mouth with speech"""
-        self.bus.emit(Message('enclosure.mouth.events.deactivate'))
+        self.bus.emit(Message('enclosure.mouth.events.deactivate',
+                              context={"destination": ["enclosure"]}))

--- a/mycroft/enclosure/api.py
+++ b/mycroft/enclosure/api.py
@@ -144,7 +144,7 @@ class EnclosureAPI:
     def eyes_fill(self, percentage):
         """Use the eyes as a type of progress meter
         Args:
-            amount (int): 0-49 fills the right eye, 50-100 also covers left
+            percentage (int): 0-49 fills the right eye, 50-100 also covers left
         """
         if percentage < 0 or percentage > 100:
             raise ValueError('percentage ({}) must be between 0-100'.

--- a/mycroft/messagebus/message.py
+++ b/mycroft/messagebus/message.py
@@ -14,7 +14,7 @@
 #
 import json
 import re
-
+import inspect
 from mycroft.util.parse import normalize
 
 
@@ -182,3 +182,14 @@ class Message:
                 # Substitute only whole words matching the token
                 utt = re.sub(r'\b' + token.get("key", "") + r"\b", "", utt)
         return normalize(utt)
+
+
+def dig_for_message():
+    """Dig Through the stack for message."""
+    stack = inspect.stack()
+    # Limit search to 10 frames back
+    stack = stack if len(stack) < 10 else stack[:10]
+    local_vars = [frame[0].f_locals for frame in stack]
+    for l in local_vars:
+        if 'message' in l and isinstance(l['message'], Message):
+            return l['message']

--- a/mycroft/messagebus/message.py
+++ b/mycroft/messagebus/message.py
@@ -74,16 +74,33 @@ class Message:
                        obj.get('data') or {},
                        obj.get('context') or {})
 
+    def forward(self, msg_type, data=None):
+        """ Keep context and forward message
+
+        This will take the same parameters as a message object but use
+        the current message object as a reference.  It will copy the context
+        from the existing message object.
+
+        Args:
+            msg_type (str): type of message
+            data (dict): data for message
+
+        Returns:
+            Message: Message object to be used on the reply to the message
+        """
+        data = data or {}
+        return Message(msg_type, data, context=self.context)
+
     def reply(self, msg_type, data=None, context=None):
         """Construct a reply message for a given message
 
         This will take the same parameters as a message object but use
         the current message object as a reference.  It will copy the context
         from the existing message object and add any context passed in to
-        the function.  Check for a target passed in to the function from
-        the data object and add that to the context as a target.  If the
-        context has a client name then that will become the target in the
-        context.  The new message will then have data passed in plus the
+        the function.  Check for a destination passed in to the function from
+        the data object and add that to the context as a destination.  If the
+        context has a source then that will be swapped with the destination
+        in the context.  The new message will then have data passed in plus the
         new context generated.
 
         Args:
@@ -100,10 +117,12 @@ class Message:
         new_context = self.context
         for key in context:
             new_context[key] = context[key]
-        if 'target' in data:
-            new_context['target'] = data['target']
-        elif 'client_name' in context:
-            context['target'] = context['client_name']
+        if 'destination' in data:
+            new_context['destination'] = data['destination']
+        if 'source' in new_context and 'destination' in new_context:
+            s = new_context['destination']
+            new_context['destination'] = new_context['source']
+            new_context['source'] = s
         return Message(msg_type, data, context=new_context)
 
     def response(self, data=None, context=None):

--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -143,7 +143,7 @@ class CommonPlaySkill(MycroftSkill, ABC):
         # Stop any currently playing audio
         if self.audioservice.is_playing:
             self.audioservice.stop()
-        self.bus.emit(Message("mycroft.stop"))
+        self.bus.emit(message.forward("mycroft.stop"))
 
         # Save for CPS_play() later, e.g. if phrase includes modifiers like
         # "... on the chromecast"

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -106,16 +106,16 @@ class EventScheduler(Thread):
                 current_time = time.time()
                 e = self.events[event]
                 # Get scheduled times that has passed
-                passed = [(t, r, d) for (t, r, d) in e if t <= current_time]
+                passed = [(t, r, d, c) for (t, r, d, c) in e if t <= current_time]
                 # and remaining times that we're still waiting for
-                remaining = [(t, r, d) for t, r, d in e if t > current_time]
+                remaining = [(t, r, d, c) for t, r, d, c in e if t > current_time]
                 # Trigger registered methods
-                for sched_time, repeat, data in passed:
-                    pending_messages.append(Message(event, data))
+                for sched_time, repeat, data, context in passed:
+                    pending_messages.append(Message(event, data, context))
                     # if this is a repeated event add a new trigger time
                     if repeat:
                         next_time = repeat_time(sched_time, repeat)
-                        remaining.append((next_time, repeat, data))
+                        remaining.append((next_time, repeat, data, context))
                 # update list of events
                 self.events[event] = remaining
 
@@ -126,7 +126,7 @@ class EventScheduler(Thread):
         for msg in pending_messages:
             self.bus.emit(msg)
 
-    def schedule_event(self, event, sched_time, repeat=None, data=None):
+    def schedule_event(self, event, sched_time, repeat=None, data=None, context=None):
         """Add event to pending event schedule.
 
         Arguments:
@@ -134,6 +134,7 @@ class EventScheduler(Thread):
             sched_time ([type]): [description]
             repeat ([type], optional): Defaults to None. [description]
             data ([type], optional): Defaults to None. [description]
+            context (dict, optional): message context to send when the handler is called
         """
         data = data or {}
         with self.event_lock:
@@ -146,7 +147,7 @@ class EventScheduler(Thread):
                           .format(event))
             else:
                 # add received event and time
-                event_list.append((sched_time, repeat, data))
+                event_list.append((sched_time, repeat, data, context))
                 self.events[event] = event_list
 
     def schedule_event_handler(self, message):
@@ -163,8 +164,9 @@ class EventScheduler(Thread):
         sched_time = message.data.get('time')
         repeat = message.data.get('repeat')
         data = message.data.get('data')
+        context = message.context
         if event and sched_time:
-            self.schedule_event(event, sched_time, repeat, data)
+            self.schedule_event(event, sched_time, repeat, data, context)
         elif not event:
             LOG.error('Scheduled event name not provided')
         else:
@@ -198,8 +200,8 @@ class EventScheduler(Thread):
         with self.event_lock:
             # if there is an active event with this name
             if len(self.events.get(event, [])) > 0:
-                time, repeat, _ = self.events[event][0]
-                self.events[event][0] = (time, repeat, data)
+                time, repeat, _, context = self.events[event][0]
+                self.events[event][0] = (time, repeat, data, context)
 
     def update_event_handler(self, message):
         """Messagebus interface to the update_event method."""
@@ -283,7 +285,7 @@ class EventSchedulerInterface:
         """
         return str(self.sched_id) + ':' + (name or '')
 
-    def _schedule_event(self, handler, when, data, name, repeat_interval=None):
+    def _schedule_event(self, handler, when, data, name, repeat_interval=None, context=None):
         """Underlying method for schedule_event and schedule_repeating_event.
 
         Takes scheduling information and sends it off on the message bus.
@@ -297,6 +299,7 @@ class EventSchedulerInterface:
             data (dict, optional):  data to send when the handler is called
             name (str, optional):   reference name, must be unique
             repeat_interval (float/int):  time in seconds between calls
+            context (dict, optional): message context to send when the handler is called
 
         """
         if isinstance(when, (int, float)) and when >= 0:
@@ -320,9 +323,9 @@ class EventSchedulerInterface:
                       'repeat': repeat_interval,
                       'data': data}
         self.bus.emit(Message('mycroft.scheduler.schedule_event',
-                              data=event_data))
+                              data=event_data, context=context))
 
-    def schedule_event(self, handler, when, data=None, name=None):
+    def schedule_event(self, handler, when, data=None, name=None, context=None):
         """Schedule a single-shot event.
 
         Arguments:
@@ -335,11 +338,12 @@ class EventSchedulerInterface:
                                    NOTE: This will not warn or replace a
                                    previously scheduled event of the same
                                    name.
+            context (dict, optional): message context to send when the handler is called
         """
-        self._schedule_event(handler, when, data, name)
+        self._schedule_event(handler, when, data, name, context=context)
 
     def schedule_repeating_event(self, handler, when, interval,
-                                 data=None, name=None):
+                                 data=None, name=None, context=None):
         """Schedule a repeating event.
 
         Arguments:
@@ -351,6 +355,7 @@ class EventSchedulerInterface:
             interval (float/int):   time in seconds between calls
             data (dict, optional):  data to send when the handler is called
             name (str, optional):   reference name, must be unique
+            context (dict, optional): message context to send when the handler is called
         """
         # Do not schedule if this event is already scheduled by the skill
         if name not in self.scheduled_repeats:
@@ -358,7 +363,7 @@ class EventSchedulerInterface:
             # from now.
             if not when:
                 when = datetime.now() + timedelta(seconds=interval)
-            self._schedule_event(handler, when, data, name, interval)
+            self._schedule_event(handler, when, data, name, interval, context=context)
         else:
             LOG.debug('The event is already scheduled, cancel previous '
                       'event if this scheduling should replace the last.')

--- a/mycroft/skills/event_scheduler.py
+++ b/mycroft/skills/event_scheduler.py
@@ -106,9 +106,11 @@ class EventScheduler(Thread):
                 current_time = time.time()
                 e = self.events[event]
                 # Get scheduled times that has passed
-                passed = [(t, r, d, c) for (t, r, d, c) in e if t <= current_time]
+                passed = [(t, r, d, c) for
+                          (t, r, d, c) in e if t <= current_time]
                 # and remaining times that we're still waiting for
-                remaining = [(t, r, d, c) for t, r, d, c in e if t > current_time]
+                remaining = [(t, r, d, c) for
+                             t, r, d, c in e if t > current_time]
                 # Trigger registered methods
                 for sched_time, repeat, data, context in passed:
                     pending_messages.append(Message(event, data, context))
@@ -126,7 +128,8 @@ class EventScheduler(Thread):
         for msg in pending_messages:
             self.bus.emit(msg)
 
-    def schedule_event(self, event, sched_time, repeat=None, data=None, context=None):
+    def schedule_event(self, event, sched_time, repeat=None,
+                       data=None, context=None):
         """Add event to pending event schedule.
 
         Arguments:
@@ -134,7 +137,9 @@ class EventScheduler(Thread):
             sched_time ([type]): [description]
             repeat ([type], optional): Defaults to None. [description]
             data ([type], optional): Defaults to None. [description]
-            context (dict, optional): message context to send when the handler is called
+            context (dict, optional): context (dict, optional): message
+                                      context to send when the
+                                      handler is called
         """
         data = data or {}
         with self.event_lock:
@@ -285,7 +290,8 @@ class EventSchedulerInterface:
         """
         return str(self.sched_id) + ':' + (name or '')
 
-    def _schedule_event(self, handler, when, data, name, repeat_interval=None, context=None):
+    def _schedule_event(self, handler, when, data, name,
+                        repeat_interval=None, context=None):
         """Underlying method for schedule_event and schedule_repeating_event.
 
         Takes scheduling information and sends it off on the message bus.
@@ -299,8 +305,8 @@ class EventSchedulerInterface:
             data (dict, optional):  data to send when the handler is called
             name (str, optional):   reference name, must be unique
             repeat_interval (float/int):  time in seconds between calls
-            context (dict, optional): message context to send when the handler is called
-
+            context (dict, optional): message context to send
+                                      when the handler is called
         """
         if isinstance(when, (int, float)) and when >= 0:
             when = datetime.now() + timedelta(seconds=when)
@@ -325,7 +331,8 @@ class EventSchedulerInterface:
         self.bus.emit(Message('mycroft.scheduler.schedule_event',
                               data=event_data, context=context))
 
-    def schedule_event(self, handler, when, data=None, name=None, context=None):
+    def schedule_event(self, handler, when, data=None, name=None,
+                       context=None):
         """Schedule a single-shot event.
 
         Arguments:
@@ -338,7 +345,8 @@ class EventSchedulerInterface:
                                    NOTE: This will not warn or replace a
                                    previously scheduled event of the same
                                    name.
-            context (dict, optional): message context to send when the handler is called
+            context (dict, optional): message context to send
+                                      when the handler is called
         """
         self._schedule_event(handler, when, data, name, context=context)
 
@@ -355,7 +363,8 @@ class EventSchedulerInterface:
             interval (float/int):   time in seconds between calls
             data (dict, optional):  data to send when the handler is called
             name (str, optional):   reference name, must be unique
-            context (dict, optional): message context to send when the handler is called
+            context (dict, optional): message context to send
+                                      when the handler is called
         """
         # Do not schedule if this event is already scheduled by the skill
         if name not in self.scheduled_repeats:
@@ -363,7 +372,8 @@ class EventSchedulerInterface:
             # from now.
             if not when:
                 when = datetime.now() + timedelta(seconds=interval)
-            self._schedule_event(handler, when, data, name, interval, context=context)
+            self._schedule_event(handler, when, data, name, interval,
+                                 context=context)
         else:
             LOG.debug('The event is already scheduled, cancel previous '
                       'event if this scheduling should replace the last.')

--- a/mycroft/skills/fallback_skill.py
+++ b/mycroft/skills/fallback_skill.py
@@ -61,8 +61,8 @@ class FallbackSkill(MycroftSkill):
 
         def handler(message):
             # indicate fallback handling start
-            bus.emit(message.reply("mycroft.skill.handler.start",
-                                   data={'handler': "fallback"}))
+            bus.emit(message.forward("mycroft.skill.handler.start",
+                                     data={'handler': "fallback"}))
 
             stopwatch = Stopwatch()
             handler_name = None
@@ -73,7 +73,7 @@ class FallbackSkill(MycroftSkill):
                         if handler(message):
                             #  indicate completion
                             handler_name = get_handler_name(handler)
-                            bus.emit(message.reply(
+                            bus.emit(message.forward(
                                      'mycroft.skill.handler.complete',
                                      data={'handler': "fallback",
                                            "fallback_handler": handler_name}))
@@ -81,13 +81,13 @@ class FallbackSkill(MycroftSkill):
                     except Exception:
                         LOG.exception('Exception in fallback.')
                 else:  # No fallback could handle the utterance
-                    bus.emit(message.reply('complete_intent_failure'))
+                    bus.emit(message.forward('complete_intent_failure'))
                     warning = "No fallback could handle intent."
                     LOG.warning(warning)
                     #  indicate completion with exception
-                    bus.emit(message.reply('mycroft.skill.handler.complete',
-                                           data={'handler': "fallback",
-                                                 'exception': warning}))
+                    bus.emit(message.forward('mycroft.skill.handler.complete',
+                                             data={'handler': "fallback",
+                                                   'exception': warning}))
 
             # Send timing metric
             if message.context.get('ident'):

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1257,7 +1257,7 @@ class MycroftSkill:
             LOG.error('Failed to stop skill: {}'.format(self.name),
                       exc_info=True)
 
-    def schedule_event(self, handler, when, data=None, name=None):
+    def schedule_event(self, handler, when, data=None, name=None, context=None):
         """Schedule a single-shot event.
 
         Arguments:
@@ -1270,11 +1270,13 @@ class MycroftSkill:
                                    NOTE: This will not warn or replace a
                                    previously scheduled event of the same
                                    name.
+            context (dict, optional): message context to send when the handler is called
         """
-        return self.event_scheduler.schedule_event(handler, when, data, name)
+        context = context or {"skill": self.name}
+        return self.event_scheduler.schedule_event(handler, when, data, name, context=context)
 
     def schedule_repeating_event(self, handler, when, frequency,
-                                 data=None, name=None):
+                                 data=None, name=None, context=None):
         """Schedule a repeating event.
 
         Arguments:
@@ -1286,13 +1288,16 @@ class MycroftSkill:
             frequency (float/int):  time in seconds between calls
             data (dict, optional):  data to send when the handler is called
             name (str, optional):   reference name, must be unique
+            context (dict, optional): message context to send when the handler is called
         """
+        context = context or {"skill": self.name}
         return self.event_scheduler.schedule_repeating_event(
             handler,
             when,
             frequency,
             data,
-            name
+            name,
+            context=context
         )
 
     def update_scheduled_event(self, name, data=None):

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1257,7 +1257,8 @@ class MycroftSkill:
             LOG.error('Failed to stop skill: {}'.format(self.name),
                       exc_info=True)
 
-    def schedule_event(self, handler, when, data=None, name=None, context=None):
+    def schedule_event(self, handler, when, data=None, name=None,
+                       context=None):
         """Schedule a single-shot event.
 
         Arguments:
@@ -1270,10 +1271,13 @@ class MycroftSkill:
                                    NOTE: This will not warn or replace a
                                    previously scheduled event of the same
                                    name.
-            context (dict, optional): message context to send when the handler is called
+            context (dict, optional): context (dict, optional): message
+                                      context to send when the handler
+                                      is called
         """
         context = context or {"skill": self.name}
-        return self.event_scheduler.schedule_event(handler, when, data, name, context=context)
+        return self.event_scheduler.schedule_event(handler, when, data, name,
+                                                   context=context)
 
     def schedule_repeating_event(self, handler, when, frequency,
                                  data=None, name=None, context=None):
@@ -1288,7 +1292,9 @@ class MycroftSkill:
             frequency (float/int):  time in seconds between calls
             data (dict, optional):  data to send when the handler is called
             name (str, optional):   reference name, must be unique
-            context (dict, optional): message context to send when the handler is called
+            context (dict, optional): context (dict, optional): message
+                                      context to send when the handler
+                                      is called
         """
         context = context or {"skill": self.name}
         return self.event_scheduler.schedule_repeating_event(

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -15,7 +15,6 @@
 """Common functionality relating to the implementation of mycroft skills."""
 
 from copy import deepcopy
-import inspect
 import sys
 import re
 import traceback
@@ -34,7 +33,7 @@ from mycroft.enclosure.gui import SkillGUI
 from mycroft.configuration import Configuration
 from mycroft.dialog import load_dialogs
 from mycroft.filesystem import FileSystemAccess
-from mycroft.messagebus.message import Message
+from mycroft.messagebus.message import Message, dig_for_message
 from mycroft.metrics import report_metric
 from mycroft.util import (
     resolve_resource_file,
@@ -100,17 +99,6 @@ def get_non_properties(obj):
         return np
 
     return set(check_class(obj.__class__))
-
-
-def dig_for_message():
-    """Dig Through the stack for message."""
-    stack = inspect.stack()
-    # Limit search to 10 frames back
-    stack = stack if len(stack) < 10 else stack[:10]
-    local_vars = [frame[0].f_locals for frame in stack]
-    for l in local_vars:
-        if 'message' in l and isinstance(l['message'], Message):
-            return l['message']
 
 
 class MycroftSkill:

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -811,7 +811,7 @@ class MycroftSkill:
             if handler_info:
                 # Indicate that the skill handler is starting if requested
                 msg_type = handler_info + '.start'
-                self.bus.emit(message.reply(msg_type, skill_data))
+                self.bus.emit(message.forward(msg_type, skill_data))
 
         def on_end(message):
             """Store settings and indicate that the skill handler has completed
@@ -821,7 +821,7 @@ class MycroftSkill:
                 self._initial_settings = self.settings
             if handler_info:
                 msg_type = handler_info + '.complete'
-                self.bus.emit(message.reply(msg_type, skill_data))
+                self.bus.emit(message.forward(msg_type, skill_data))
 
         wrapper = create_wrapper(handler, self.skill_id, on_start, on_end,
                                  on_error)
@@ -1080,7 +1080,8 @@ class MycroftSkill:
         data = {'utterance': utterance,
                 'expect_response': expect_response}
         message = dig_for_message()
-        m = message.reply("speak", data) if message else Message("speak", data)
+        m = message.forward("speak", data) if message \
+            else Message("speak", data)
         self.bus.emit(m)
 
         if wait:

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1263,7 +1263,8 @@ class MycroftSkill:
                                       context to send when the handler
                                       is called
         """
-        context = context or {"skill": self.name}
+        message = dig_for_message()
+        context = context or message.context if message else {}
         return self.event_scheduler.schedule_event(handler, when, data, name,
                                                    context=context)
 
@@ -1284,7 +1285,8 @@ class MycroftSkill:
                                       context to send when the handler
                                       is called
         """
-        context = context or {"skill": self.name}
+        message = dig_for_message()
+        context = context or message.context if message else {}
         return self.event_scheduler.schedule_repeating_event(
             handler,
             when,

--- a/test/unittests/skills/test_event_scheduler.py
+++ b/test/unittests/skills/test_event_scheduler.py
@@ -79,7 +79,7 @@ class TestEventScheduler(unittest.TestCase):
 
         # Make sure the dump method wasn't called with test-repeat
         self.assertEqual(mock_dump.call_args[0][0],
-                         {'test': [(900000000000, None, {})]})
+                         {'test': [(900000000000, None, {}, None)]})
 
     @patch('threading.Thread')
     @patch('json.load')


### PR DESCRIPTION
I could swear i made this PR before, but could not find it so here it goes again.

This is needed for the hive mind

# Description
The speech handling now checks the message context if it's the intended target for the message and will only speak in the following conditions:

- Explicitly targeted i.e. the destination is "audio"
- destination is set to None
- destination is missing completely

The idea is that for example when the android app is used to access Mycroft the device at home shouldn't start to speak.

# Targeting Theory

The context target parameter in the original message can be set to list with any number of intended targets:

```python
bus.emit(Message('recognizer_loop:utterance', data, 
				 context={'destination': ['audio', 'kde'],
						  'source': "remote_service"))
```

A missing destination or if the destination is set to None is interpreted as a multicast and should trigger all output capable processes (be it the mycroft-audio process, a web-interface, the KDE plasmoid or maybe the android app)

## Messages

- new message.forward method, keeps previous context.
	- message continues going to same destination
- message.reply method now swaps "source" with "destination"
	- message goes back to source

### Inside mycroft-core
- stt / cli will use "audio" or "debug_cli" as source
- intent service will .reply to utterance message
- all skill/intent service messages are .forward (from previous intent service .reply)
- cli is for debug, will print all utterances
- audio will check if "audio" or "debug_cli" is the destination

## How to test

- STT utterances trigger TTS
- Cli utterances trigger TTS
- [Remote Clients](https://github.com/JarbasAl/hive_mind) do not trigger TTS
