### PR TITLE
intent api

### DIFF
--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -555,7 +555,7 @@ class IntentService:
                                     {"skills": self.skill_names}))
 
     def handle_get_active_skills(self, message):
-        self.bus.emit(message.reply("intent.service.skills.reply",
+        self.bus.emit(message.reply("intent.service.active_skills.reply",
                                     {"skills": [s[0] for s in
                                                 self.active_skills]}))
 

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -769,9 +769,11 @@ class IntentApi:
                 entities.append({"name": ent["name"], "samples": samples})
         return entities
 
-    def get_keyword_manifest(self):
+    def get_keywords_manifest(self):
         padatious = self.get_entities_manifest()
         adapt = self.get_vocab_manifest()
+        regex = self.get_regex_manifest()
         return {"adapt": adapt,
-                "padatious": padatious}
+                "padatious": padatious,
+                "regex": regex}
 

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 import time
-from os.path import isfile
 from adapt.context import ContextManagerFrame
 from adapt.engine import IntentDeterminationEngine
 from adapt.intent import IntentBuilder
@@ -26,8 +25,6 @@ from mycroft.util.parse import normalize
 from mycroft.metrics import report_timing, Stopwatch
 from mycroft.skills.padatious_service import PadatiousService
 from .intent_service_interface import open_intent_envelope
-from mycroft.messagebus.client import MessageBusClient
-from mycroft.util import create_daemon
 
 
 class AdaptIntent(IntentBuilder):
@@ -119,7 +116,7 @@ class ContextManager:
                               relevant_frames[i].entities]
             for entity in frame_entities:
                 entity['confidence'] = entity.get('confidence', 1.0) \
-                    / (2.0 + depth)
+                                       / (2.0 + depth)
             context += frame_entities
 
             # Update depth
@@ -184,6 +181,7 @@ class IntentService:
 
         def add_active_skill_handler(message):
             self.add_active_skill(message.data['skill_id'])
+
         self.bus.on('active_skill_request', add_active_skill_handler)
         self.active_skills = []  # [skill_id , timestamp]
         self.converse_timeout = 5  # minutes to prune active_skills
@@ -197,9 +195,11 @@ class IntentService:
         self.bus.on('intent.service.adapt.get', self.handle_get_adapt)
         self.bus.on('intent.service.intent.get', self.handle_get_intent)
         self.bus.on('intent.service.skills.get', self.handle_get_skills)
-        self.bus.on('intent.service.active_skills.get', self.handle_get_active_skills)
+        self.bus.on('intent.service.active_skills.get',
+                    self.handle_get_active_skills)
         self.bus.on('intent.service.adapt.manifest.get', self.handle_manifest)
-        self.bus.on('intent.service.adapt.vocab.manifest.get', self.handle_vocab_manifest)
+        self.bus.on('intent.service.adapt.vocab.manifest.get',
+                    self.handle_vocab_manifest)
 
     def update_skill_name_dict(self, message):
         """
@@ -355,8 +355,8 @@ class IntentService:
                     for utt in combined:
                         _intent = PadatiousService.instance.calc_intent(utt)
                         if _intent:
-                            best = padatious_intent.conf if padatious_intent\
-                                        else 0.0
+                            best = padatious_intent.conf if padatious_intent \
+                                else 0.0
                             if best < _intent.conf:
                                 padatious_intent = _intent
                     LOG.debug("Padatious intent: {}".format(padatious_intent))
@@ -370,7 +370,7 @@ class IntentService:
                               {'intent_type': 'converse'})
                 return
             elif (intent and intent.get('confidence', 0.0) > 0.0 and
-                    not (padatious_intent and padatious_intent.conf >= 0.95)):
+                  not (padatious_intent and padatious_intent.conf >= 0.95)):
                 # Send the message to the Adapt intent's handler unless
                 # Padatious is REALLY sure it was directed at it instead.
                 self.update_context(intent)
@@ -544,7 +544,8 @@ class IntentService:
         # Adapt intent's handler is used unless
         # Padatious is REALLY sure it was directed at it instead.
         padatious_intent = PadatiousService.instance.calc_intent(utterance)
-        if intent is None or (padatious_intent and padatious_intent.conf >= 0.95):
+        if intent is None or (
+                padatious_intent and padatious_intent.conf >= 0.95):
             intent = padatious_intent.__dict__
         self.bus.emit(message.reply("intent.service.intent.reply",
                                     {"intent": intent}))
@@ -555,7 +556,8 @@ class IntentService:
 
     def handle_get_active_skills(self, message):
         self.bus.emit(message.reply("intent.service.skills.reply",
-                                    {"skills": [s[0] for s in self.active_skills]}))
+                                    {"skills": [s[0] for s in
+                                                self.active_skills]}))
 
     def handle_manifest(self, message):
         self.bus.emit(message.reply("intent.service.adapt.manifest",
@@ -564,219 +566,3 @@ class IntentService:
     def handle_vocab_manifest(self, message):
         self.bus.emit(message.reply("intent.service.adapt.vocab.manifest",
                                     {"vocab": self.registered_vocab}))
-
-
-class IntentApi:
-    """
-    Query Intent Service at runtime
-    """
-
-    def __init__(self, bus=None, timeout=5):
-        if bus is None:
-            bus = MessageBusClient()
-            create_daemon(bus.run_forever)
-        self.bus = bus
-        self.timeout = timeout
-        self.bus.on('intent.service.padatious.reply', self._receive_data)
-        self.bus.on('intent.service.adapt.reply', self._receive_data)
-        self.bus.on('intent.service.intent.reply', self._receive_data)
-        self.bus.on('intent.service.skills.reply', self._receive_data)
-        self.bus.on('intent.service.padatious.manifest', self._receive_data)
-        self.bus.on('intent.service.adapt.manifest', self._receive_data)
-        self.bus.on('intent.service.adapt.vocab.manifest', self._receive_data)
-        self.bus.on('intent.service.padatious.entities.manifest', self._receive_data)
-        self._response = None
-        self.waiting = False
-
-    def _receive_data(self, message):
-        self.waiting = False
-        self._response = message.data
-
-    def get_adapt_intent(self, utterance):
-        """ get best adapt intent for utterance """
-        start = time.time()
-        self._response = None
-        self.waiting = True
-        self.bus.emit(Message("intent.service.adapt.get",
-                              {"utterance": utterance},
-                              context={"destination": "intent_service",
-                                       "source": "intent_api"}))
-        while self.waiting and time.time() - start <= self.timeout:
-            time.sleep(0.3)
-        if time.time() - start > self.timeout:
-            LOG.error("Intent Service timed out!")
-            return None
-        return self._response["intent"]
-
-    def get_padatious_intent(self, utterance):
-        """ get best padatious intent for utterance """
-        start = time.time()
-        self._response = None
-        self.waiting = True
-        self.bus.emit(Message("intent.service.padatious.get",
-                              {"utterance": utterance},
-                              context={"destination": "intent_service",
-                                       "source": "intent_api"}))
-        while self.waiting and time.time() - start <= self.timeout:
-            time.sleep(0.3)
-        if time.time() - start > self.timeout:
-            LOG.error("Intent Service timed out!")
-            return None
-        return self._response["intent"]
-
-    def get_intent(self, utterance):
-        """ get best intent for utterance """
-        start = time.time()
-        self._response = None
-        self.waiting = True
-        self.bus.emit(Message("intent.service.intent.get",
-                              {"utterance": utterance},
-                              context={"destination": "intent_service",
-                                       "source": "intent_api"}))
-        while self.waiting and time.time() - start <= self.timeout:
-            time.sleep(0.3)
-        if time.time() - start > self.timeout:
-            LOG.error("Intent Service timed out!")
-            return None
-        return self._response["intent"]
-
-    def get_skills(self):
-        start = time.time()
-        self._response = None
-        self.waiting = True
-        self.bus.emit(Message("intent.service.skills.get",
-                              context={"destination": "intent_service",
-                                       "source": "intent_api"}))
-        while self.waiting and time.time() - start <= self.timeout:
-            time.sleep(0.3)
-        if time.time() - start > self.timeout:
-            LOG.error("Intent Service timed out!")
-            return None
-        return self._response["skills"]
-
-    def get_active_skills(self):
-        start = time.time()
-        self._response = None
-        self.waiting = True
-        self.bus.emit(Message("intent.service.active_skills.get",
-                              context={"destination": "intent_service",
-                                       "source": "intent_api"}))
-        while self.waiting and time.time() - start <= self.timeout:
-            time.sleep(0.3)
-        if time.time() - start > self.timeout:
-            LOG.error("Intent Service timed out!")
-            return None
-        return self._response["skills"]
-
-    def get_adapt_manifest(self):
-        start = time.time()
-        self._response = None
-        self.waiting = True
-        self.bus.emit(Message("intent.service.adapt.manifest.get",
-                              context={"destination": "intent_service",
-                                       "source": "intent_api"}))
-        while self.waiting and time.time() - start <= self.timeout:
-            time.sleep(0.3)
-        if time.time() - start > self.timeout:
-            LOG.error("Intent Service timed out!")
-            return None
-        return self._response["intents"]
-
-    def get_padatious_manifest(self):
-        start = time.time()
-        self._response = None
-        self.waiting = True
-        self.bus.emit(Message("intent.service.padatious.manifest.get",
-                              context={"destination": "intent_service",
-                                       "source": "intent_api"}))
-        while self.waiting and time.time() - start <= self.timeout:
-            time.sleep(0.3)
-        if time.time() - start > self.timeout:
-            LOG.error("Intent Service timed out!")
-            return None
-        return self._response["intents"]
-
-    def get_intent_manifest(self):
-        padatious = self.get_padatious_manifest()
-        adapt = self.get_adapt_manifest()
-        return {"adapt": adapt,
-                "padatious": padatious}
-
-    def get_vocab_manifest(self):
-        start = time.time()
-        self._response = None
-        self.waiting = True
-        self.bus.emit(Message("intent.service.adapt.vocab.manifest.get",
-                              context={"destination": "intent_service",
-                                       "source": "intent_api"}))
-        while self.waiting and time.time() - start <= self.timeout:
-            time.sleep(0.3)
-        if time.time() - start > self.timeout:
-            LOG.error("Intent Service timed out!")
-            return None
-        vocab = {}
-        for voc in self._response["vocab"]:
-            if voc.get("regex"):
-                continue
-            if voc["end"] not in vocab:
-                vocab[voc["end"]] = {"samples": []}
-            vocab[voc["end"]]["samples"].append(voc["start"])
-        return [{"name": voc, "samples": vocab[voc]["samples"]}
-                for voc in vocab]
-
-    def get_regex_manifest(self):
-        start = time.time()
-        self._response = None
-        self.waiting = True
-        self.bus.emit(Message("intent.service.adapt.vocab.manifest.get",
-                              context={"destination": "intent_service",
-                                       "source": "intent_api"}))
-        while self.waiting and time.time() - start <= self.timeout:
-            time.sleep(0.3)
-        if time.time() - start > self.timeout:
-            LOG.error("Intent Service timed out!")
-            return None
-
-        vocab = {}
-        for voc in self._response["vocab"]:
-            if not voc.get("regex"):
-                continue
-            name = voc["regex"].split("(?P<")[-1].split(">")[0]
-            if name not in vocab:
-                vocab[name] = {"samples": []}
-            vocab[name]["samples"].append(voc["regex"])
-        return [{"name": voc, "regexes": vocab[voc]["samples"]}
-                for voc in vocab]
-
-    def get_entities_manifest(self):
-        start = time.time()
-        self._response = None
-        self.waiting = True
-        self.bus.emit(Message("intent.service.padatious.entities.manifest.get",
-                              context={"destination": "intent_service",
-                                       "source": "intent_api"}))
-        while self.waiting and time.time() - start <= self.timeout:
-            time.sleep(0.3)
-        if time.time() - start > self.timeout:
-            LOG.error("Intent Service timed out!")
-            return None
-        entities = []
-        # read files
-        for ent in self._response["entities"]:
-            if isfile(ent["file_name"]):
-                with open(ent["file_name"]) as f:
-                    lines = f.read().replace("(", "").replace(")", "").split("\n")
-                samples = []
-                for l in lines:
-                    samples += [a.strip() for a in l.split("|") if a.strip()]
-                entities.append({"name": ent["name"], "samples": samples})
-        return entities
-
-    def get_keywords_manifest(self):
-        padatious = self.get_entities_manifest()
-        adapt = self.get_vocab_manifest()
-        regex = self.get_regex_manifest()
-        return {"adapt": adapt,
-                "padatious": padatious,
-                "regex": regex}
-

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -532,15 +532,15 @@ class IntentService:
 
     def handle_get_adapt(self, message):
         utterance = message.data["utterance"]
-        intent = self._adapt_intent_match([utterance], [utterance],
-                                          self.language_config["internal"])
+        lang = message.data.get("lang", "en-us")
+        intent = self._adapt_intent_match([utterance], [utterance], lang)
         self.bus.emit(message.reply("intent.service.adapt.reply",
                                     {"intent": intent}))
 
     def handle_get_intent(self, message):
         utterance = message.data["utterance"]
-        intent = self._adapt_intent_match([utterance], [utterance],
-                                          self.language_config["internal"])
+        lang = message.data.get("lang", "en-us")
+        intent = self._adapt_intent_match([utterance], [utterance], lang)
         # Adapt intent's handler is used unless
         # Padatious is REALLY sure it was directed at it instead.
         padatious_intent = PadatiousService.instance.calc_intent(utterance)

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -544,7 +544,7 @@ class IntentService:
         # Adapt intent's handler is used unless
         # Padatious is REALLY sure it was directed at it instead.
         padatious_intent = PadatiousService.instance.calc_intent(utterance)
-        if padatious_intent and padatious_intent.conf >= 0.95:
+        if intent is None or (padatious_intent and padatious_intent.conf >= 0.95):
             intent = padatious_intent.__dict__
         self.bus.emit(message.reply("intent.service.intent.reply",
                                     {"intent": intent}))
@@ -568,7 +568,7 @@ class IntentService:
 
 class IntentApi:
     """
-    NOTE: works only in internal language, you need to manually translate otherwise
+    Query Intent Service at runtime
     """
 
     def __init__(self, bus=None, timeout=5):
@@ -593,6 +593,7 @@ class IntentApi:
         self._response = message.data
 
     def get_adapt_intent(self, utterance):
+        """ get best adapt intent for utterance """
         start = time.time()
         self._response = None
         self.waiting = True
@@ -608,6 +609,7 @@ class IntentApi:
         return self._response["intent"]
 
     def get_padatious_intent(self, utterance):
+        """ get best padatious intent for utterance """
         start = time.time()
         self._response = None
         self.waiting = True
@@ -623,6 +625,7 @@ class IntentApi:
         return self._response["intent"]
 
     def get_intent(self, utterance):
+        """ get best intent for utterance """
         start = time.time()
         self._response = None
         self.waiting = True

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -533,17 +533,21 @@ class IntentService:
     def handle_get_adapt(self, message):
         utterance = message.data["utterance"]
         lang = message.data.get("lang", "en-us")
-        intent = self._adapt_intent_match([utterance], [utterance], lang)
+        norm = normalize(utterance, lang, remove_articles=False)
+        intent = self._adapt_intent_match([utterance], [norm], lang)
         self.bus.emit(message.reply("intent.service.adapt.reply",
                                     {"intent": intent}))
 
     def handle_get_intent(self, message):
         utterance = message.data["utterance"]
         lang = message.data.get("lang", "en-us")
-        intent = self._adapt_intent_match([utterance], [utterance], lang)
+        norm = normalize(utterance, lang, remove_articles=False)
+        intent = self._adapt_intent_match([utterance], [norm], lang)
         # Adapt intent's handler is used unless
         # Padatious is REALLY sure it was directed at it instead.
         padatious_intent = PadatiousService.instance.calc_intent(utterance)
+        if not padatious_intent and norm != utterance:
+            padatious_intent = PadatiousService.instance.calc_intent(norm)
         if intent is None or (
                 padatious_intent and padatious_intent.conf >= 0.95):
             intent = padatious_intent.__dict__

--- a/mycroft/skills/intent_service_interface.py
+++ b/mycroft/skills/intent_service_interface.py
@@ -15,11 +15,14 @@
 """The intent service interface offers a unified wrapper class for the
 Intent Service. Including both adapt and padatious.
 """
-from os.path import exists
-
+from os.path import exists, isfile
+import time
 from adapt.intent import Intent
 
 from mycroft.messagebus.message import Message
+from mycroft.messagebus.client import MessageBusClient
+from mycroft.util import create_daemon
+from mycroft.util.log import LOG
 
 
 class IntentServiceInterface:
@@ -29,6 +32,7 @@ class IntentServiceInterface:
     for easier interaction with the service. It wraps both the Adapt and
     Precise parts of the intent services.
     """
+
     def __init__(self, bus=None):
         self.bus = bus
         self.registered_intents = []
@@ -157,6 +161,223 @@ class IntentServiceInterface:
                 return intent
         else:
             return None
+
+
+class IntentApi:
+    """
+    Query Intent Service at runtime
+    """
+
+    def __init__(self, bus=None, timeout=5):
+        if bus is None:
+            bus = MessageBusClient()
+            create_daemon(bus.run_forever)
+        self.bus = bus
+        self.timeout = timeout
+        self.bus.on('intent.service.padatious.reply', self._receive_data)
+        self.bus.on('intent.service.adapt.reply', self._receive_data)
+        self.bus.on('intent.service.intent.reply', self._receive_data)
+        self.bus.on('intent.service.skills.reply', self._receive_data)
+        self.bus.on('intent.service.padatious.manifest', self._receive_data)
+        self.bus.on('intent.service.adapt.manifest', self._receive_data)
+        self.bus.on('intent.service.adapt.vocab.manifest', self._receive_data)
+        self.bus.on('intent.service.padatious.entities.manifest',
+                    self._receive_data)
+        self._response = None
+        self.waiting = False
+
+    def _receive_data(self, message):
+        self.waiting = False
+        self._response = message.data
+
+    def get_adapt_intent(self, utterance):
+        """ get best adapt intent for utterance """
+        start = time.time()
+        self._response = None
+        self.waiting = True
+        self.bus.emit(Message("intent.service.adapt.get",
+                              {"utterance": utterance},
+                              context={"destination": "intent_service",
+                                       "source": "intent_api"}))
+        while self.waiting and time.time() - start <= self.timeout:
+            time.sleep(0.3)
+        if time.time() - start > self.timeout:
+            LOG.error("Intent Service timed out!")
+            return None
+        return self._response["intent"]
+
+    def get_padatious_intent(self, utterance):
+        """ get best padatious intent for utterance """
+        start = time.time()
+        self._response = None
+        self.waiting = True
+        self.bus.emit(Message("intent.service.padatious.get",
+                              {"utterance": utterance},
+                              context={"destination": "intent_service",
+                                       "source": "intent_api"}))
+        while self.waiting and time.time() - start <= self.timeout:
+            time.sleep(0.3)
+        if time.time() - start > self.timeout:
+            LOG.error("Intent Service timed out!")
+            return None
+        return self._response["intent"]
+
+    def get_intent(self, utterance):
+        """ get best intent for utterance """
+        start = time.time()
+        self._response = None
+        self.waiting = True
+        self.bus.emit(Message("intent.service.intent.get",
+                              {"utterance": utterance},
+                              context={"destination": "intent_service",
+                                       "source": "intent_api"}))
+        while self.waiting and time.time() - start <= self.timeout:
+            time.sleep(0.3)
+        if time.time() - start > self.timeout:
+            LOG.error("Intent Service timed out!")
+            return None
+        return self._response["intent"]
+
+    def get_skills(self):
+        start = time.time()
+        self._response = None
+        self.waiting = True
+        self.bus.emit(Message("intent.service.skills.get",
+                              context={"destination": "intent_service",
+                                       "source": "intent_api"}))
+        while self.waiting and time.time() - start <= self.timeout:
+            time.sleep(0.3)
+        if time.time() - start > self.timeout:
+            LOG.error("Intent Service timed out!")
+            return None
+        return self._response["skills"]
+
+    def get_active_skills(self):
+        start = time.time()
+        self._response = None
+        self.waiting = True
+        self.bus.emit(Message("intent.service.active_skills.get",
+                              context={"destination": "intent_service",
+                                       "source": "intent_api"}))
+        while self.waiting and time.time() - start <= self.timeout:
+            time.sleep(0.3)
+        if time.time() - start > self.timeout:
+            LOG.error("Intent Service timed out!")
+            return None
+        return self._response["skills"]
+
+    def get_adapt_manifest(self):
+        start = time.time()
+        self._response = None
+        self.waiting = True
+        self.bus.emit(Message("intent.service.adapt.manifest.get",
+                              context={"destination": "intent_service",
+                                       "source": "intent_api"}))
+        while self.waiting and time.time() - start <= self.timeout:
+            time.sleep(0.3)
+        if time.time() - start > self.timeout:
+            LOG.error("Intent Service timed out!")
+            return None
+        return self._response["intents"]
+
+    def get_padatious_manifest(self):
+        start = time.time()
+        self._response = None
+        self.waiting = True
+        self.bus.emit(Message("intent.service.padatious.manifest.get",
+                              context={"destination": "intent_service",
+                                       "source": "intent_api"}))
+        while self.waiting and time.time() - start <= self.timeout:
+            time.sleep(0.3)
+        if time.time() - start > self.timeout:
+            LOG.error("Intent Service timed out!")
+            return None
+        return self._response["intents"]
+
+    def get_intent_manifest(self):
+        padatious = self.get_padatious_manifest()
+        adapt = self.get_adapt_manifest()
+        return {"adapt": adapt,
+                "padatious": padatious}
+
+    def get_vocab_manifest(self):
+        start = time.time()
+        self._response = None
+        self.waiting = True
+        self.bus.emit(Message("intent.service.adapt.vocab.manifest.get",
+                              context={"destination": "intent_service",
+                                       "source": "intent_api"}))
+        while self.waiting and time.time() - start <= self.timeout:
+            time.sleep(0.3)
+        if time.time() - start > self.timeout:
+            LOG.error("Intent Service timed out!")
+            return None
+        vocab = {}
+        for voc in self._response["vocab"]:
+            if voc.get("regex"):
+                continue
+            if voc["end"] not in vocab:
+                vocab[voc["end"]] = {"samples": []}
+            vocab[voc["end"]]["samples"].append(voc["start"])
+        return [{"name": voc, "samples": vocab[voc]["samples"]}
+                for voc in vocab]
+
+    def get_regex_manifest(self):
+        start = time.time()
+        self._response = None
+        self.waiting = True
+        self.bus.emit(Message("intent.service.adapt.vocab.manifest.get",
+                              context={"destination": "intent_service",
+                                       "source": "intent_api"}))
+        while self.waiting and time.time() - start <= self.timeout:
+            time.sleep(0.3)
+        if time.time() - start > self.timeout:
+            LOG.error("Intent Service timed out!")
+            return None
+
+        vocab = {}
+        for voc in self._response["vocab"]:
+            if not voc.get("regex"):
+                continue
+            name = voc["regex"].split("(?P<")[-1].split(">")[0]
+            if name not in vocab:
+                vocab[name] = {"samples": []}
+            vocab[name]["samples"].append(voc["regex"])
+        return [{"name": voc, "regexes": vocab[voc]["samples"]}
+                for voc in vocab]
+
+    def get_entities_manifest(self):
+        start = time.time()
+        self._response = None
+        self.waiting = True
+        self.bus.emit(Message("intent.service.padatious.entities.manifest.get",
+                              context={"destination": "intent_service",
+                                       "source": "intent_api"}))
+        while self.waiting and time.time() - start <= self.timeout:
+            time.sleep(0.3)
+        if time.time() - start > self.timeout:
+            LOG.error("Intent Service timed out!")
+            return None
+        entities = []
+        # read files
+        for ent in self._response["entities"]:
+            if isfile(ent["file_name"]):
+                with open(ent["file_name"]) as f:
+                    lines = f.read().replace("(", "").replace(")", "").split(
+                        "\n")
+                samples = []
+                for l in lines:
+                    samples += [a.strip() for a in l.split("|") if a.strip()]
+                entities.append({"name": ent["name"], "samples": samples})
+        return entities
+
+    def get_keywords_manifest(self):
+        padatious = self.get_entities_manifest()
+        adapt = self.get_vocab_manifest()
+        regex = self.get_regex_manifest()
+        return {"adapt": adapt,
+                "padatious": padatious,
+                "regex": regex}
 
 
 def open_intent_envelope(message):

--- a/mycroft/skills/intent_service_interface.py
+++ b/mycroft/skills/intent_service_interface.py
@@ -191,13 +191,13 @@ class IntentApi:
         self.waiting = False
         self._response = message.data
 
-    def get_adapt_intent(self, utterance):
+    def get_adapt_intent(self, utterance, lang="en-us"):
         """ get best adapt intent for utterance """
         start = time.time()
         self._response = None
         self.waiting = True
         self.bus.emit(Message("intent.service.adapt.get",
-                              {"utterance": utterance},
+                              {"utterance": utterance, "lang": lang},
                               context={"destination": "intent_service",
                                        "source": "intent_api"}))
         while self.waiting and time.time() - start <= self.timeout:
@@ -207,13 +207,13 @@ class IntentApi:
             return None
         return self._response["intent"]
 
-    def get_padatious_intent(self, utterance):
+    def get_padatious_intent(self, utterance, lang="en-us"):
         """ get best padatious intent for utterance """
         start = time.time()
         self._response = None
         self.waiting = True
         self.bus.emit(Message("intent.service.padatious.get",
-                              {"utterance": utterance},
+                              {"utterance": utterance, "lang": lang},
                               context={"destination": "intent_service",
                                        "source": "intent_api"}))
         while self.waiting and time.time() - start <= self.timeout:
@@ -223,13 +223,13 @@ class IntentApi:
             return None
         return self._response["intent"]
 
-    def get_intent(self, utterance):
+    def get_intent(self, utterance, lang="en-us"):
         """ get best intent for utterance """
         start = time.time()
         self._response = None
         self.waiting = True
         self.bus.emit(Message("intent.service.intent.get",
-                              {"utterance": utterance},
+                              {"utterance": utterance, "lang": lang},
                               context={"destination": "intent_service",
                                        "source": "intent_api"}))
         while self.waiting and time.time() - start <= self.timeout:
@@ -239,9 +239,9 @@ class IntentApi:
             return None
         return self._response["intent"]
 
-    def get_skill(self, utterance):
+    def get_skill(self, utterance, lang="en-us"):
         """ get skill that utterance will trigger """
-        intent = self.get_intent(utterance)
+        intent = self.get_intent(utterance, lang)
         if not intent:
             return None
         # retrieve skill from munged intent name

--- a/mycroft/skills/intent_service_interface.py
+++ b/mycroft/skills/intent_service_interface.py
@@ -177,6 +177,7 @@ class IntentApi:
         self.bus.on('intent.service.padatious.reply', self._receive_data)
         self.bus.on('intent.service.adapt.reply', self._receive_data)
         self.bus.on('intent.service.intent.reply', self._receive_data)
+        self.bus.on('intent.service.active_skills.reply', self._receive_data)
         self.bus.on('intent.service.skills.reply', self._receive_data)
         self.bus.on('intent.service.padatious.manifest', self._receive_data)
         self.bus.on('intent.service.adapt.manifest', self._receive_data)

--- a/mycroft/skills/intent_service_interface.py
+++ b/mycroft/skills/intent_service_interface.py
@@ -238,7 +238,15 @@ class IntentApi:
             return None
         return self._response["intent"]
 
-    def get_skills(self):
+    def get_skill(self, utterance):
+        """ get skill that utterance will trigger """
+        intent = self.get_intent(utterance)
+        if not intent:
+            return None
+        # retrieve skill from munged intent name
+        return intent["name"].split(":")[0]
+
+    def get_skills_manifest(self):
         start = time.time()
         self._response = None
         self.waiting = True

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -59,6 +59,9 @@ class PadatiousService(FallbackSkill):
         self.bus.on('detach_intent', self.handle_detach_intent)
         self.bus.on('detach_skill', self.handle_detach_skill)
         self.bus.on('mycroft.skills.initialized', self.train)
+        self.bus.on('intent.service.padatious.get', self.handle_get_padatious)
+        self.bus.on('intent.service.padatious.manifest.get', self.handle_manifest)
+        self.bus.on('intent.service.padatious.entities.manifest.get', self.handle_entity_manifest)
 
         # Call Padatious an an early fallback, looking for a high match intent
         self.register_fallback(self.handle_fallback,
@@ -75,6 +78,7 @@ class PadatiousService(FallbackSkill):
         self.train_time = get_time() + self.train_delay
 
         self.registered_intents = []
+        self.registered_entities = []
 
     def train(self, message=None):
         padatious_single_thread = Configuration.get()[
@@ -146,6 +150,7 @@ class PadatiousService(FallbackSkill):
         self._register_object(message, 'intent', self.container.load_intent)
 
     def register_entity(self, message):
+        self.registered_entities.append(message.data)
         self._register_object(message, 'entity', self.container.load_entity)
 
     def handle_fallback(self, message, threshold=0.8):
@@ -174,6 +179,22 @@ class PadatiousService(FallbackSkill):
 
     def handle_fallback_last_chance(self, message):
         return self.handle_fallback(message, 0.5)
+
+    def handle_get_padatious(self, message):
+        utterance = message.data["utterance"]
+        intent = self.calc_intent(utterance)
+        if intent:
+            intent = intent.__dict__
+        self.bus.emit(message.reply("intent.service.padatious.reply",
+                                    {"intent": intent}))
+
+    def handle_manifest(self, message):
+        self.bus.emit(message.reply("intent.service.padatious.manifest",
+                                    {"intents": self.registered_intents}))
+
+    def handle_entity_manifest(self, message):
+        self.bus.emit(message.reply("intent.service.padatious.entities.manifest",
+                                    {"entities": self.registered_entities}))
 
     # NOTE: This cache will keep a reference to this calss (PadatiousService),
     # but we can live with that since it is used as a singleton.

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -166,7 +166,7 @@ class PadatiousService(FallbackSkill):
 
         if not intent or intent.conf < threshold:
             # Attempt to use normalized() version
-            norm = message.data.get('norm_utt', '')
+            norm = message.data.get('norm_utt', utt)
             if norm != utt:
                 LOG.debug("               alt attempt: " + norm)
                 intent = self.calc_intent(norm)
@@ -184,7 +184,10 @@ class PadatiousService(FallbackSkill):
 
     def handle_get_padatious(self, message):
         utterance = message.data["utterance"]
+        norm = message.data.get('norm_utt', utterance)
         intent = self.calc_intent(utterance)
+        if not intent and norm != utterance:
+            intent = PadatiousService.instance.calc_intent(norm)
         if intent:
             intent = intent.__dict__
         self.bus.emit(message.reply("intent.service.padatious.reply",

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -28,7 +28,7 @@ from mycroft.util.log import LOG
 class PadatiousService(FallbackSkill):
     instance = None
 
-    fallback_tight_match = 5   # Fallback priority for the conf > 0.8 match
+    fallback_tight_match = 5  # Fallback priority for the conf > 0.8 match
     fallback_loose_match = 89  # Fallback priority for the conf > 0.5 match
 
     def __init__(self, bus, service):
@@ -60,8 +60,10 @@ class PadatiousService(FallbackSkill):
         self.bus.on('detach_skill', self.handle_detach_skill)
         self.bus.on('mycroft.skills.initialized', self.train)
         self.bus.on('intent.service.padatious.get', self.handle_get_padatious)
-        self.bus.on('intent.service.padatious.manifest.get', self.handle_manifest)
-        self.bus.on('intent.service.padatious.entities.manifest.get', self.handle_entity_manifest)
+        self.bus.on('intent.service.padatious.manifest.get',
+                    self.handle_manifest)
+        self.bus.on('intent.service.padatious.entities.manifest.get',
+                    self.handle_entity_manifest)
 
         # Call Padatious an an early fallback, looking for a high match intent
         self.register_fallback(self.handle_fallback,
@@ -193,11 +195,12 @@ class PadatiousService(FallbackSkill):
                                     {"intents": self.registered_intents}))
 
     def handle_entity_manifest(self, message):
-        self.bus.emit(message.reply("intent.service.padatious.entities.manifest",
-                                    {"entities": self.registered_entities}))
+        self.bus.emit(
+            message.reply("intent.service.padatious.entities.manifest",
+                          {"entities": self.registered_entities}))
 
     # NOTE: This cache will keep a reference to this calss (PadatiousService),
     # but we can live with that since it is used as a singleton.
-    @lru_cache(maxsize=2)   # 2 catches both raw and normalized utts in cache
+    @lru_cache(maxsize=2)  # 2 catches both raw and normalized utts in cache
     def calc_intent(self, utt):
         return self.container.calc_intent(utt)


### PR DESCRIPTION
IntentAPI, rewrite of MycroftAI/mycroft-core#859 + MycroftAI/mycroft-core#1351

Allows to query intent service from the messagebus

# Usage

```python
from pprint import pprint
from mycroft.intent_service import IntentQueryApi

intents = IntentQueryApi()

# loaded skills
pprint(intents.get_skills_manifest())
pprint(intents.get_active_skills())

# intent parsing
pprint(intents.get_adapt_intent("tell me a joke"))
pprint(intents.get_padatious_intent("tell me a joke"))
pprint(intents.get_intent("create a 10 minutes timer"))  # intent that will trigger

# skill from utterance
pprint(intents.get_skill("say a joke"))
pprint(intents.get_skill("do you rhyme"))

# registered intents
pprint(intents.get_adapt_manifest())
pprint(intents.get_padatious_manifest())
pprint(intents.get_intent_manifest())  # all of the above

# registered vocab
pprint(intents.get_entities_manifest()) # padatious entities / .entity files
pprint(intents.get_vocab_manifest()) # adapt vocab / .voc files
pprint(intents.get_regex_manifest()) # adapt regex / .rx files
pprint(intents.get_keywords_manifest())  # all of the above
```