### PR TITLE
Don't forward the context instead use a bare message

### DIFF
--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -143,7 +143,7 @@ class CommonPlaySkill(MycroftSkill, ABC):
         # Stop any currently playing audio
         if self.audioservice.is_playing:
             self.audioservice.stop()
-        self.bus.emit(message.forward("mycroft.stop"))
+        self.bus.emit(Message("mycroft.stop"))
 
         # Save for CPS_play() later, e.g. if phrase includes modifiers like
         # "... on the chromecast"


### PR DESCRIPTION
## Description
Without this the stop handling is really REALLY slow. The exact cause
will need to be researched but this works around the issue for now.

## How to test
Start playing the news and ensure that it doesn't stop directly.

## Contributor license agreement signed?
CLA [ Yes ]
