### PR TITLE
Fallback to mimic for bad http status codes

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -22,7 +22,7 @@ from mycroft.tts import TTSFactory
 from mycroft.util import check_for_signal
 from mycroft.util.log import LOG
 from mycroft.messagebus.message import Message
-from mycroft.tts.remote_tts import RemoteTTSTimeoutException
+from mycroft.tts.remote_tts import RemoteTTSException
 from mycroft.tts.mimic_tts import Mimic
 
 bus = None  # Mycroft messagebus connection
@@ -127,7 +127,7 @@ def mute_and_speak(utterance, ident, listen=False):
     LOG.info("Speak: " + utterance)
     try:
         tts.execute(utterance, ident, listen)
-    except RemoteTTSTimeoutException as e:
+    except RemoteTTSException as e:
         LOG.error(e)
         mimic_fallback_tts(utterance, ident, listen)
     except Exception as e:

--- a/mycroft/tts/remote_tts.py
+++ b/mycroft/tts/remote_tts.py
@@ -21,7 +21,11 @@ from mycroft.util import remove_last_slash, play_wav
 from mycroft.util.log import LOG
 
 
-class RemoteTTSTimeoutException(Exception):
+class RemoteTTSException(Exception):
+    pass
+
+
+class RemoteTTSTimeoutException(RemoteTTSException):
     pass
 
 

--- a/test/unittests/audio/test_speech.py
+++ b/test/unittests/audio/test_speech.py
@@ -23,6 +23,7 @@ from os.path import exists
 
 import mycroft.audio.speech as speech
 from mycroft.messagebus import Message
+from mycroft.tts.remote_tts import RemoteTTSTimeoutException
 
 """Tests for speech dispatch service."""
 
@@ -82,7 +83,7 @@ class TestSpeech(unittest.TestCase):
         mimic_cls_mock.return_value = mimic_mock
 
         tts = tts_factory_mock.create.return_value
-        tts.execute.side_effect = speech.RemoteTTSTimeoutException
+        tts.execute.side_effect = RemoteTTSTimeoutException
 
         bus = mock.Mock()
         speech.init(bus)

--- a/test/unittests/tts/test_mimic2_tts.py
+++ b/test/unittests/tts/test_mimic2_tts.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 
 from mycroft.tts.mimic2_tts import Mimic2
+from mycroft.tts.remote_tts import RemoteTTSException
 
 
 @mock.patch('mycroft.tts.mimic2_tts.FuturesSession')
@@ -23,6 +24,23 @@ class TestMimic2(unittest.TestCase):
         with mock.patch('mycroft.tts.mimic2_tts.open') as mock_open:
             wav_file, vis = m2.get_tts("Hello old friend", 'test.wav')
         self.assertTrue(mock_session_instance.get.called)
+
+    def test_get_tts_backend_error(self, _, mock_session):
+        mock_session_instance = mock.Mock(name='SessionMock')
+        mock_session.return_value = mock_session_instance
+
+        get_mock = mock.Mock(name='getMock')
+        mock_session_instance.get.return_value = get_mock
+
+        result_mock = mock.Mock(name='resultMock')
+        get_mock.result.return_value = result_mock
+        result_mock.json.return_value = ''
+        result_mock.status_code = 500
+
+        m2 = Mimic2('en-US', {'url': 'https://just.testing.nu'})
+        with self.assertRaises(RemoteTTSException):
+            with mock.patch('mycroft.tts.mimic2_tts.open') as mock_open:
+                wav_file, vis = m2.get_tts("Hello old friend", 'test.wav')
 
     def test_visemes(self, _, __):
         m2 = Mimic2('en-US', {'url': 'https://just.testing.nu'})

--- a/test/unittests/tts/test_mimic2_tts.py
+++ b/test/unittests/tts/test_mimic2_tts.py
@@ -17,6 +17,7 @@ class TestMimic2(unittest.TestCase):
         result_mock = mock.Mock(name='resultMock')
         get_mock.result.return_value = result_mock
         result_mock.json.return_value = {'audio_base64': '', 'visimes': ''}
+        result_mock.status_code = 200
         m2 = Mimic2('en-US', {'url': 'https://just.testing.nu'})
 
         with mock.patch('mycroft.tts.mimic2_tts.open') as mock_open:


### PR DESCRIPTION
## Description
Added a RemoteTTSException exception for non-timeout exceptions, Mimic2
will consider HTTP status code 200-299 as OK while other responses will
trigger raise RemoteTTSException.

## How to test
Make sure mimic1 is used if there is a http error.

## Contributor license agreement signed?
CLA [ Yes ]
