### PR TITLE
Bugfix for padatious and converse responses

### DIFF
--- a/mycroft/messagebus/message.py
+++ b/mycroft/messagebus/message.py
@@ -16,6 +16,7 @@ import json
 import re
 import inspect
 from mycroft.util.parse import normalize
+from copy import deepcopy
 
 
 class Message:
@@ -111,10 +112,10 @@ class Message:
         Returns:
             Message: Message object to be used on the reply to the message
         """
-        data = data or {}
+        data = deepcopy(data) or {}
         context = context or {}
 
-        new_context = self.context
+        new_context = deepcopy(self.context)
         for key in context:
             new_context[key] = context[key]
         if 'destination' in data:

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -213,11 +213,11 @@ class IntentService:
         for skill in self.active_skills:
             self.do_converse(None, skill[0], lang)
 
-    def do_converse(self, utterances, skill_id, lang):
+    def do_converse(self, utterances, skill_id, lang, message):
         self.waiting_for_converse = True
         self.converse_result = False
         self.converse_skill_id = skill_id
-        self.bus.emit(Message("skill.converse.request", {
+        self.bus.emit(message.reply("skill.converse.request", {
             "skill_id": skill_id, "utterances": utterances, "lang": lang}))
         start_time = time.time()
         t = 0
@@ -333,7 +333,7 @@ class IntentService:
             padatious_intent = None
             with stopwatch:
                 # Give active skills an opportunity to handle the utterance
-                converse = self._converse(combined, lang)
+                converse = self._converse(combined, lang, message)
 
                 if not converse:
                     # No conversation, use intent system to handle utterance
@@ -387,12 +387,13 @@ class IntentService:
         except Exception as e:
             LOG.exception(e)
 
-    def _converse(self, utterances, lang):
+    def _converse(self, utterances, lang, message):
         """ Give active skills a chance at the utterance
 
         Args:
             utterances (list):  list of utterances
             lang (string):      4 letter ISO language code
+            message (Message):  message to use to generate reply
 
         Returns:
             bool: True if converse handled it, False if  no skill processes it
@@ -405,7 +406,7 @@ class IntentService:
 
         # check if any skill wants to handle utterance
         for skill in self.active_skills:
-            if self.do_converse(utterances, skill[0], lang):
+            if self.do_converse(utterances, skill[0], lang, message):
                 # update timestamp, or there will be a timeout where
                 # intent stops conversing whether its being used or not
                 self.add_active_skill(skill[0])

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -352,7 +352,9 @@ class IntentService:
             if converse:
                 # Report that converse handled the intent and return
                 LOG.debug("Handled in converse()")
-                ident = message.context['ident'] if message.context else None
+                ident = None
+                if message.context and 'ident' in message.context:
+                    ident = message.context['ident']
                 report_timing(ident, 'intent_service', stopwatch,
                               {'intent_type': 'converse'})
                 return

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -169,7 +169,7 @@ class PadatiousService(FallbackSkill):
 
         intent.matches['utterance'] = utt
         self.service.add_active_skill(intent.name.split(':')[0])
-        self.bus.emit(message.reply(intent.name, data=intent.matches))
+        self.bus.emit(message.forward(intent.name, data=intent.matches))
         return True
 
     def handle_fallback_last_chance(self, message):


### PR DESCRIPTION
## Description
- Forwards messages messages from the padatious service to keep the destination intact. 
- copies context in reply to make sure original message context stays the same.
- Fix error when the ident is missing during converse handling

## How to test
Make sure the hello world skill's "how are you" intent, qa skill and "what's the weather like" intent returns audio.

## Contributor license agreement signed?
CLA [ Yes ]
