### PR TITLE
msm default to 20.02

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -102,7 +102,7 @@
         // Relative to "data_dir"
         "cache": ".skills-repo",
         "url": "https://github.com/MycroftAI/mycroft-skills",
-        "branch": "19.08"
+        "branch": "20.02"
       }
     },
     "upload_skill_manifest": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ fasteners==0.14.1
 PyYAML==5.1.2
 
 lingua-franca==0.2.0
-msm==0.8.5
+msm==0.8.6
 msk==0.3.14
 adapt-parser==0.3.4
 padatious==0.4.6


### PR DESCRIPTION
## Description
Updates msm to 0.8.6 defaulting to the 20.02 branch and updates the mycroft conf to use the same branch.

## How to test
Make sure msm functions

## Contributor license agreement signed?
CLA [ Yes ]
