### PR TITLE
Added a "save_path" configuration for saved wake words and utterances.

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -227,7 +227,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         self.save_utterances = listener_config.get('save_utterances', False)
 
         self.save_wake_words = listener_config.get('record_wake_words')
-        self.saved_wake_words_dir = join(gettempdir(), 'mycroft_wake_words')
+        self.save_path = listener_config.get('save_path', gettempdir())
+        self.saved_wake_words_dir = join(self.save_path, 'mycroft_wake_words')
 
         self.upload_lock = Lock()
         self.filenames_to_upload = []
@@ -647,7 +648,10 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         if self.save_utterances:
             LOG.info("Recording utterance")
             stamp = str(datetime.datetime.now())
-            filename = "/tmp/mycroft_utterance%s.wav" % stamp
+            filename = "/{}/mycroft_utterances/{}.wav".format(
+                self.save_path,
+                stamp
+            )
             with open(filename, 'wb') as filea:
                 filea.write(audio_data.get_wav_data())
             LOG.debug("Thinking...")

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -222,13 +222,18 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         self.audio = pyaudio.PyAudio()
         self.multiplier = listener_config.get('multiplier')
         self.energy_ratio = listener_config.get('energy_ratio')
-        # check the config for the flag to save wake words.
 
+        # Check the config for the flag to save wake words, utterances
+        # and for a path under which to save them
         self.save_utterances = listener_config.get('save_utterances', False)
-
-        self.save_wake_words = listener_config.get('record_wake_words')
+        self.save_wake_words = listener_config.get('record_wake_words', False)
         self.save_path = listener_config.get('save_path', gettempdir())
         self.saved_wake_words_dir = join(self.save_path, 'mycroft_wake_words')
+        if self.save_wake_words and not isdir(self.saved_wake_words_dir):
+            os.mkdir(self.saved_wake_words_dir)
+        self.saved_utterances_dir = join(self.save_path, 'mycroft_utterances')
+        if self.save_utterances and not isdir(self.saved_utterances_dir):
+            os.mkdir(self.saved_utterances_dir)
 
         self.upload_lock = Lock()
         self.filenames_to_upload = []
@@ -554,8 +559,6 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
                         # Save wake word locally
                         audio = self._create_audio_data(byte_data, source)
                         mtd = self._compile_metadata()
-                        if not isdir(self.saved_wake_words_dir):
-                            os.mkdir(self.saved_wake_words_dir)
                         module = self.wake_word_recognizer.__class__.__name__
 
                         fn = join(
@@ -648,8 +651,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         if self.save_utterances:
             LOG.info("Recording utterance")
             stamp = str(datetime.datetime.now())
-            filename = "/{}/mycroft_utterances/{}.wav".format(
-                self.save_path,
+            filename = "/{}/{}.wav".format(
+                self.saved_utterances_dir,
                 stamp
             )
             with open(filename, 'wb') as filea:

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -153,7 +153,7 @@
     // 'record_wake_words' and/or 'save_utterances' are set to 'true'.
     // WARNING: Make sure that user 'mycroft' has write-access on the
     // directory!
-    "save_path": "/tmp",
+    // "save_path": "/tmp",
     // Set 'record_wake_words' to save a copy of wake word triggers
     // as .wav files under: /'save_path'/mycroft_wake_words
     "record_wake_words": false,

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -149,13 +149,18 @@
   // Override: REMOTE
   "listener": {
     "sample_rate": 16000,
+    // Set 'save_path' to configure the location of files stored if
+    // 'record_wake_words' and/or 'save_utterances' are set to 'true'.
+    // WARNING: Make sure that user 'mycroft' has write-access on the
+    // directory!
+    "save_path": "/tmp",
     // Set 'record_wake_words' to save a copy of wake word triggers
-    // as .wav files under: /tmp/mycroft_wake_words
+    // as .wav files under: /'save_path'/mycroft_wake_words
     "record_wake_words": false,
     // Set 'save_utterances' to save each sentence sent to STT -- by default
     // they are only kept briefly in-memory.  This can be useful for for
     // debugging or other custom purposes.  Recordings are saved
-    // under: /tmp/mycroft_utterance<TIMESTAMP>.wav
+    // under: /'save_path'/mycroft_utterances/<TIMESTAMP>.wav
     "save_utterances": false,
     "wake_word_upload": {
       "disable": false,


### PR DESCRIPTION
## Description
Fixes #2454 

## How to test
- Set 'save_utterances' and 'record_wake_words' to true
- Set the 'save_path' to something else than "/tmp"

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
