### PR TITLE
Enable snowboy to use several wakeword models

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -299,7 +299,7 @@ class SnowboyHotWord(HotWordEngine):
 
     def found_wake_word(self, frame_data):
         wake_word = self.snowboy.detector.RunDetection(frame_data)
-        return wake_word == 1
+        return wake_word >= 1
 
 
 class PorcupineHotWord(HotWordEngine):


### PR DESCRIPTION
Snowboy could use several wakeword models, not only the first one.

## Description
Fix [#2498](https://github.com/MycroftAI/mycroft-core/issues/2498)

## How to test
Use snowboy, with several hotword model at the same time.
Every one of them should wake mycroft.

## Contributor license agreement signed?
CLA [ ]
Not yet, I'm in processing. But I think that for a change this small, it will not be a problem ;-)
