### PR TITLE
Add tzinfo to extracted datetime

### DIFF
--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -209,8 +209,8 @@ def extract_datetime(text, anchorDate=None, lang=None, default_time=None):
         ... )
         None
     """
-    ret = lingua_franca.parse.extract_datetime(text, anchorDate, lang,
-                                               default_time)
+    ret = lingua_franca.parse.extract_datetime(text, anchorDate or now_local(),
+                                               lang, default_time)
 
     # TODO: When default skills work with the documented behavour below needs
     # to be removed.

--- a/test/unittests/util/test_parse.py
+++ b/test/unittests/util/test_parse.py
@@ -26,6 +26,7 @@ from mycroft.util.parse import normalize
 from mycroft.util.lang.parse_en import _ReplaceableNumber, \
     _extract_whole_number_with_text_en, _tokenize, _Token, \
     _extract_decimal_with_text_en
+from mycroft.util.time import default_timezone
 
 
 class TestFuzzyMatch(unittest.TestCase):
@@ -143,6 +144,12 @@ class TestNormalize(unittest.TestCase):
         self.assertEqual(extract_number("a couple hundred beers"), 200)
         self.assertEqual(extract_number("a couple thousand beers"), 2000)
         self.assertEqual(extract_number("100%"), 100)
+
+    def test_extract_datetime(self):
+        """Check that extract_datetime returns the expected timezone."""
+        tz = default_timezone()
+        dt, _ = extract_datetime("today")
+        self.assertEqual(tz, dt.tzinfo)
 
     def test_extract_duration_en(self):
         self.assertEqual(extract_duration("10 seconds"),


### PR DESCRIPTION
## Description
Lingua-franca returns the extracted datetime without the datetime from
the device info. This needs to be added by core through an "anchorDate" specifying the current time (including timezone info).

## How to test
Set your timezone to Kansas City run the skill tester for the latest alarm skill version and assure the tests passes.

## Contributor license agreement signed?
CLA [ Yes ]
