### PR TITLE
Update pyee to v7.0.1

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -16,7 +16,7 @@ import time
 from threading import Thread
 import speech_recognition as sr
 import pyaudio
-from pyee import EventEmitter
+from pyee import BaseEventEmitter
 from requests import RequestException
 from requests.exceptions import ConnectionError
 
@@ -271,7 +271,7 @@ def recognizer_conf_hash(config):
     return hash(json.dumps(c, sort_keys=True))
 
 
-class RecognizerLoop(EventEmitter):
+class RecognizerLoop(BaseEventEmitter):
     """ EventEmitter loop running speech recognition.
 
     Local wake word recognizer and remote general speech recognition.

--- a/mycroft/messagebus/client/client.py
+++ b/mycroft/messagebus/client/client.py
@@ -27,14 +27,14 @@ from mycroft.messagebus.load_config import load_message_bus_config
 from mycroft.messagebus.message import Message
 from mycroft.util import create_echo_function
 from mycroft.util.log import LOG
-from .threaded_event_emitter import ThreadedEventEmitter
+from pyee import ExecutorEventEmitter
 
 
 class MessageBusClient:
     def __init__(self, host=None, port=None, route=None, ssl=None):
         config_overrides = dict(host=host, port=port, route=route, ssl=ssl)
         self.config = load_message_bus_config(**config_overrides)
-        self.emitter = ThreadedEventEmitter()
+        self.emitter = ExecutorEventEmitter()
         self.client = self.create_client()
         self.retry = 5
         self.connected_event = Event()

--- a/mycroft/messagebus/client/threaded_event_emitter.py
+++ b/mycroft/messagebus/client/threaded_event_emitter.py
@@ -12,9 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""
+The threaded event emitter is deprecated in favor of pyee's
+ExecutorEventEmitter.
+
+The ThreadedEventEmitter executes events using a threadpool allowing
+concurrent execution of events.
+"""
 from pyee import EventEmitter
 from multiprocessing.pool import ThreadPool
 from collections import defaultdict
+
+from mycroft.util.log import LOG
 
 
 class ThreadedEventEmitter(EventEmitter):
@@ -25,6 +34,7 @@ class ThreadedEventEmitter(EventEmitter):
         super().__init__()
         self.pool = ThreadPool(threads)
         self.wrappers = defaultdict(list)
+        LOG.warning('Depreciated, use ExecutorEventEmitter in pyee instead.')
 
     def on(self, event, f=None):
         """ Wrap on with a threaded launcher. """

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ six==1.13.0
 requests==2.20.0
 gTTS==2.0.4
 PyAudio==0.2.11
-pyee==5.0.0
+pyee==7.0.1
 SpeechRecognition==3.8.1
 tornado==6.0.3
 websocket-client==0.54.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -19,7 +19,7 @@ PyYAML==5.1.2
 lingua-franca==0.2.1
 msm==0.8.7
 msk==0.3.15
-adapt-parser==0.3.4
+adapt-parser==0.3.6
 padatious==0.4.8
 fann2==1.0.7
 padaos==0.1.9


### PR DESCRIPTION
## Description
pyee has added ThreadExecutor variant of the EventEmitter which can
replace the home-spun threadpool based emitter.

Adapt has been updated to match this change.

## How to test
Make sure mycroft-core still works as expected.

## Contributor license agreement signed?
CLA [ Yes ]