### PR TITLE
Remove the ConfigurationManager compatibility

### DIFF
--- a/mycroft/configuration/__init__.py
+++ b/mycroft/configuration/__init__.py
@@ -14,10 +14,3 @@
 #
 from .config import Configuration, LocalConf, RemoteConf
 from .locations import SYSTEM_CONFIG, USER_CONFIG
-
-
-# Compatibility
-class ConfigurationManager(Configuration):
-    @staticmethod
-    def instance():
-        return Configuration.get()


### PR DESCRIPTION
## Description
ConfigurationManager has been deprecated since 0.9.4 so it's time to
remove it completely

## Contributor license agreement signed?
CLA [ Yes ]
