### PR TITLE
feat/ read mark1 eye color

### DIFF
--- a/mycroft/client/enclosure/mark1/eyes.py
+++ b/mycroft/client/enclosure/mark1/eyes.py
@@ -46,6 +46,10 @@ class EnclosureEyes:
         self.bus.on('enclosure.eyes.rgb.get', self.handle_get_color)
 
     def handle_get_color(self, message):
+        """Get the eye RGB color for all pixels
+        Returns:
+           (list) list of (r,g,b) tuples for each eye pixel
+        """
         self.bus.emit(message.reply("enclosure.eyes.rgb",
                                     {"pixels": self._current_rgb}))
 

--- a/mycroft/client/enclosure/mark1/eyes.py
+++ b/mycroft/client/enclosure/mark1/eyes.py
@@ -23,6 +23,9 @@ class EnclosureEyes:
     def __init__(self, bus, writer):
         self.bus = bus
         self.writer = writer
+
+        self._num_pixels = 12 * 2
+        self._current_rgb = [(255, 255, 255) for i in range(self._num_pixels)]
         self.__init_events()
 
     def __init_events(self):
@@ -39,6 +42,12 @@ class EnclosureEyes:
         self.bus.on('enclosure.eyes.reset', self.reset)
         self.bus.on('enclosure.eyes.setpixel', self.set_pixel)
         self.bus.on('enclosure.eyes.fill', self.fill)
+
+        self.bus.on('enclosure.eyes.rgb.get', self.handle_get_color)
+
+    def handle_get_color(self, message):
+        self.bus.emit(message.reply("enclosure.eyes.rgb",
+                                    {"pixels": self._current_rgb}))
 
     def on(self, event=None):
         self.writer.write("eyes.on")
@@ -67,6 +76,7 @@ class EnclosureEyes:
             g = int(event.data.get("g", g))
             b = int(event.data.get("b", b))
         color = (r * 65536) + (g * 256) + b
+        self._current_rgb = [(r, g, b) for i in range(self._num_pixels)]
         self.writer.write("eyes.color=" + str(color))
 
     def set_pixel(self, event=None):
@@ -77,6 +87,7 @@ class EnclosureEyes:
             r = int(event.data.get("r", r))
             g = int(event.data.get("g", g))
             b = int(event.data.get("b", b))
+        self._current_rgb[idx] = (r, g, b)
         color = (r * 65536) + (g * 256) + b
         self.writer.write("eyes.set=" + str(idx) + "," + str(color))
 

--- a/mycroft/enclosure/api.py
+++ b/mycroft/enclosure/api.py
@@ -326,11 +326,9 @@ class EnclosureAPI:
                               context={"destination": ["enclosure"]}))
 
     def get_eyes_color(self):
-        """
-        Get the eye RGB color for all pixels
-
-        :returns pixels (list) - list of (r,g,b) tuples for each eye pixel
-
+        """Get the eye RGB color for all pixels
+        Returns:
+           (list) pixels - list of (r,g,b) tuples for each eye pixel
         """
         message = Message("enclosure.eyes.rgb.get",
                           context={"source": "enclosure_api",
@@ -341,11 +339,9 @@ class EnclosureAPI:
         raise TimeoutError("Enclosure took too long to respond")
 
     def get_eyes_pixel_color(self, idx):
-        """
-        Get the RGB color for a specific eye pixel
-
-        :returns (r,g,b) tuples for selected pixel
-
+        """Get the RGB color for a specific eye pixel
+        Returns:
+            (r,g,b) tuples for selected pixel
         """
         if idx < 0 or idx > 23:
             raise ValueError('idx ({}) must be between 0-23'.format(str(idx)))

--- a/mycroft/enclosure/api.py
+++ b/mycroft/enclosure/api.py
@@ -324,3 +324,29 @@ class EnclosureAPI:
         """Disable movement of the mouth with speech"""
         self.bus.emit(Message('enclosure.mouth.events.deactivate',
                               context={"destination": ["enclosure"]}))
+
+    def get_eyes_color(self):
+        """
+        Get the eye RGB color for all pixels
+
+        :returns pixels (list) - list of (r,g,b) tuples for each eye pixel
+
+        """
+        message = Message("enclosure.eyes.rgb.get",
+                          context={"source": "enclosure_api",
+                                   "destination": "enclosure"})
+        response = self.bus.wait_for_response(message, "enclosure.eyes.rgb")
+        if response:
+            return response.data["pixels"]
+        raise TimeoutError("Enclosure took too long to respond")
+
+    def get_eyes_pixel_color(self, idx):
+        """
+        Get the RGB color for a specific eye pixel
+
+        :returns (r,g,b) tuples for selected pixel
+
+        """
+        if idx < 0 or idx > 23:
+            raise ValueError('idx ({}) must be between 0-23'.format(str(idx)))
+        return self.get_eyes_color()[idx]


### PR DESCRIPTION
## Description
Adds a mechanism to query the current eye color for the mark1

There is no way to get this info from the arduino directly, instead this keeps track of every change in the Enclosure class


## How to test
```python
pixels = self.enclosure.get_eyes_color()
individual_pixel = self.enclosure.get_eyes_pixel_color(idx)
```

## Contributor license agreement signed?
CLA [y] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
