### PR TITLE
Convert hash sign comments to double slash (# -> //)

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -221,8 +221,8 @@
     // Platform name
     // Options: 'picroft', 'mycroft_mark_1'
     // Override: SYSTEM (set by specific enclosures)
-    # "platform": "picroft",
-    # "platform_enclosure_path": "/etc/myenclosure/code.py",
+    // "platform": "picroft",
+    // "platform_enclosure_path": "/etc/myenclosure/code.py",
 
     // COMM params to the Arduino/faceplate
     "port": "/dev/ttyAMA0",


### PR DESCRIPTION
## Description
The hash sing makes it difficult to deal with the json file. Even using tools like [jsmin](https://github.com/tikitu/jsmin/) does not help since hashes are not supported. To enhance interoperability and consistency, they can be removed (also because only two lines use them).
