### PR TITLE
remove deprecated Settings class

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -47,7 +47,7 @@ from mycroft.util.parse import match_one, extract_number
 from .event_container import EventContainer, create_wrapper, get_handler_name
 from ..event_scheduler import EventSchedulerInterface
 from ..intent_service_interface import IntentServiceInterface
-from ..settings import get_local_settings, save_settings, Settings
+from ..settings import get_local_settings, save_settings
 from ..skill_data import (
     load_vocabulary,
     load_regex,
@@ -124,8 +124,8 @@ class MycroftSkill:
         #: directory. E.g. /opt/mycroft/skills/my-skill.me/
         self.root_dir = dirname(abspath(sys.modules[self.__module__].__file__))
         if use_settings:
-            self.settings = Settings(self)
-            self._initial_settings = deepcopy(self.settings.as_dict())
+            self.settings = get_local_settings(self.root_dir, self.name)
+            self._initial_settings = deepcopy(self.settings)
         else:
             self.settings = None
 
@@ -1238,7 +1238,6 @@ class MycroftSkill:
 
         # Clear skill from gui
         self.gui.shutdown()
-        self.settings.shutdown()
 
         # removing events
         self.event_scheduler.shutdown()

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -92,15 +92,11 @@ def get_local_settings(skill_dir, skill_name) -> dict:
 
 def save_settings(skill_dir, skill_settings):
     """Save skill settings to file."""
-    if isinstance(skill_settings, Settings):
-        settings_to_save = skill_settings.as_dict()
-    else:
-        settings_to_save = skill_settings
     settings_path = Path(skill_dir).joinpath('settings.json')
     if Path(skill_dir).exists():
         with open(str(settings_path), 'w') as settings_file:
             try:
-                json.dump(settings_to_save, settings_file)
+                json.dump(skill_settings, settings_file)
             except Exception:
                 LOG.exception('error saving skill settings to '
                               '{}'.format(settings_path))
@@ -414,46 +410,3 @@ class SkillSettingsDownloader:
                     data={skill_gid: remote_settings}
                 )
                 self.bus.emit(message)
-
-
-# TODO: remove in 20.02
-class Settings:
-    def __init__(self, skill):
-        self._skill = skill
-        self._settings = get_local_settings(skill.root_dir, skill.name)
-
-    def __getattr__(self, attr):
-        if attr not in ['store', 'set_changed_callback', 'as_dict']:
-            return getattr(self._settings, attr)
-        else:
-            return getattr(self, attr)
-
-    def __setitem__(self, key, val):
-        self._settings[key] = val
-
-    def __getitem__(self, key):
-        return self._settings[key]
-
-    def __iter__(self):
-        return iter(self._settings)
-
-    def __contains__(self, key):
-        return key in self._settings
-
-    def __delitem__(self, item):
-        del self._settings[item]
-
-    def store(self, force=False):
-        LOG.warning('DEPRECATED - use mycroft.skills.settings.save_settings()')
-        save_settings(self._skill.root_dir, self._settings)
-
-    def set_changed_callback(self, callback):
-        LOG.warning('DEPRECATED - set the settings_change_callback attribute')
-        self._skill.settings_change_callback = callback
-
-    def as_dict(self):
-        return self._settings
-
-    def shutdown(self):
-        """Shutdown the Settings object removing any references."""
-        self._skill = None

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -21,6 +21,7 @@ from time import time
 
 from mycroft.configuration import Configuration
 from mycroft.messagebus import Message
+from mycroft.skills.settings import save_settings
 from mycroft.util.log import LOG
 
 from .settings import SettingsMetaUploader
@@ -258,7 +259,7 @@ class SkillLoader:
         if first_run:
             LOG.info("First run of " + self.skill_id)
             self.instance.settings["__mycroft_skill_firstrun"] = False
-            self.instance.settings.store()
+            save_settings(self.skill_directory, self.instance.settings)
             intro = self.instance.get_intro_message()
             if intro:
                 self.instance.speak(intro)

--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -32,6 +32,7 @@ To set up a test the test runner can
 
 """
 from queue import Queue, Empty
+from copy import copy
 import json
 import time
 import os
@@ -42,7 +43,6 @@ from pyee import EventEmitter
 from numbers import Number
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import MycroftSkill, FallbackSkill
-from mycroft.skills.settings import Settings
 from mycroft.skills.skill_loader import SkillLoader
 from mycroft.configuration import Configuration
 from mycroft.util.log import LOG
@@ -194,28 +194,6 @@ class InterceptEmitter(object):
         pass
 
 
-class TestSettings(Settings):
-    """ Settings instance without saving/loading capability.
-    """
-    def save_skill_settings(self, skill_settings):
-        pass
-
-    def _poll_skill_settings(self):
-        pass
-
-    def _load_settings_meta(self):
-        return None
-
-    def update(self, settings_meta):
-        pass
-
-    def load_skill_settings_from_file(self):
-        pass
-
-    def store(self, force=False):
-        pass
-
-
 class MockSkillsLoader(object):
     """Load a skill and set up emitter
     """
@@ -342,9 +320,7 @@ class SkillTest(object):
 
     def apply_test_settings(self, s, test_case):
         """Replace the skills settings with settings from the test_case."""
-        s.settings = TestSettings(s)
-        for key in test_case['settings']:
-            s.settings[key] = test_case['settings'][key]
+        s.settings = copy(test_case['settings'])
         print(color.YELLOW, 'will run test with custom settings:',
                             '\n{}'.format(s.settings), color.RESET)
 

--- a/test/unittests/skills/test_skill_loader.py
+++ b/test/unittests/skills/test_skill_loader.py
@@ -54,7 +54,6 @@ class TestSkillLoader(MycroftUnitTestBase):
         skill_instance.name = 'test_skill'
         skill_instance.reload_skill = True
         skill_instance.default_shutdown = Mock()
-        skill_instance.settings = Mock()
         self.skill_instance_mock = skill_instance
 
     def test_get_last_modified_date(self):


### PR DESCRIPTION
## Description
The Settings class was deprecated in 19.08 and is now being removed.

## How to test
Ensure skill settings are loaded and synchronized as expected. No functionality should change.

## Contributor license agreement signed?
CLA [yes] 
