### PR TITLE
Clear is speaking signal on exceptions

### DIFF
--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -51,6 +51,7 @@ class PlaybackThread(Thread):
         self._terminated = False
         self._processing_queue = False
         self.enclosure = None
+        self.p = None
         # Check if the tts shall have a ducking role set
         if Configuration.get().get('tts', {}).get('pulse_duck'):
             self.pulse_env = _TTS_ENV
@@ -102,8 +103,9 @@ class PlaybackThread(Thread):
                         self.p = play_mp3(data, environment=self.pulse_env)
                     if visemes:
                         self.show_visemes(visemes)
-                    self.p.communicate()
-                    self.p.wait()
+                    if self.p:
+                        self.p.communicate()
+                        self.p.wait()
                 report_timing(ident, 'speech_playback', stopwatch)
 
                 if self.queue.empty():
@@ -312,6 +314,13 @@ class TTS(metaclass=ABCMeta):
         sentence = self.validate_ssml(sentence)
 
         create_signal("isSpeaking")
+        try:
+            self._execute(sentence, ident, listen)
+        except Exception:
+            # If an error occurs end the audio sequence
+            self.queue.put((None, None, None, None, None))
+
+    def _execute(self, sentence, ident, listen):
         if self.phonetic_spelling:
             for word in re.findall(r"[\w']+", sentence):
                 if word.lower() in self.spellings:


### PR DESCRIPTION
## Description
This fixes lingering isSpeaking signals if an exception occurs during playback. A dummy package is added to the tts playback queue

## How to test
Check that the unittest passes and that tts is working as expected.

## Contributor license agreement signed?
CLA [ Yes ]
