### PR TITLE
Feature/timing out of thread

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -226,7 +226,13 @@ class MycroftSkill:
         """Add all events allowing the standard interaction with the Mycroft
         system.
         """
-        self.add_event('mycroft.stop', self.__handle_stop)
+        def stop_is_implemented():
+            return self.__class__.stop is not MycroftSkill.stop
+
+        # Only register stop if it's been implemented
+        if stop_is_implemented():
+            self.add_event('mycroft.stop', self.__handle_stop)
+
         self.add_event(
             'mycroft.skill.enable_intent',
             self.handle_enable_intent
@@ -1179,6 +1185,7 @@ class MycroftSkill:
         """Handler for the "mycroft.stop" signal. Runs the user defined
         `stop()` method.
         """
+        self.log.info(_.context)
 
         def __stop_timeout():
             # The self.stop() call took more than 100ms, assume it handled Stop

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -40,17 +40,6 @@ _TTS_ENV = deepcopy(os.environ)
 _TTS_ENV['PULSE_PROP'] = 'media.role=phone'
 
 
-def send_playback_metric(stopwatch, ident):
-    """Send playback metrics in a background thread."""
-
-    def do_send(stopwatch, ident):
-        report_timing(ident, 'speech_playback', stopwatch)
-
-    t = Thread(target=do_send, args=(stopwatch, ident))
-    t.daemon = True
-    t.start()
-
-
 class PlaybackThread(Thread):
     """Thread class for playing back tts audio and sending
     viseme data to enclosure.
@@ -115,7 +104,7 @@ class PlaybackThread(Thread):
                         self.show_visemes(visemes)
                     self.p.communicate()
                     self.p.wait()
-                send_playback_metric(stopwatch, ident)
+                report_timing(ident, 'speech_playback', stopwatch)
 
                 if self.queue.empty():
                     self.tts.end_audio(listen)


### PR DESCRIPTION
## Description
Fix a thread pool starvation issue when reporting metrics. Previously this was done in the emitter thread after a skill or subsystem had delivered their content to avoid slowing down the system. However massively parallell calls like the "mycroft.stop" message would starve the threadpool causing the upload time to limit the execution speed of these.

This also limits the number of listeners to the "mycroft.stop" message to those who actually implements a stop method.

## How to test
Make sure the news skill is played correctly on this branch and make sure stop stops the playback as expected

## Contributor license agreement signed?
CLA [ Yes ]
