### PR TITLE
Add single Voight Kampff module interface

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,12 +34,23 @@ pipeline {
                 {
                     sh 'docker run \
                         -v "$HOME/voight-kampff:/root/.mycroft" \
-                        mycroft-core:${BRANCH_ALIAS}'
+                        mycroft-core:${BRANCH_ALIAS} -f \
+                        allure_behave.formatter:AllureFormatter \
+                        -o /root/.mycroft/allure-result'
                 }
             }
             post {
                 always {
                     echo 'Report Test Results'
+                    echo 'Changing ownership...'
+                    sh 'docker run \
+                        -v "$HOME/voight-kampff:/root/.mycroft" \
+                        --entrypoint=/bin/bash \
+                        mycroft-core:${BRANCH_ALIAS} \
+                        -x -c "chown $(id -u $USER):$(id -g $USER) \
+                        -R /root/.mycroft/allure-result"'
+
+                    echo 'Transfering...'
                     sh 'mv $HOME/voight-kampff/allure-result allure-result'
                     script {
                         allure([

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,39 @@
+pipeline {
+    agent any
+    options {
+        // Running builds concurrently could cause a race condition with
+        // building the Docker image.
+        disableConcurrentBuilds()
+    }
+    stages {
+        // Run the build in the against the dev branch to check for compile errors
+        stage('Run Integration Tests') {
+            when {
+                anyOf {
+                    branch 'dev'
+                    branch 'master'
+                    changeRequest target: 'dev'
+                }
+            }
+            steps {
+                echo 'Building Test Docker Image'
+                sh 'cp test/Dockerfile.test Dockerfile'
+                sh 'docker build --target voigt_kampff -t mycroft-core:latest .'
+                echo 'Running Tests'
+                timeout(time: 10, unit: 'MINUTES')
+                {
+                    sh 'docker run \
+                        -v "$HOME/voigtmycroft:/root/.mycroft" \
+                        mycroft-core:latest'
+                }
+            }
+        }
+    }
+    post {
+        always('Important stuff') {
+            echo 'Cleaning up docker containers and images'
+            sh 'docker container prune --force'
+            sh 'docker image prune --force'
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
             steps {
                 echo 'Building Test Docker Image'
                 sh 'cp test/Dockerfile.test Dockerfile'
-                sh 'docker build --no-cache --target voight_kampff -t mycroft-core:${BRANCH_ALIAS} .'
+                sh 'docker build --target voight_kampff -t mycroft-core:${BRANCH_ALIAS} .'
                 echo 'Running Tests'
                 timeout(time: 10, unit: 'MINUTES')
                 {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,14 +33,14 @@ pipeline {
                 timeout(time: 10, unit: 'MINUTES')
                 {
                     sh 'docker run \
-                        -v "$HOME/voigtmycroft:/root/.mycroft" \
+                        -v "$HOME/voight-kampff:/root/.mycroft" \
                         mycroft-core:${BRANCH_ALIAS}'
                 }
             }
             post {
                 always {
                     echo 'Report Test Results'
-                    sh 'mv $HOME/voigtmycroft/allure-result allure-result'
+                    sh 'mv $HOME/voight-kampff/allure-result allure-result'
                     script {
                         allure([
                             includeProperties: false,
@@ -55,8 +55,8 @@ pipeline {
                         label: 'Publish Report to Web Server',
                         script: '''scp allure-report.zip root@157.245.127.234:~;
                             ssh root@157.245.127.234 "unzip -o ~/allure-report.zip";
-                            ssh root@157.245.127.234 "rm -rf /var/www/voigt-kampff/${BRANCH_ALIAS}";
-                            ssh root@157.245.127.234 "mv allure-report /var/www/voigt-kampff/${BRANCH_ALIAS}"
+                            ssh root@157.245.127.234 "rm -rf /var/www/voight-kampff/${BRANCH_ALIAS}";
+                            ssh root@157.245.127.234 "mv allure-report /var/www/voight-kampff/${BRANCH_ALIAS}"
                         '''
                     )
                     echo 'Report Published'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,16 @@ pipeline {
         // building the Docker image.
         disableConcurrentBuilds()
     }
+    environment {
+        // Some branches have a "/" in their name (e.g. feature/new-and-cool)
+        // Some commands, such as those tha deal with directories, don't
+        // play nice with this naming convention.  Define an alias for the
+        // branch name that can be used in these scenarios.
+        BRANCH_ALIAS = sh(
+            script: 'echo $BRANCH_NAME | sed -e "s#/#_#g"',
+            returnStdout: true
+        ).trim()
+    }
     stages {
         // Run the build in the against the dev branch to check for compile errors
         stage('Run Integration Tests') {
@@ -18,13 +28,13 @@ pipeline {
             steps {
                 echo 'Building Test Docker Image'
                 sh 'cp test/Dockerfile.test Dockerfile'
-                sh 'docker build --target voigt_kampff -t mycroft-core:latest .'
+                sh 'docker build --target voigt_kampff -t mycroft-core:${BRANCH_ALIAS} .'
                 echo 'Running Tests'
                 timeout(time: 10, unit: 'MINUTES')
                 {
                     sh 'docker run \
                         -v "$HOME/voigtmycroft:/root/.mycroft" \
-                        mycroft-core:latest'
+                        mycroft-core:${BRANCH_ALIAS}'
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,10 +33,11 @@ pipeline {
                 timeout(time: 10, unit: 'MINUTES')
                 {
                     sh 'docker run \
-                        -v "$HOME/voight-kampff:/root/.mycroft" \
-                        mycroft-core:${BRANCH_ALIAS} -f \
-                        allure_behave.formatter:AllureFormatter \
-                        -o /root/.mycroft/allure-result --tags ~@xfail'
+                        -v "$HOME/voight-kampff/identity:/root/.mycroft/identity" \
+                        -v "$HOME/voight-kampff/:/root/allure" \
+                        mycroft-core:${BRANCH_ALIAS} \
+                        -f allure_behave.formatter:AllureFormatter \
+                        -o /root/allure/allure-result --tags ~@xfail'
                 }
             }
             post {
@@ -44,11 +45,11 @@ pipeline {
                     echo 'Report Test Results'
                     echo 'Changing ownership...'
                     sh 'docker run \
-                        -v "$HOME/voight-kampff:/root/.mycroft" \
+                        -v "$HOME/voight-kampff/:/root/allure" \
                         --entrypoint=/bin/bash \
                         mycroft-core:${BRANCH_ALIAS} \
                         -x -c "chown $(id -u $USER):$(id -g $USER) \
-                        -R /root/.mycroft/allure-result"'
+                        -R /root/allure/"'
 
                     echo 'Transfering...'
                     sh 'mv $HOME/voight-kampff/allure-result allure-result'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ pipeline {
                         -v "$HOME/voight-kampff:/root/.mycroft" \
                         mycroft-core:${BRANCH_ALIAS} -f \
                         allure_behave.formatter:AllureFormatter \
-                        -o /root/.mycroft/allure-result'
+                        -o /root/.mycroft/allure-result --tags ~@xfail'
                 }
             }
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,7 @@ pipeline {
                         -R /root/allure/"'
 
                     echo 'Transfering...'
+                    sh 'rm -rf allure-result/*'
                     sh 'mv $HOME/voight-kampff/allure-result allure-result'
                     script {
                         allure([

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
                 sh 'cp test/Dockerfile.test Dockerfile'
                 sh 'docker build --target voight_kampff -t mycroft-core:${BRANCH_ALIAS} .'
                 echo 'Running Tests'
-                timeout(time: 10, unit: 'MINUTES')
+                timeout(time: 60, unit: 'MINUTES')
                 {
                     sh 'docker run \
                         -v "$HOME/voight-kampff/identity:/root/.mycroft/identity" \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,16 +4,7 @@ pipeline {
         // Running builds concurrently could cause a race condition with
         // building the Docker image.
         disableConcurrentBuilds()
-    }
-    environment {
-        // Some branches have a "/" in their name (e.g. feature/new-and-cool)
-        // Some commands, such as those tha deal with directories, don't
-        // play nice with this naming convention.  Define an alias for the
-        // branch name that can be used in these scenarios.
-        BRANCH_ALIAS = sh(
-            script: 'echo $BRANCH_NAME | sed -e "s#/#_#g"',
-            returnStdout: true
-        ).trim()
+        buildDiscarder(logRotator(numToKeepStr: '5'))
     }
     stages {
         // Run the build in the against the dev branch to check for compile errors
@@ -25,17 +16,30 @@ pipeline {
                     changeRequest target: 'dev'
                 }
             }
+            environment {
+                // Some branches have a "/" in their name (e.g. feature/new-and-cool)
+                // Some commands, such as those tha deal with directories, don't
+                // play nice with this naming convention.  Define an alias for the
+                // branch name that can be used in these scenarios.
+                BRANCH_ALIAS = sh(
+                    script: 'echo $BRANCH_NAME | sed -e "s#/#_#g"',
+                    returnStdout: true
+                ).trim()
+            }
             steps {
-                echo 'Building Test Docker Image'
+                echo 'Building Mark I Voight-Kampff Docker Image'
                 sh 'cp test/Dockerfile.test Dockerfile'
-                sh 'docker build --target voight_kampff -t mycroft-core:${BRANCH_ALIAS} .'
-                echo 'Running Tests'
+                sh 'docker build \
+                    --target voight_kampff_builder \
+                    --build-arg platform=mycroft_mark_1 \
+                    -t voight-kampff-mark-1:${BRANCH_ALIAS} .'
+                echo 'Running Mark I Voight-Kampff Test Suite'
                 timeout(time: 60, unit: 'MINUTES')
                 {
                     sh 'docker run \
                         -v "$HOME/voight-kampff/identity:/root/.mycroft/identity" \
                         -v "$HOME/voight-kampff/:/root/allure" \
-                        mycroft-core:${BRANCH_ALIAS} \
+                       voight-kampff-mark-1:${BRANCH_ALIAS} \
                         -f allure_behave.formatter:AllureFormatter \
                         -o /root/allure/allure-result --tags ~@xfail'
                 }
@@ -47,11 +51,11 @@ pipeline {
                     sh 'docker run \
                         -v "$HOME/voight-kampff/:/root/allure" \
                         --entrypoint=/bin/bash \
-                        mycroft-core:${BRANCH_ALIAS} \
+                        voight-kampff-mark-1:${BRANCH_ALIAS} \
                         -x -c "chown $(id -u $USER):$(id -g $USER) \
                         -R /root/allure/"'
 
-                    echo 'Transfering...'
+                    echo 'Transferring...'
                     sh 'rm -rf allure-result/*'
                     sh 'mv $HOME/voight-kampff/allure-result allure-result'
                     script {

--- a/bin/mycroft-skill-testrunner
+++ b/bin/mycroft-skill-testrunner
@@ -23,8 +23,9 @@ source "$DIR/../venv-activate.sh" -q
 # Invoke the individual skill tester
 if [ "$#" -eq 0 ] ; then
     python -m test.integrationtests.skills.runner .
-elif [ "$1" -eq "vktest"] ; then
-    python -m test.integrationtests.voight_kampff $@
+elif [ "$1" = "vktest" ] ; then
+    shift
+    python -m test.integrationtests.voight_kampff "$@"
 else
     python -m test.integrationtests.skills.runner $@
 fi

--- a/bin/mycroft-skill-testrunner
+++ b/bin/mycroft-skill-testrunner
@@ -23,6 +23,8 @@ source "$DIR/../venv-activate.sh" -q
 # Invoke the individual skill tester
 if [ "$#" -eq 0 ] ; then
     python -m test.integrationtests.skills.runner .
+elif [ "$1" -eq "vktest"] ; then
+    python -m test.integrationtests.voight_kampff $@
 else
     python -m test.integrationtests.skills.runner $@
 fi

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -230,8 +230,10 @@ class IntentService:
         if result and 'error' in result.data:
             self.handle_converse_error(result)
             return False
-        else:
+        elif result is not None:
             return result.data.get('result', False)
+        else:
+            return False
 
     def handle_converse_error(self, message):
         skill_id = message.data["skill_id"]

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1071,10 +1071,12 @@ class MycroftSkill:
             meta:                   Information of what built the sentence.
         """
         # registers the skill as being active
+        meta = meta or {}
+        meta['skill'] = self.name
         self.enclosure.register(self.name)
         data = {'utterance': utterance,
                 'expect_response': expect_response,
-                'meta': meta or {}}
+                'meta': meta}
         message = dig_for_message()
         m = message.forward("speak", data) if message \
             else Message("speak", data)

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -392,9 +392,9 @@ class MycroftSkill:
         validator = validator or validator_default
 
         # Speak query and wait for user response
-        utterance = self.dialog_renderer.render(dialog, data)
-        if utterance:
-            self.speak(utterance, expect_response=True, wait=True)
+        dialog_exists = self.dialog_renderer.render(dialog, data)
+        if dialog_exists:
+            self.speak_dialog(dialog, data, expect_response=True, wait=True)
         else:
             self.bus.emit(Message('mycroft.mic.listen'))
         return self._wait_response(is_cancel, validator, on_fail_fn,
@@ -1058,7 +1058,7 @@ class MycroftSkill:
         re.compile(regex)  # validate regex
         self.intent_service.register_adapt_regex(regex)
 
-    def speak(self, utterance, expect_response=False, wait=False):
+    def speak(self, utterance, expect_response=False, wait=False, meta=None):
         """Speak a sentence.
 
         Arguments:
@@ -1068,11 +1068,13 @@ class MycroftSkill:
                                     speaking the utterance.
             wait (bool):            set to True to block while the text
                                     is being spoken.
+            meta:                   Information of what built the sentence.
         """
         # registers the skill as being active
         self.enclosure.register(self.name)
         data = {'utterance': utterance,
-                'expect_response': expect_response}
+                'expect_response': expect_response,
+                'meta': meta or {}}
         message = dig_for_message()
         m = message.forward("speak", data) if message \
             else Message("speak", data)
@@ -1096,7 +1098,7 @@ class MycroftSkill:
         """
         data = data or {}
         self.speak(self.dialog_renderer.render(key, data),
-                   expect_response, wait)
+                   expect_response, wait, meta={'dialog': key, 'data': data})
 
     def acknowledge(self):
         """Acknowledge a successful request.

--- a/mycroft/tts/dummy_tts.py
+++ b/mycroft/tts/dummy_tts.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A Dummy TTS without any audio output."""
+
+from mycroft.util.log import LOG
+
+from .tts import TTS, TTSValidator
+
+
+class DummyTTS(TTS):
+    def __init__(self, lang, config):
+        super().__init__(lang, config, DummyValidator(self), 'wav')
+
+    def execute(self, sentence, ident=None, listen=False):
+        """Don't do anything, return nothing."""
+        LOG.info('Mycroft: {}'.format(sentence))
+        return None
+
+
+class DummyValidator(TTSValidator):
+    """Do no tests."""
+    def __init__(self, tts):
+        super().__init__(tts)
+
+    def validate_lang(self):
+        pass
+
+    def validate_connection(self):
+        pass
+
+    def get_tts_class(self):
+        return DummyTTS

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -471,6 +471,7 @@ class TTSFactory:
     from mycroft.tts.responsive_voice_tts import ResponsiveVoice
     from mycroft.tts.mimic2_tts import Mimic2
     from mycroft.tts.yandex_tts import YandexTTS
+    from mycroft.tts.dummy_tts import DummyTTS
 
     CLASSES = {
         "mimic": Mimic,
@@ -483,7 +484,8 @@ class TTSFactory:
         "watson": WatsonTTS,
         "bing": BingTTS,
         "responsive_voice": ResponsiveVoice,
-        "yandex": YandexTTS
+        "yandex": YandexTTS,
+        "dummy": DummyTTS
     }
 
     @staticmethod

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -51,6 +51,7 @@ class PlaybackThread(Thread):
         self._terminated = False
         self._processing_queue = False
         self.enclosure = None
+        self.p = None
         # Check if the tts shall have a ducking role set
         if Configuration.get().get('tts', {}).get('pulse_duck'):
             self.pulse_env = _TTS_ENV
@@ -102,8 +103,9 @@ class PlaybackThread(Thread):
                         self.p = play_mp3(data, environment=self.pulse_env)
                     if visemes:
                         self.show_visemes(visemes)
-                    self.p.communicate()
-                    self.p.wait()
+                    if self.p:
+                        self.p.communicate()
+                        self.p.wait()
                 report_timing(ident, 'speech_playback', stopwatch)
 
                 if self.queue.empty():
@@ -312,6 +314,13 @@ class TTS(metaclass=ABCMeta):
         sentence = self.validate_ssml(sentence)
 
         create_signal("isSpeaking")
+        try:
+            self._execute(sentence, ident, listen)
+        except Exception:
+            # If an error occurs end the audio sequence
+            self.queue.put((None, None, None, None, None))
+
+    def _execute(self, sentence, ident, listen):
         if self.phonetic_spelling:
             for word in re.findall(r"[\w']+", sentence):
                 if word.lower() in self.spellings:

--- a/scripts/prepare-msm.sh
+++ b/scripts/prepare-msm.sh
@@ -43,7 +43,7 @@ fi
 # change ownership of ${mycroft_root_dir} to ${setup_user } recursively
 function change_ownership {
     echo "Changing ownership of" ${mycroft_root_dir} "to user:" ${setup_user} "with group:" ${setup_group}
-    $SUDO chown -Rvf ${setup_user}:${setup_group} ${mycroft_root_dir}
+    $SUDO chown -Rf ${setup_user}:${setup_group} ${mycroft_root_dir}
 }
 
 

--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -40,6 +40,7 @@ function help() {
     echo "  cli                      the Command Line Interface"
     echo "  unittest                 run mycroft-core unit tests (requires pytest)"
     echo "  skillstest               run the skill autotests for all skills (requires pytest)"
+    echo "  vktest                   run the Voight Kampff integration test suite"
     echo
     echo "Util COMMANDs:"
     echo "  audiotest                attempt simple audio validation"
@@ -235,6 +236,10 @@ case ${_opt} in
     "skillstest")
         source-venv
         pytest test/integrationtests/skills/discover_tests.py "$@"
+        ;;
+    "vktest")
+        source-venv
+        python -m test.integrationtests.voight_kampff "$@"
         ;;
     "audiotest")
         launch-process ${_opt}

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,3 +5,4 @@ pytest-cov==2.8.1
 cov-core==1.15.0
 sphinx==2.2.1
 sphinx-rtd-theme==0.4.3
+behave==1.2.6

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ cov-core==1.15.0
 sphinx==2.2.1
 sphinx-rtd-theme==0.4.3
 behave==1.2.6
+allure-behave==2.8.10

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,5 +5,5 @@ pytest-cov==2.8.1
 cov-core==1.15.0
 sphinx==2.2.1
 sphinx-rtd-theme==0.4.3
-behave==1.2.6
+git+https://github.com/behave/behave@v1.2.7.dev1
 allure-behave==2.8.10

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -1,0 +1,39 @@
+FROM ubuntu:18.04 as builder
+ENV TERM linux
+ENV DEBIAN_FRONTEND noninteractive
+COPY . /opt/mycroft/mycroft-core
+# Install Server Dependencies for Mycroft
+RUN set -x \
+    # Un-comment any package sources that include a multiverse
+	&& sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list \
+	&& apt-get update \
+	# Install packages specific to Docker implementation
+    && apt-get -y install locales sudo\
+	&& mkdir /opt/mycroft/skills \
+	&& CI=true bash -x /opt/mycroft/mycroft-core/dev_setup.sh --allow-root -sm \
+	&& apt-get -y autoremove \
+	&& apt-get clean \
+	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+# Set the locale
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+# Add the local configuration directory
+RUN mkdir ~/.mycroft
+EXPOSE 8181
+
+# Integration Test Suite
+FROM builder as voight_kampff
+# Add the mycroft core virtual environment to the system path.
+ENV PATH /opt/mycroft/mycroft-core/.venv/bin:$PATH
+WORKDIR /opt/mycroft/mycroft-core/test/integrationtests/voight_kampff
+# Install Mark I default skills
+RUN msm -p mycroft_mark_1 default
+# The behave feature files for a skill are defined within the skill's
+# repository.  Copy those files into the local feature file directory
+# for test discovery.
+RUN python -m test.integrationtests.voight_kampff.skill_setup -c default.yml
+RUN mkdir ~/.mycroft/allure-result
+# Setup and run the integration tests
+ENTRYPOINT "./run_test_suite.sh"

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -1,40 +1,95 @@
+# Build an Ubuntu-based container to run Mycroft
+#
+#   The steps in this build are ordered from least likely to change to most
+#   likely to change.  The intent behind this is to reduce build time so things
+#   like Jenkins jobs don't spend a lot of time re-building things that did not
+#   change from one build to the next.
+#
 FROM ubuntu:18.04 as builder
 ENV TERM linux
 ENV DEBIAN_FRONTEND noninteractive
-COPY . /opt/mycroft/mycroft-core
+# Un-comment any package sources that include a multiverse
+RUN sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list
 # Install Server Dependencies for Mycroft
-RUN set -x \
-    # Un-comment any package sources that include a multiverse
-	&& sed -i 's/# \(.*multiverse$\)/\1/g' /etc/apt/sources.list \
-	&& apt-get update \
-	# Install packages specific to Docker implementation
-    && apt-get -y install locales sudo\
-	&& mkdir /opt/mycroft/skills \
-	&& CI=true bash -x /opt/mycroft/mycroft-core/dev_setup.sh --allow-root -sm \
-	&& apt-get -y autoremove \
-	&& apt-get clean \
-	&& rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    bison \
+    build-essential \
+    curl \
+    flac \
+    git \
+    jq \
+    libfann-dev \
+    libffi-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libglib2.0-dev \
+    libssl-dev \
+    libtool \
+    locales \
+    mpg123 \
+    pkg-config \
+    portaudio19-dev \
+    pulseaudio \
+    pulseaudio-utils \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-setuptools \
+    python3-venv \
+    screen \
+    sudo \
+    swig \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
 # Set the locale
 RUN locale-gen en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-# Add the local configuration directory
-RUN mkdir ~/.mycroft
-VOLUME /root/.mycroft
+
+# Setup the virtual environment
+#   This may not be the most efficient way to do this in terms of number of
+#   steps, but it is built to take advantage of Docker's caching mechanism
+#   to only rebuild things that have changed since the last build.
+RUN mkdir /opt/mycroft
+RUN mkdir /var/log/mycroft
+WORKDIR /opt/mycroft
+RUN mkdir mycroft-core skills ~/.mycroft
+RUN python3 -m venv "/opt/mycroft/mycroft-core/.venv"
+RUN mycroft-core/.venv/bin/python -m pip install pip==20.0.2
+COPY requirements.txt mycroft-core
+RUN mycroft-core/.venv/bin/python -m pip install -r mycroft-core/requirements.txt
+COPY . mycroft-core
 EXPOSE 8181
 
+
 # Integration Test Suite
+#
+#   Build against this target to set the container up as an executable that
+#   will run the "voight_kampff" integration test suite.
+#
 FROM builder as voight_kampff
 # Add the mycroft core virtual environment to the system path.
 ENV PATH /opt/mycroft/mycroft-core/.venv/bin:$PATH
-WORKDIR /opt/mycroft/mycroft-core/test/integrationtests/voight_kampff
+# Install required packages for test environments
+RUN mycroft-core/.venv/bin/python -m pip install -r mycroft-core/test-requirements.txt
+RUN mycroft-core/.venv/bin/python -m pip install --no-deps /opt/mycroft/mycroft-core
+RUN mkdir ~/.mycroft/allure-result
+
 # Install Mark I default skills
 RUN msm -p mycroft_mark_1 default
+
 # The behave feature files for a skill are defined within the skill's
 # repository.  Copy those files into the local feature file directory
 # for test discovery.
-RUN python -m test.integrationtests.voight_kampff.test_setup -c default.yml
-RUN mkdir ~/.mycroft/allure-result
+WORKDIR /opt/mycroft/mycroft-core
+# Generate hash of required packages
+RUN md5sum requirements.txt test-requirements.txt dev_setup.sh > .installed
+RUN python -m test.integrationtests.voight_kampff.test_setup -c test/integrationtests/voight_kampff/default.yml
+
 # Setup and run the integration tests
+WORKDIR /opt/mycroft/mycroft-core/test/integrationtests/voight_kampff
 ENTRYPOINT "./run_test_suite.sh"

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -21,6 +21,7 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 # Add the local configuration directory
 RUN mkdir ~/.mycroft
+VOLUME /root/.mycroft
 EXPOSE 8181
 
 # Integration Test Suite
@@ -33,7 +34,7 @@ RUN msm -p mycroft_mark_1 default
 # The behave feature files for a skill are defined within the skill's
 # repository.  Copy those files into the local feature file directory
 # for test discovery.
-RUN python -m test.integrationtests.voight_kampff.skill_setup -c default.yml
+RUN python -m test.integrationtests.voight_kampff.test_setup -c default.yml
 RUN mkdir ~/.mycroft/allure-result
 # Setup and run the integration tests
 ENTRYPOINT "./run_test_suite.sh"

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -72,6 +72,8 @@ EXPOSE 8181
 #   will run the "voight_kampff" integration test suite.
 #
 FROM builder as voight_kampff
+RUN mkdir /etc/mycroft
+RUN echo '{"tts": {"module": "dummy"}}' > /etc/mycroft/mycroft.conf
 # Add the mycroft core virtual environment to the system path.
 ENV PATH /opt/mycroft/mycroft-core/.venv/bin:$PATH
 # Install required packages for test environments

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -5,7 +5,8 @@
 #   like Jenkins jobs don't spend a lot of time re-building things that did not
 #   change from one build to the next.
 #
-FROM ubuntu:18.04 as builder
+FROM ubuntu:18.04 as core_builder
+ARG platform
 ENV TERM linux
 ENV DEBIAN_FRONTEND noninteractive
 # Un-comment any package sources that include a multiverse
@@ -56,15 +57,27 @@ ENV CI true
 #   This may not be the most efficient way to do this in terms of number of
 #   steps, but it is built to take advantage of Docker's caching mechanism
 #   to only rebuild things that have changed since the last build.
-RUN mkdir /opt/mycroft
-RUN mkdir /var/log/mycroft
-WORKDIR /opt/mycroft
-RUN mkdir mycroft-core skills ~/.mycroft
+RUN mkdir -p /opt/mycroft/mycroft-core /opt/mycroft/skills /root/.mycroft /var/log/mycroft
 RUN python3 -m venv "/opt/mycroft/mycroft-core/.venv"
-RUN mycroft-core/.venv/bin/python -m pip install pip==20.0.2
-COPY requirements.txt mycroft-core
-RUN mycroft-core/.venv/bin/python -m pip install -r mycroft-core/requirements.txt
-COPY . mycroft-core
+
+# Install required Python packages.  Generate hash, which mycroft core uses to
+# determine if any changes have been made since it last started
+WORKDIR /opt/mycroft/mycroft-core
+RUN .venv/bin/python -m pip install pip==20.0.2
+COPY requirements.txt .
+RUN .venv/bin/python -m pip install -r requirements.txt
+COPY test-requirements.txt .
+RUN .venv/bin/python -m pip install -r test-requirements.txt
+COPY dev_setup.sh .
+RUN md5sum requirements.txt test-requirements.txt dev_setup.sh > .installed
+
+# Add the mycroft core virtual environment to the system path.
+ENV PATH /opt/mycroft/mycroft-core/.venv/bin:$PATH
+
+# Install Mark I default skills
+RUN msm -p mycroft_mark_1 default
+COPY . /opt/mycroft/mycroft-core
+RUN .venv/bin/python -m pip install --no-deps /opt/mycroft/mycroft-core
 EXPOSE 8181
 
 
@@ -73,25 +86,18 @@ EXPOSE 8181
 #   Build against this target to set the container up as an executable that
 #   will run the "voight_kampff" integration test suite.
 #
-FROM builder as voight_kampff
+FROM core_builder as voight_kampff_builder
+ARG platform
+# Setup a dummy TTS backend for the audio process
 RUN mkdir /etc/mycroft
 RUN echo '{"tts": {"module": "dummy"}}' > /etc/mycroft/mycroft.conf
-# Add the mycroft core virtual environment to the system path.
-ENV PATH /opt/mycroft/mycroft-core/.venv/bin:$PATH
-# Install required packages for test environments
-RUN mycroft-core/.venv/bin/python -m pip install -r mycroft-core/test-requirements.txt
-RUN mycroft-core/.venv/bin/python -m pip install --no-deps /opt/mycroft/mycroft-core
 RUN mkdir ~/.mycroft/allure-result
-
-# Install Mark I default skills
-RUN msm -p mycroft_mark_1 default
 
 # The behave feature files for a skill are defined within the skill's
 # repository.  Copy those files into the local feature file directory
 # for test discovery.
 WORKDIR /opt/mycroft/mycroft-core
 # Generate hash of required packages
-RUN md5sum requirements.txt test-requirements.txt dev_setup.sh > .installed
 RUN python -m test.integrationtests.voight_kampff.test_setup -c test/integrationtests/voight_kampff/default.yml
 
 # Setup and run the integration tests

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -50,6 +50,8 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
+ENV USER root
+ENV CI true
 # Setup the virtual environment
 #   This may not be the most efficient way to do this in terms of number of
 #   steps, but it is built to take advantage of Docker's caching mechanism

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -93,4 +93,4 @@ RUN python -m test.integrationtests.voight_kampff.test_setup -c test/integration
 # Setup and run the integration tests
 ENV PYTHONPATH /opt/mycroft/mycroft-core/
 WORKDIR /opt/mycroft/mycroft-core/test/integrationtests/voight_kampff
-ENTRYPOINT "./run_test_suite.sh"
+ENTRYPOINT ["./run_test_suite.sh"]

--- a/test/Dockerfile.test
+++ b/test/Dockerfile.test
@@ -91,5 +91,6 @@ RUN md5sum requirements.txt test-requirements.txt dev_setup.sh > .installed
 RUN python -m test.integrationtests.voight_kampff.test_setup -c test/integrationtests/voight_kampff/default.yml
 
 # Setup and run the integration tests
+ENV PYTHONPATH /opt/mycroft/mycroft-core/
 WORKDIR /opt/mycroft/mycroft-core/test/integrationtests/voight_kampff
 ENTRYPOINT "./run_test_suite.sh"

--- a/test/integrationtests/voight_kampff/README.md
+++ b/test/integrationtests/voight_kampff/README.md
@@ -1,0 +1,58 @@
+# Voight Kampff tester
+
+> You’re watching television. Suddenly you realize there’s a wasp crawling on your arm.
+
+The Voight Kampff tester is an integration test system based on the "behave" framework using human readable test cases. The tester connects to the running mycroft-core instance and performs tests. Checking that user utterances returns a correct response.
+
+## Test setup
+`test_setup` collects feature files for behave and installs any skills that should be present during the test.
+
+## Running the test
+After the test has been setup run `behave` to start the test.
+
+## Feature file
+Feature files is the way tests are specified for behave (Read more [here](https://behave.readthedocs.io/en/latest/tutorial.html))
+
+Below is an example of a feature file that can be used with the test suite.
+```feature
+Feature: mycroft-weather
+  Scenario Outline: current local weather question
+    Given an english speaking user
+     When the user says "<current local weather>"
+     Then "mycroft-weather" should reply with "Right now, it's overcast clouds and 32 degrees."
+
+   Examples: local weather questions
+        | current local weather |
+        | what's the weather like |
+        | current weather |
+        | tell me the weather |
+
+  Scenario: Temperature in paris
+    Given an english speaking user
+     When the user says "how hot will it be in paris"
+     Then "mycroft-weather" should reply with dialog from "current.high.temperature.dialog"
+```
+
+### Given ...
+
+Given is used to perform initial setup for the test case. currently this has little effect and the test will always be performed in english but need to be specified in each test as 
+
+```Given an english speaking user```
+
+### When ...
+The When is the start of the test and will inject a message on the running mycroft instance. The current available When is
+
+`When the user says "<utterance>"`
+
+where utterance is the sentence to test.
+
+### Then ...
+The "Then" step will verify the response of the user, currently there is two ways of specifying the response.
+
+Expected dialog:
+`"<skill-name>" should reply with dialog from "<dialog-file>"`
+
+Example phrase:
+`Then "<skill-name>" should reply with "<example>"
+
+This will try to map the example phrase to a dialog file and will allow any response from that dialog file.

--- a/test/integrationtests/voight_kampff/README.md
+++ b/test/integrationtests/voight_kampff/README.md
@@ -56,3 +56,26 @@ Example phrase:
 `Then "<skill-name>" should reply with "<example>"
 
 This will try to map the example phrase to a dialog file and will allow any response from that dialog file.
+
+User reply:
+`Then the user says "<utterance>"`
+
+This allows setting up scenarios with conversational aspects, e.g. when using `get_response()` in the skill.
+
+Example:
+```feature
+Scenario: Bridge of death
+  Given an english speaking user
+  When the user says "let's go to the bridge of death"
+  Then "death-bridge" should reply with dialog from "questions_one.dialog"
+  Then the user says "My name is Sir Lancelot of Camelot"
+  Then "death-bridge" should reply with dialog from "questions_two.dialog"
+  Then the user says "To seek the holy grail"
+  Then "death-bridge" should reply with dialog from "questions_three.dialog"
+  Then the user says "blue"
+```
+
+Mycroft messagebus message:
+`mycroft should send the message "<message type>"`
+
+This verifies that a specific message is emitted on the messagebus. This can be used to check that a playback request is sent or other action is triggered.

--- a/test/integrationtests/voight_kampff/README.md
+++ b/test/integrationtests/voight_kampff/README.md
@@ -47,17 +47,22 @@ The When is the start of the test and will inject a message on the running mycro
 where utterance is the sentence to test.
 
 ### Then ...
-The "Then" step will verify the response of the user, currently there is two ways of specifying the response.
+The "Then" step will verify Mycroft's response, handle a followup action or check for messages on the messagebus.
 
-Expected dialog:
+#### Expected dialog:
 `"<skill-name>" should reply with dialog from "<dialog-file>"`
 
 Example phrase:
 `Then "<skill-name>" should reply with "<example>"
 
-This will try to map the example phrase to a dialog file and will allow any response from that dialog file.
+This will try to map the example phrase to a dialog file and will allow any response from that dialog file. This one is somewhat experimental et the moment.
 
-User reply:
+#### Should contain:
+`mycroft reply should contain "<text>"`
+
+This will match any sentence containing the specified text.
+
+#### User reply:
 `Then the user says "<utterance>"`
 
 This allows setting up scenarios with conversational aspects, e.g. when using `get_response()` in the skill.
@@ -75,7 +80,7 @@ Scenario: Bridge of death
   Then the user says "blue"
 ```
 
-Mycroft messagebus message:
+#### Mycroft messagebus message:
 `mycroft should send the message "<message type>"`
 
 This verifies that a specific message is emitted on the messagebus. This can be used to check that a playback request is sent or other action is triggered.

--- a/test/integrationtests/voight_kampff/__init__.py
+++ b/test/integrationtests/voight_kampff/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/test/integrationtests/voight_kampff/__init__.py
+++ b/test/integrationtests/voight_kampff/__init__.py
@@ -12,3 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+from .tools import emit_utterance, wait_for_dialog

--- a/test/integrationtests/voight_kampff/__init__.py
+++ b/test/integrationtests/voight_kampff/__init__.py
@@ -13,4 +13,5 @@
 # limitations under the License.
 #
 
-from .tools import emit_utterance, wait_for_dialog
+from .tools import (emit_utterance, wait_for_dialog, then_wait,
+                    mycroft_responses, print_mycroft_responses)

--- a/test/integrationtests/voight_kampff/__main__.py
+++ b/test/integrationtests/voight_kampff/__main__.py
@@ -1,0 +1,37 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+import subprocess
+import sys
+from .test_setup import main as test_setup
+from .test_setup import create_argument_parser
+"""Voigt Kampff Test Module
+
+A single interface for the Voice Kampff integration test module.
+
+Full documentation can be found at https://mycroft.ai/docs
+"""
+
+
+def main(cmdline_args):
+    parser = create_argument_parser()
+    setup_args, behave_args = parser.parse_known_args(cmdline_args)
+    test_setup(setup_args)
+    os.chdir(os.path.dirname(__file__))
+    subprocess.call(['./run_test_suite.sh', *behave_args])
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/test/integrationtests/voight_kampff/default.yml
+++ b/test/integrationtests/voight_kampff/default.yml
@@ -1,0 +1,9 @@
+extra_skills:
+- cocktails
+platform: mycroft_mark_1
+tested_skills:
+- mycroft-date-time
+- mycroft-weather
+- mycroft-hello-world
+- mycroft-pairing
+- mycroft-wiki

--- a/test/integrationtests/voight_kampff/default.yml
+++ b/test/integrationtests/voight_kampff/default.yml
@@ -2,8 +2,20 @@ extra_skills:
 - cocktails
 platform: mycroft_mark_1
 tested_skills:
+- mycroft-alarm
+- mycroft-timer
 - mycroft-date-time
+- mycroft-npr-news
 - mycroft-weather
 - mycroft-hello-world
 - mycroft-pairing
 - mycroft-wiki
+- mycroft-personal
+- mycroft-npr-news
+- mycroft-installer
+- mycroft-singing
+- mycroft-stock
+- mycroft-mark-1
+- fallback-unknown
+- fallback-query
+- mycroft-volume

--- a/test/integrationtests/voight_kampff/default.yml
+++ b/test/integrationtests/voight_kampff/default.yml
@@ -1,7 +1,5 @@
-extra_skills:
-- cocktails
 platform: mycroft_mark_1
-tested_skills:
+test_skills:
 - mycroft-alarm
 - mycroft-timer
 - mycroft-date-time

--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -1,0 +1,71 @@
+# Copyright 2017 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from threading import Event, Lock
+from time import sleep, monotonic
+
+from msm import MycroftSkillsManager
+from mycroft.messagebus.client import MessageBusClient
+from mycroft.messagebus import Message
+from mycroft.util import create_daemon
+
+
+def before_all(context):
+    bus = MessageBusClient()
+    bus_connected = Event()
+    bus.once('open', bus_connected.set)
+
+    context.speak_messages = []
+    context.speak_lock = Lock()
+
+    def on_speak(message):
+        with context.speak_lock:
+            context.speak_messages.append(message)
+
+    bus.on('speak', on_speak)
+    create_daemon(bus.run_forever)
+
+    context.msm = MycroftSkillsManager()
+    # Wait for connection
+    print('Waiting for messagebus connection...')
+    bus_connected.wait()
+
+    print('Waiting for skills to be loaded...')
+    start = monotonic()
+    while True:
+        response = bus.wait_for_response(Message('mycroft.skills.all_loaded'))
+        if response and response.data['status']:
+            break
+        elif monotonic() - start >= 2 * 60:
+            raise Exception('Timeout waiting for skills to become ready.')
+        else:
+            sleep(1)
+
+    context.bus = bus
+    context.matched_message = None
+
+
+def after_all(context):
+    context.bus.close()
+
+
+def after_feature(context, feature):
+    sleep(2)
+
+
+def after_scenario(context, scenario):
+    with context.speak_lock:
+        context.speak_messages = []
+    context.matched_message = None
+    sleep(0.5)

--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -86,7 +86,7 @@ def after_feature(context, feature):
 
 def after_scenario(context, scenario):
     # TODO wait for skill handler complete
-    sleep(0.5)
+    sleep(2)
     wait_while_speaking()
     context.bus.clear_messages()
     context.matched_message = None

--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -40,10 +40,12 @@ class InterceptAllBusClient(MessageBusClient):
         super().__init__()
         self.messages = []
         self.message_lock = Lock()
+        self.new_message_available = Event()
 
     def on_message(self, message):
         with self.message_lock:
             self.messages.append(Message.deserialize(message))
+        self.new_message_available.set()
         super().on_message(message)
 
     def get_messages(self, msg_type):

--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -15,6 +15,7 @@
 import logging
 from threading import Event, Lock
 from time import sleep, monotonic
+from behave.contrib.scenario_autoretry import patch_scenario_with_autoretry
 
 from msm import MycroftSkillsManager
 from mycroft.audio import wait_while_speaking
@@ -95,6 +96,8 @@ def before_all(context):
 
 def before_feature(context, feature):
     context.log.info('Starting tests for {}'.format(feature.name))
+    for scenario in feature.scenarios:
+        patch_scenario_with_autoretry(scenario, max_attempts=2)
 
 
 def after_all(context):

--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -81,13 +81,12 @@ def after_all(context):
 
 
 def after_feature(context, feature):
-    sleep(2)
+    sleep(1)
 
 
 def after_scenario(context, scenario):
     # TODO wait for skill handler complete
-    sleep(2)
+    sleep(0.5)
     wait_while_speaking()
     context.bus.clear_messages()
     context.matched_message = None
-    sleep(0.5)

--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Mycroft AI Inc.
+# Copyright 2020 Mycroft AI Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,6 +39,10 @@ class InterceptAllBusClient(MessageBusClient):
                 return [m for m in self.messages]
             else:
                 return [m for m in self.messages if m.msg_type == msg_type]
+
+    def remove_message(self, msg):
+        with self.message_lock:
+            self.messages.remove(msg)
 
     def clear_messages(self):
         with self.message_lock:

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -163,7 +163,7 @@ def then_dialog(context, skill, dialog):
         assert_msg = debug
         assert_msg += mycroft_responses(context)
 
-    assert passed, assert_msg
+    assert passed, assert_msg or 'Mycroft didn\'t respond'
 
 
 @then('"{skill}" should reply with "{example}"')

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -243,4 +243,7 @@ def then_messagebus_message(context, message_type):
         if cnt > 20:
             assert False, "Message not found"
             break
+        else:
+            cnt += 1
+
         time.sleep(0.5)

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -33,15 +33,15 @@ TIMEOUT = 10
 SLEEP_LENGTH = 0.25
 
 
-def find_dialog(skill_path, dialog):
+def find_dialog(skill_path, dialog, lang):
     """Check the usual location for dialogs.
 
     TODO: subfolders
     """
     if exists(join(skill_path, 'dialog')):
-        return join(skill_path, 'dialog', 'en-us', dialog)
+        return join(skill_path, 'dialog', lang, dialog)
     else:
-        return join(skill_path, 'locale', 'en-us', dialog)
+        return join(skill_path, 'locale', lang, dialog)
 
 
 def load_dialog_file(dialog_path):
@@ -68,9 +68,17 @@ def load_dialog_list(skill_path, dialog):
     return load_dialog_file(dialog_path), debug
 
 
-def dialog_from_sentence(sentence, skill_path):
-    """Find dialog file from example sentence."""
-    dialog_paths = join(skill_path, 'dialog', 'en-us', '*.dialog')
+def dialog_from_sentence(sentence, skill_path, lang):
+    """Find dialog file from example sentence.
+
+    Arguments:
+        sentence (str): Text to match
+        skill_path (str): path to skill directory
+        lang (str): language code to use
+
+    Returns (str): Dialog file best matching the sentence.
+    """
+    dialog_paths = join(skill_path, 'dialog', lang, '*.dialog')
     best = (None, 0)
     for path in glob(dialog_paths):
         patterns = load_dialog_file(path)
@@ -118,7 +126,7 @@ def given_english(context):
 def when_user_says(context, text):
     context.bus.emit(Message('recognizer_loop:utterance',
                              data={'utterances': [text],
-                                   'lang': 'en-us',
+                                   'lang': context.lang,
                                    'session': '',
                                    'ident': time.time()},
                              context={'client_name': 'mycroft_listener'}))
@@ -141,7 +149,7 @@ def then_dialog(context, skill, dialog):
 @then('"{skill}" should reply with "{example}"')
 def then_example(context, skill, example):
     skill_path = context.msm.find_skill(skill).path
-    dialog = dialog_from_sentence(example, skill_path)
+    dialog = dialog_from_sentence(example, skill_path, context.lang)
     print('Matching with the dialog file: {}'.format(dialog))
     assert dialog is not None, 'No matching dialog...'
     then_dialog(context, skill, dialog)
@@ -198,7 +206,7 @@ def then_user_follow_up(context, text):
     wait_while_speaking()
     context.bus.emit(Message('recognizer_loop:utterance',
                              data={'utterances': [text],
-                                   'lang': 'en-us',
+                                   'lang': context.lang,
                                    'session': '',
                                    'ident': time.time()},
                              context={'client_name': 'mycroft_listener'}))

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -137,6 +137,14 @@ def then_wait(msg_type, then_func, context, timeout=TIMEOUT):
     return False, debug
 
 
+def print_mycroft_responses(context):
+    messages = context.bus.get_messages('speak')
+    if len(messages) > 0:
+        print('Mycroft responded with:')
+        for m in messages:
+            print('Mycroft: "{}"'.format(m.data['utterance']))
+
+
 @then('"{skill}" should reply with dialog from "{dialog}"')
 def then_dialog(context, skill, dialog):
     def check_dialog(message):
@@ -146,6 +154,8 @@ def then_dialog(context, skill, dialog):
     passed, debug = then_wait('speak', check_dialog, context)
     if not passed:
         print(debug)
+        print_mycroft_responses(context)
+
     assert passed
 
 
@@ -182,6 +192,7 @@ def then_exactly(context, skill, text):
     passed, debug = then_wait('speak', check_exact_match, context)
     if not passed:
         print(debug)
+        print_mycroft_responses(context)
     assert passed
 
 
@@ -197,6 +208,7 @@ def then_contains(context, text):
 
     if not passed:
         print('No speech contained the expected content')
+        print_mycroft_responses(context)
     assert passed
 
 

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -1,0 +1,217 @@
+# Copyright 2017 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Predefined step definitions for handling dialog interaction with Mycroft for
+use with behave.
+"""
+from os.path import join, exists, basename
+from glob import glob
+import re
+import time
+
+from behave import given, when, then
+
+from mycroft.messagebus import Message
+
+
+TIMEOUT = 10
+
+
+def find_dialog(skill_path, dialog):
+    """Check the usual location for dialogs.
+
+    TODO: subfolders
+    """
+    if exists(join(skill_path, 'dialog')):
+        return join(skill_path, 'dialog', 'en-us', dialog)
+    else:
+        return join(skill_path, 'locale', 'en-us', dialog)
+
+
+def load_dialog_file(dialog_path):
+    """Load dialog files and get the contents."""
+    with open(dialog_path) as f:
+        lines = f.readlines()
+    return [l.strip().lower() for l in lines
+            if l.strip() != '' and l.strip()[0] != '#']
+
+
+def load_dialog_list(skill_path, dialog):
+    """Load dialog from files into a single list.
+
+    Arguments:
+        skill (MycroftSkill): skill to load dialog from
+        dialog (list): Dialog names (str) to load
+
+    Returns:
+        tuple (list of Expanded dialog strings, debug string)
+    """
+    dialog_path = find_dialog(skill_path, dialog)
+
+    debug = 'Opening {}\n'.format(dialog_path)
+    return load_dialog_file(dialog_path), debug
+
+
+def dialog_from_sentence(sentence, skill_path):
+    """Find dialog file from example sentence."""
+    dialog_paths = join(skill_path, 'dialog', 'en-us', '*.dialog')
+    best = (None, 0)
+    for path in glob(dialog_paths):
+        patterns = load_dialog_file(path)
+        match, _ = _match_dialog_patterns(patterns, sentence.lower())
+        if match is not False:
+            if len(patterns[match]) > best[1]:
+                best = (path, len(patterns[match]))
+    if best[0] is not None:
+        return basename(best[0])
+    else:
+        return None
+
+
+def _match_dialog_patterns(dialogs, sentence):
+    """Match sentence against a list of dialog patterns.
+
+    Returns index of found match.
+    """
+    # Allow custom fields to be anything
+    dialogs = [re.sub(r'{.*?\}', r'.*', dia) for dia in dialogs]
+    # Remove left over '}'
+    dialogs = [re.sub(r'\}', r'', dia) for dia in dialogs]
+    dialogs = [re.sub(r' .* ', r' .*', dia) for dia in dialogs]
+    # Merge consequtive .*'s into a single .*
+    dialogs = [re.sub(r'\.\*( \.\*)+', r'.*', dia) for dia in dialogs]
+    # Remove double whitespaces
+    dialogs = ['^' + ' '.join(dia.split()) for dia in dialogs]
+    debug = 'MATCHING: {}\n'.format(sentence)
+    for index, regex in enumerate(dialogs):
+        match = re.match(regex, sentence)
+        debug += '---------------\n'
+        debug += '{} {}\n'.format(regex, match is not None)
+        if match:
+            return index, debug
+    else:
+        return False, debug
+
+
+def match_dialog_patterns(dialogs, sentence):
+    """Match sentence against a list of dialog patterns.
+
+    Returns simple True/False and not index
+    """
+    index, debug = _match_dialog_patterns(dialogs, sentence)
+    return index is not False, debug
+
+
+def expected_dialog_check(utterance, skill_path, dialog):
+    """Check that expected dialog file is used. """
+    dialogs, load_debug = load_dialog_list(skill_path, dialog)
+    match, match_debug = match_dialog_patterns(dialogs, utterance)
+    return match, load_debug + match_debug
+
+
+@given('an english speaking user')
+def given_impl(context):
+    context.lang = 'en-us'
+
+
+@when('the user says "{text}"')
+def when_impl(context, text):
+    context.bus.emit(Message('recognizer_loop:utterance',
+                             data={'utterances': [text],
+                                   'lang': 'en-us',
+                                   'session': '',
+                                   'ident': time.time()},
+                             context={'client_name': 'mycroft_listener'}))
+
+
+def then_timeout(then_func, context, timeout=TIMEOUT):
+    count = 0
+    debug = ''
+    while count < TIMEOUT:
+        for message in context.speak_messages:
+            status, test_dbg = then_func(message)
+            debug += test_dbg
+            if status:
+                context.matched_message = message
+                return True, debug
+        time.sleep(1)
+        count += 1
+    # Timed out return debug from test
+    return False, debug
+
+
+@then('"{skill}" should reply with dialog from "{dialog}"')
+def then_dialog(context, skill, dialog):
+    skill_path = context.msm.find_skill(skill).path
+
+    def check_dialog(message):
+        utt = message.data['utterance'].lower()
+        return expected_dialog_check(utt, skill_path, dialog)
+
+    passed, debug = then_timeout(check_dialog, context)
+    if not passed:
+        print(debug)
+    assert passed
+
+
+@then('"{skill}" should reply with "{example}"')
+def then_example(context, skill, example):
+    skill_path = context.msm.find_skill(skill).path
+    dialog = dialog_from_sentence(example, skill_path)
+    print('Matching with the dialog file: {}'.format(dialog))
+    assert dialog is not None
+    then_dialog(context, skill, dialog)
+
+
+@then('"{skill}" should reply with anything')
+def then_anything(context, skill):
+    def check_any_messages(message):
+        debug = ''
+        result = message is not None
+        return (result, debug)
+
+    passed = then_timeout(check_any_messages, context)
+    if not passed:
+        print('No speech recieved at all.')
+    assert passed
+
+
+@then('"{skill}" should reply with exactly "{text}"')
+def then_exactly(context, skill, text):
+    def check_exact_match(message):
+        utt = message.data['utterance'].lower()
+        debug = 'Comparing {} with expected {}\n'.format(utt, text)
+        result = utt == text.lower()
+        return (result, debug)
+
+    passed, debug = then_timeout(check_exact_match, context)
+    if not passed:
+        print(debug)
+    assert passed
+
+
+@then('mycroft reply should contain "{text}"')
+def then_contains(context, text):
+    def check_contains(message):
+        utt = message.data['utterance'].lower()
+        debug = 'Checking if "{}" contains "{}"\n'.format(utt, text)
+        result = text.lower() in utt
+        return (result, debug)
+
+    passed, debug = then_timeout(check_contains, context)
+
+    if not passed:
+        print('No speech contained the expected content')
+    assert passed

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -28,6 +28,7 @@ from mycroft.audio import wait_while_speaking
 
 
 TIMEOUT = 10
+SLEEP_LENGTH = 0.25
 
 
 def find_dialog(skill_path, dialog):
@@ -124,7 +125,7 @@ def when_user_says(context, text):
 def then_wait(msg_type, then_func, context, timeout=TIMEOUT):
     count = 0
     debug = ''
-    while count < TIMEOUT:
+    while count < int(timeout * (1 / SLEEP_LENGTH)):
         for message in context.bus.get_messages(msg_type):
             status, test_dbg = then_func(message)
             debug += test_dbg
@@ -132,7 +133,7 @@ def then_wait(msg_type, then_func, context, timeout=TIMEOUT):
                 context.matched_message = message
                 context.bus.remove_message(message)
                 return True, debug
-        time.sleep(1)
+        time.sleep(SLEEP_LENGTH)
         count += 1
     # Timed out return debug from test
     return False, debug
@@ -240,10 +241,10 @@ def then_user_follow_up(context, text):
 def then_messagebus_message(context, message_type):
     cnt = 0
     while context.bus.get_messages(message_type) == []:
-        if cnt > 20:
+        if cnt > int(TIMEOUT * (1.0 / SLEEP_LENGTH)):
             assert False, "Message not found"
             break
         else:
             cnt += 1
 
-        time.sleep(0.5)
+        time.sleep(SLEEP_LENGTH)

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -26,6 +26,8 @@ from behave import given, when, then
 from mycroft.messagebus import Message
 from mycroft.audio import wait_while_speaking
 
+from test.integrationtests.voight_kampff import mycroft_responses, then_wait
+
 
 TIMEOUT = 10
 SLEEP_LENGTH = 0.25
@@ -120,41 +122,6 @@ def when_user_says(context, text):
                                    'session': '',
                                    'ident': time.time()},
                              context={'client_name': 'mycroft_listener'}))
-
-
-def then_wait(msg_type, then_func, context, timeout=TIMEOUT):
-    count = 0
-    debug = ''
-    while count < int(timeout * (1 / SLEEP_LENGTH)):
-        for message in context.bus.get_messages(msg_type):
-            status, test_dbg = then_func(message)
-            debug += test_dbg
-            if status:
-                context.matched_message = message
-                context.bus.remove_message(message)
-                return True, debug
-        time.sleep(SLEEP_LENGTH)
-        count += 1
-    # Timed out return debug from test
-    return False, debug
-
-
-def mycroft_responses(context):
-    responses = ''
-    messages = context.bus.get_messages('speak')
-    if len(messages) > 0:
-        responses = 'Mycroft responded with:\n'
-        for m in messages:
-            responses += 'Mycroft: '
-            if 'dialog' in m.data['meta']:
-                responses += '{}.dialog'.format(m.data['meta']['dialog'])
-            responses += '({})\n'.format(m.data['meta'].get('skill'))
-            responses += '"{}"\n'.format(m.data['utterance'])
-    return responses
-
-
-def print_mycroft_responses(context):
-    print(mycroft_responses(context))
 
 
 @then('"{skill}" should reply with dialog from "{dialog}"')

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -144,7 +144,11 @@ def mycroft_responses(context):
     if len(messages) > 0:
         responses = 'Mycroft responded with:\n'
         for m in messages:
-            responses += 'Mycroft: "{}"\n'.format(m.data['utterance'])
+            responses += 'Mycroft: '
+            if 'dialog' in m.data['meta']:
+                responses += '{}.dialog'.format(m.data['meta']['dialog'])
+            responses += '({})\n'.format(m.data['meta'].get('skill'))
+            responses += '"{}"\n'.format(m.data['utterance'])
     return responses
 
 

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -24,6 +24,7 @@ import time
 from behave import given, when, then
 
 from mycroft.messagebus import Message
+from mycroft.audio import wait_while_speaking
 
 
 TIMEOUT = 10
@@ -215,3 +216,15 @@ def then_contains(context, text):
     if not passed:
         print('No speech contained the expected content')
     assert passed
+
+
+@then('the user says "{text}"')
+def when_impl(context, text):
+    time.sleep(2)
+    wait_while_speaking()
+    context.bus.emit(Message('recognizer_loop:utterance',
+                             data={'utterances': [text],
+                                   'lang': 'en-us',
+                                   'session': '',
+                                   'ident': time.time()},
+                             context={'client_name': 'mycroft_listener'}))

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -130,6 +130,7 @@ def then_wait(msg_type, then_func, context, timeout=TIMEOUT):
             debug += test_dbg
             if status:
                 context.matched_message = message
+                context.bus.remove_message(message)
                 return True, debug
         time.sleep(1)
         count += 1
@@ -213,6 +214,7 @@ def then_contains(context, text):
     if not passed:
         assert_msg = 'No speech contained the expected content'
         assert_msg += mycroft_responses(context)
+
     assert passed, assert_msg
 
 

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -222,3 +222,13 @@ def then_user_follow_up(context, text):
                                    'session': '',
                                    'ident': time.time()},
                              context={'client_name': 'mycroft_listener'}))
+
+
+@then('mycroft should send the message "{message_type}"')
+def then_messagebus_message(context, message_type):
+    cnt = 0
+    while context.bus.get_messages(message_type) == []:
+        if cnt > 20:
+            assert False, "Message not found"
+            break
+        time.sleep(0.5)

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -212,6 +212,8 @@ def then_contains(context, text):
     assert passed
 
 
+@then('the user replies with "{text}"')
+@then('the user replies "{text}"')
 @then('the user says "{text}"')
 def then_user_follow_up(context, text):
     time.sleep(2)

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -137,12 +137,18 @@ def then_wait(msg_type, then_func, context, timeout=TIMEOUT):
     return False, debug
 
 
-def print_mycroft_responses(context):
+def mycroft_responses(context):
+    responses = ''
     messages = context.bus.get_messages('speak')
     if len(messages) > 0:
-        print('Mycroft responded with:')
+        responses = 'Mycroft responded with:\n'
         for m in messages:
-            print('Mycroft: "{}"'.format(m.data['utterance']))
+            responses += 'Mycroft: "{}"\n'.format(m.data['utterance'])
+    return responses
+
+
+def print_mycroft_responses(context):
+    print(mycroft_responses(context))
 
 
 @then('"{skill}" should reply with dialog from "{dialog}"')
@@ -153,10 +159,10 @@ def then_dialog(context, skill, dialog):
 
     passed, debug = then_wait('speak', check_dialog, context)
     if not passed:
-        print(debug)
-        print_mycroft_responses(context)
+        assert_msg = debug
+        assert_msg += mycroft_responses(context)
 
-    assert passed
+    assert passed, assert_msg
 
 
 @then('"{skill}" should reply with "{example}"')
@@ -164,7 +170,7 @@ def then_example(context, skill, example):
     skill_path = context.msm.find_skill(skill).path
     dialog = dialog_from_sentence(example, skill_path)
     print('Matching with the dialog file: {}'.format(dialog))
-    assert dialog is not None
+    assert dialog is not None, 'No matching dialog...'
     then_dialog(context, skill, dialog)
 
 
@@ -176,9 +182,7 @@ def then_anything(context, skill):
         return (result, debug)
 
     passed = then_wait('speak', check_any_messages, context)
-    if not passed:
-        print('No speech recieved at all.')
-    assert passed
+    assert passed, 'No speech received at all'
 
 
 @then('"{skill}" should reply with exactly "{text}"')
@@ -191,9 +195,9 @@ def then_exactly(context, skill, text):
 
     passed, debug = then_wait('speak', check_exact_match, context)
     if not passed:
-        print(debug)
-        print_mycroft_responses(context)
-    assert passed
+        assert_msg = debug
+        assert_msg += mycroft_responses(context)
+    assert passed, assert_msg
 
 
 @then('mycroft reply should contain "{text}"')
@@ -207,9 +211,9 @@ def then_contains(context, text):
     passed, debug = then_wait('speak', check_contains, context)
 
     if not passed:
-        print('No speech contained the expected content')
-        print_mycroft_responses(context)
-    assert passed
+        assert_msg = 'No speech contained the expected content'
+        assert_msg += mycroft_responses(context)
+    assert passed, assert_msg
 
 
 @then('the user replies with "{text}"')

--- a/test/integrationtests/voight_kampff/generate_feature.py
+++ b/test/integrationtests/voight_kampff/generate_feature.py
@@ -1,0 +1,65 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from glob import glob
+import json
+from pathlib import Path
+import sys
+
+"""Convert existing intent tests to behave tests."""
+
+TEMPLATE = """
+  Scenario: {scenario}
+    Given an english speaking user
+     When the user says "{utterance}"
+     Then "{skill}" should reply with dialog from "{dialog_file}.dialog"
+"""
+
+
+def json_files(path):
+    """Generator function returning paths of all json files in a folder."""
+    for json_file in sorted(glob(str(Path(path, '*.json')))):
+        yield Path(json_file)
+
+
+def generate_feature(skill, skill_path):
+    """Generate a feature file provided a skill name and a path to the skill.
+    """
+    test_path = Path(skill_path, 'test', 'intent')
+    case = []
+    if test_path.exists() and test_path.is_dir():
+        for json_file in json_files(test_path):
+            with open(str(json_file)) as test_file:
+                test = json.load(test_file)
+                if 'utterance' and 'expected_dialog' in test:
+                    utt = test['utterance']
+                    dialog = test['expected_dialog']
+                    # Simple handling of multiple accepted dialogfiles
+                    if isinstance(dialog, list):
+                        dialog = dialog[0]
+
+                    case.append((json_file.name, utt, dialog))
+
+    output = ''
+    if case:
+        output += 'Feature: {}\n'.format(skill)
+    for c in case:
+        output += TEMPLATE.format(skill=skill, scenario=c[0],
+                                  utterance=c[1], dialog_file=c[2])
+
+    return output
+
+
+if __name__ == '__main__':
+    print(generate_feature(*sys.argv[1:]))

--- a/test/integrationtests/voight_kampff/run_test_suite.sh
+++ b/test/integrationtests/voight_kampff/run_test_suite.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Script to setup the integration test environment and run the tests.
+#
+# The comands runing in this script are those that need to be executed at
+# runtime. Assumes running within a Docker container where the PATH environment
+# variable has been set to include the virtual envionrment's bin directory
+
+# Start all mycroft core services.
+pwd
+/opt/mycroft/mycroft-core/start-mycroft.sh all
+# Run the integration test suite.  Results will be formatted for input into
+# the Allure reporting tool.
+behave -f allure_behave.formatter:AllureFormatter -o allure-results
+RESULT=$?
+# Stop all mycroft core services.
+/opt/mycroft/mycroft-core/stop-mycroft.sh all
+
+# Remove temporary skill files
+rm -rf ~/.mycroft/skills
+# Remove intent cache
+rm -rf ~/.mycroft/intent_cache
+
+exit $RESULT

--- a/test/integrationtests/voight_kampff/run_test_suite.sh
+++ b/test/integrationtests/voight_kampff/run_test_suite.sh
@@ -14,11 +14,6 @@ behave $@
 RESULT=$?
 # Stop all mycroft core services.
 /opt/mycroft/mycroft-core/stop-mycroft.sh all
-# Make the jenkins user the owner of the allure results.  This allows the
-# jenkins job to build a report from the results
-# Remove temporary skill files
-rm -rf ~/.mycroft/skills
-# Remove intent cache
-rm -rf ~/.mycroft/intent_cache
 
+# Reort the result of the behave test as exit status
 exit $RESULT

--- a/test/integrationtests/voight_kampff/run_test_suite.sh
+++ b/test/integrationtests/voight_kampff/run_test_suite.sh
@@ -6,15 +6,16 @@
 # variable has been set to include the virtual envionrment's bin directory
 
 # Start all mycroft core services.
-pwd
 /opt/mycroft/mycroft-core/start-mycroft.sh all
 # Run the integration test suite.  Results will be formatted for input into
 # the Allure reporting tool.
-behave -f allure_behave.formatter:AllureFormatter -o allure-results
+behave -f allure_behave.formatter:AllureFormatter -o ~/.mycroft/allure-result
 RESULT=$?
 # Stop all mycroft core services.
 /opt/mycroft/mycroft-core/stop-mycroft.sh all
-
+# Make the jenkins user the owner of the allure results.  This allows the
+# jenkins job to build a report from the results
+chown --recursive 110:116 ~/.mycroft/allure-result
 # Remove temporary skill files
 rm -rf ~/.mycroft/skills
 # Remove intent cache

--- a/test/integrationtests/voight_kampff/run_test_suite.sh
+++ b/test/integrationtests/voight_kampff/run_test_suite.sh
@@ -9,13 +9,13 @@
 /opt/mycroft/mycroft-core/start-mycroft.sh all
 # Run the integration test suite.  Results will be formatted for input into
 # the Allure reporting tool.
-behave -f allure_behave.formatter:AllureFormatter -o ~/.mycroft/allure-result
+echo "Running behave with the arguments \"$@\""
+behave $@
 RESULT=$?
 # Stop all mycroft core services.
 /opt/mycroft/mycroft-core/stop-mycroft.sh all
 # Make the jenkins user the owner of the allure results.  This allows the
 # jenkins job to build a report from the results
-chown --recursive 110:116 ~/.mycroft/allure-result
 # Remove temporary skill files
 rm -rf ~/.mycroft/skills
 # Remove intent cache

--- a/test/integrationtests/voight_kampff/run_test_suite.sh
+++ b/test/integrationtests/voight_kampff/run_test_suite.sh
@@ -5,8 +5,14 @@
 # runtime. Assumes running within a Docker container where the PATH environment
 # variable has been set to include the virtual envionrment's bin directory
 
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Start pulseaudio if running in CI environment
+if [[ -v CI ]]; then
+    pulseaudio -D
+fi
 # Start all mycroft core services.
-/opt/mycroft/mycroft-core/start-mycroft.sh all
+${SCRIPT_DIR}/../../../start-mycroft.sh all
 # Run the integration test suite.  Results will be formatted for input into
 # the Allure reporting tool.
 echo "Running behave with the arguments \"$@\""

--- a/test/integrationtests/voight_kampff/test_setup.py
+++ b/test/integrationtests/voight_kampff/test_setup.py
@@ -1,0 +1,149 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import argparse
+from glob import glob
+from os.path import join, dirname, expanduser, basename
+from pathlib import Path
+from random import shuffle
+import shutil
+import sys
+
+import yaml
+
+from msm import MycroftSkillsManager
+
+from .generate_feature import generate_feature
+
+"""Test environment setup for voigt kampff test
+
+The script sets up the selected tests in the feature directory so they can
+be found and executed by the behave framework.
+
+The script also ensures that the tested skills are installed and that any
+specified extra skills also gets installed into the environment.
+"""
+
+FEATURE_DIR = join(dirname(__file__), 'features') + '/'
+
+
+def copy_feature_files(source, destination):
+    """Copy all feature files from source to destination."""
+    # Copy feature files to the feature directory
+    for f in glob(join(source, '*.feature')):
+        shutil.copyfile(f, join(destination, basename(f)))
+
+
+def copy_step_files(source, destination):
+    """Copy all python files from source to destination."""
+    # Copy feature files to the feature directory
+    for f in glob(join(source, '*.py')):
+        shutil.copyfile(f, join(destination, basename(f)))
+
+
+def load_config(config, args):
+    """Load config and add to unset arguments."""
+    with open(expanduser(config)) as f:
+        conf_dict = yaml.safe_load(f)
+
+    if not args.tested_skills:
+        args.tested_skills = conf_dict['tested_skills']
+    if not args.extra_skills:
+        args.extra_skills = conf_dict['extra_skills']
+    if not args.platform:
+        args.platform = conf_dict['platform']
+    return
+
+
+def main(cmdline_args):
+    """Parse arguments and run environment setup."""
+    platforms = list(MycroftSkillsManager.SKILL_GROUPS)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-p', '--platform', choices=platforms)
+    parser.add_argument('-t', '--tested-skills', default=[])
+    parser.add_argument('-s', '--extra-skills', default=[])
+    parser.add_argument('-r', '--random-skills', default=0)
+    parser.add_argument('-d', '--skills-dir')
+    parser.add_argument('-c', '--config')
+
+    args = parser.parse_args(cmdline_args)
+    if args.tested_skills:
+        args.tested_skills = args.tested_skills.replace(',', ' ').split()
+    if args.extra_skills:
+        args.extra_skills = args.extra_skills.replace(',', ' ').split()
+
+    if args.config:
+        load_config(args.config, args)
+
+    if args.platform is None:
+        args.platform = "mycroft_mark_1"
+
+    msm = MycroftSkillsManager(args.platform, args.skills_dir)
+    run_setup(msm, args.tested_skills, args.extra_skills, args.random_skills)
+
+
+def run_setup(msm, test_skills, extra_skills, num_random_skills):
+    """Install needed skills and collect feature files for the test."""
+    skills = [msm.find_skill(s) for s in test_skills + extra_skills]
+    # Install test skills
+    for s in skills:
+        if not s.is_local:
+            print('Installing {}'.format(s))
+            msm.install(s)
+
+    # collect feature files
+    for skill_name in test_skills:
+        skill = msm.find_skill(skill_name)
+        behave_dir = join(skill.path, 'test', 'behave')
+        if Path(behave_dir).exists():
+            copy_feature_files(behave_dir, FEATURE_DIR)
+
+            step_dir = join(behave_dir, 'steps')
+            if Path().exists():
+                copy_step_files(step_dir, join(FEATURE_DIR, 'steps'))
+        else:
+            # Generate feature file if no data exists yet
+            print('No feature files exists for {}, '
+                  'generating...'.format(skill_name))
+            # No feature files setup, generate automatically
+            feature = generate_feature(skill_name, skill.path)
+            with open(join(FEATURE_DIR, skill_name + '.feature'), 'w') as f:
+                f.write(feature)
+
+    # Install random skills from uninstalled skill list
+    random_skills = [s for s in msm.all_skills if s not in msm.local_skills]
+    shuffle(random_skills)  # Make them random
+    random_skills = random_skills[:num_random_skills]
+    for s in random_skills:
+        msm.install(s)
+
+    print_install_report(msm.platform, test_skills,
+                         extra_skills + [s.name for s in random_skills])
+    return
+
+
+def print_install_report(platform, test_skills, extra_skills):
+    """Print in nice format."""
+    print('-------- TEST SETUP --------')
+    yml = yaml.dump({
+        'platform': platform,
+        'tested_skills': test_skills,
+        'extra_skills': extra_skills
+        })
+    print(yml)
+    print('----------------------------')
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/test/integrationtests/voight_kampff/test_setup.py
+++ b/test/integrationtests/voight_kampff/test_setup.py
@@ -205,7 +205,11 @@ def main(cmdline_args):
     This installs and/or upgrades any skills needed for the tests and
     collects the feature and step files for the skills.
     """
-    args = get_arguments(cmdline_args)
+    is_pre_parsed = type(cmdline_args).__name__ == 'Namespace'
+    if is_pre_parsed:
+        args = cmdline_args
+    else:
+        args = get_arguments(cmdline_args)
     if args.config:
         apply_config(args.config, args)
 

--- a/test/integrationtests/voight_kampff/test_setup.py
+++ b/test/integrationtests/voight_kampff/test_setup.py
@@ -21,7 +21,7 @@ import shutil
 import sys
 
 import yaml
-from msm import MycroftSkillsManager
+from msm import MycroftSkillsManager, SkillRepo
 from msm.exceptions import MsmException
 
 from .generate_feature import generate_feature
@@ -94,6 +94,10 @@ def create_argument_parser():
     parser.add_argument('-r', '--random-skills', default=0, type=int,
                         help='Number of random skills to install.')
     parser.add_argument('-d', '--skills-dir')
+    parser.add_argument('-u', '--repo-url',
+                        help='URL for skills repo to install / update from')
+    parser.add_argument('-b', '--branch',
+                        help='repo branch to use')
     parser.add_argument('-c', '--config',
                         help='Path to test configuration file.')
     return parser
@@ -179,6 +183,22 @@ def get_arguments(cmdline_args):
     return args
 
 
+def create_skills_manager(platform, skills_dir, url, branch):
+    """Create mycroft skills manager for the given url / branch.
+
+    Arguments:
+        platform (str): platform to use
+        skills_dir (str): skill directory to use
+        url (str): skills repo url
+        branch (str): skills repo branch
+
+    Returns:
+        MycroftSkillsManager
+    """
+    repo = SkillRepo(url=url, branch=branch)
+    return MycroftSkillsManager(platform, skills_dir, repo)
+
+
 def main(cmdline_args):
     """Parse arguments and run test environment setup.
 
@@ -189,7 +209,8 @@ def main(cmdline_args):
     if args.config:
         apply_config(args.config, args)
 
-    msm = MycroftSkillsManager(args.platform, args.skills_dir)
+    msm = create_skills_manager(args.platform, args.skills_dir,
+                                args.repo_url, args.branch)
 
     random_skills = get_random_skills(msm, args.random_skills)
     all_skills = args.test_skills + args.extra_skills + random_skills

--- a/test/integrationtests/voight_kampff/test_setup.py
+++ b/test/integrationtests/voight_kampff/test_setup.py
@@ -58,11 +58,11 @@ def load_config(config, args):
     with open(expanduser(config)) as f:
         conf_dict = yaml.safe_load(f)
 
-    if not args.tested_skills:
+    if not args.tested_skills and 'tested_skills' in conf_dict:
         args.tested_skills = conf_dict['tested_skills']
-    if not args.extra_skills:
+    if not args.extra_skills and 'extra_skills' in conf_dict:
         args.extra_skills = conf_dict['extra_skills']
-    if not args.platform:
+    if not args.platform and 'platform' in conf_dict:
         args.platform = conf_dict['platform']
     return
 

--- a/test/integrationtests/voight_kampff/test_setup.py
+++ b/test/integrationtests/voight_kampff/test_setup.py
@@ -199,17 +199,12 @@ def create_skills_manager(platform, skills_dir, url, branch):
     return MycroftSkillsManager(platform, skills_dir, repo)
 
 
-def main(cmdline_args):
+def main(args):
     """Parse arguments and run test environment setup.
 
     This installs and/or upgrades any skills needed for the tests and
     collects the feature and step files for the skills.
     """
-    is_pre_parsed = type(cmdline_args).__name__ == 'Namespace'
-    if is_pre_parsed:
-        args = cmdline_args
-    else:
-        args = get_arguments(cmdline_args)
     if args.config:
         apply_config(args.config, args)
 
@@ -227,4 +222,4 @@ def main(cmdline_args):
 
 
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    main(get_arguments(sys.argv[1:]))

--- a/test/integrationtests/voight_kampff/test_setup.py
+++ b/test/integrationtests/voight_kampff/test_setup.py
@@ -32,8 +32,8 @@ from .generate_feature import generate_feature
 The script sets up the selected tests in the feature directory so they can
 be found and executed by the behave framework.
 
-The script also ensures that the tested skills are installed and that any
-specified extra skills also gets installed into the environment.
+The script also ensures that the skills marked for testing are installed and
+that anyi specified extra skills also gets installed into the environment.
 """
 
 FEATURE_DIR = join(dirname(__file__), 'features') + '/'
@@ -58,8 +58,8 @@ def load_config(config, args):
     with open(expanduser(config)) as f:
         conf_dict = yaml.safe_load(f)
 
-    if not args.tested_skills and 'tested_skills' in conf_dict:
-        args.tested_skills = conf_dict['tested_skills']
+    if not args.test_skills and 'test_skills' in conf_dict:
+        args.test_skills = conf_dict['test_skills']
     if not args.extra_skills and 'extra_skills' in conf_dict:
         args.extra_skills = conf_dict['extra_skills']
     if not args.platform and 'platform' in conf_dict:
@@ -72,15 +72,15 @@ def main(cmdline_args):
     platforms = list(MycroftSkillsManager.SKILL_GROUPS)
     parser = argparse.ArgumentParser()
     parser.add_argument('-p', '--platform', choices=platforms)
-    parser.add_argument('-t', '--tested-skills', default=[])
+    parser.add_argument('-t', '--test-skills', default=[])
     parser.add_argument('-s', '--extra-skills', default=[])
     parser.add_argument('-r', '--random-skills', default=0)
     parser.add_argument('-d', '--skills-dir')
     parser.add_argument('-c', '--config')
 
     args = parser.parse_args(cmdline_args)
-    if args.tested_skills:
-        args.tested_skills = args.tested_skills.replace(',', ' ').split()
+    if args.test_skills:
+        args.test_skills = args.test_skills.replace(',', ' ').split()
     if args.extra_skills:
         args.extra_skills = args.extra_skills.replace(',', ' ').split()
 
@@ -91,7 +91,7 @@ def main(cmdline_args):
         args.platform = "mycroft_mark_1"
 
     msm = MycroftSkillsManager(args.platform, args.skills_dir)
-    run_setup(msm, args.tested_skills, args.extra_skills, args.random_skills)
+    run_setup(msm, args.test_skills, args.extra_skills, args.random_skills)
 
 
 def run_setup(msm, test_skills, extra_skills, num_random_skills):
@@ -144,7 +144,7 @@ def print_install_report(platform, test_skills, extra_skills):
     print('-------- TEST SETUP --------')
     yml = yaml.dump({
         'platform': platform,
-        'tested_skills': test_skills,
+        'test_skills': test_skills,
         'extra_skills': extra_skills
         })
     print(yml)

--- a/test/integrationtests/voight_kampff/test_setup.py
+++ b/test/integrationtests/voight_kampff/test_setup.py
@@ -15,14 +15,12 @@
 import argparse
 from argparse import RawTextHelpFormatter
 from glob import glob
-from os.path import join, dirname, expanduser, basename
-from pathlib import Path
+from os.path import join, dirname, expanduser, basename, exists
 from random import shuffle
 import shutil
 import sys
 
 import yaml
-
 from msm import MycroftSkillsManager
 from msm.exceptions import MsmException
 
@@ -54,7 +52,7 @@ def copy_step_files(source, destination):
         shutil.copyfile(f, join(destination, basename(f)))
 
 
-def load_config(config, args):
+def apply_config(config, args):
     """Load config and add to unset arguments."""
     with open(expanduser(config)) as f:
         conf_dict = yaml.safe_load(f)
@@ -65,47 +63,57 @@ def load_config(config, args):
         args.extra_skills = conf_dict['extra_skills']
     if not args.platform and 'platform' in conf_dict:
         args.platform = conf_dict['platform']
-    return
 
 
-def main(cmdline_args):
-    """Parse arguments and run environment setup."""
+def create_argument_parser():
+    """Create the argument parser for the command line options.
+
+    Returns: ArgumentParser
+    """
+    class TestSkillAction(argparse.Action):
+        def __call__(self, parser, args, values, option_string=None):
+            args.test_skills = values.replace(',', ' ').split()
+
+    class ExtraSkillAction(argparse.Action):
+        def __call__(self, parser, args, values, option_string=None):
+            args.extra_skills = values.replace(',', ' ').split()
+
     platforms = list(MycroftSkillsManager.SKILL_GROUPS)
     parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter)
-    parser.add_argument('-p', '--platform', choices=platforms)
+    parser.add_argument('-p', '--platform', choices=platforms,
+                        default='mycroft_mark_1')
     parser.add_argument('-t', '--test-skills', default=[],
+                        action=TestSkillAction,
                         help=('Comma-separated list of skills to test.\n'
                               'Ex: "mycroft-weather, mycroft-stock"'))
     parser.add_argument('-s', '--extra-skills', default=[],
+                        action=ExtraSkillAction,
                         help=('Comma-separated list of extra skills to '
                               'install.\n'
                               'Ex: "cocktails, laugh"'))
-    parser.add_argument('-r', '--random-skills', default=0,
+    parser.add_argument('-r', '--random-skills', default=0, type=int,
                         help='Number of random skills to install.')
     parser.add_argument('-d', '--skills-dir')
     parser.add_argument('-c', '--config',
                         help='Path to test configuration file.')
-
-    args = parser.parse_args(cmdline_args)
-    if args.test_skills:
-        args.test_skills = args.test_skills.replace(',', ' ').split()
-    if args.extra_skills:
-        args.extra_skills = args.extra_skills.replace(',', ' ').split()
-
-    if args.config:
-        load_config(args.config, args)
-
-    if args.platform is None:
-        args.platform = "mycroft_mark_1"
-
-    msm = MycroftSkillsManager(args.platform, args.skills_dir)
-    run_setup(msm, args.test_skills, args.extra_skills, args.random_skills)
+    return parser
 
 
-def run_setup(msm, test_skills, extra_skills, num_random_skills):
-    """Install needed skills and collect feature files for the test."""
-    skills = [msm.find_skill(s) for s in test_skills + extra_skills]
-    # Install test skills
+def get_random_skills(msm, num_random_skills):
+    """Install random skills from uninstalled skill list."""
+    random_skills = [s for s in msm.all_skills if not s.is_local]
+    shuffle(random_skills)  # Make them random
+    return [s.name for s in random_skills[:num_random_skills]]
+
+
+def install_or_upgrade_skills(msm, skills):
+    """Install needed skills if uninstalled, otherwise try to update.
+
+    Arguments:
+        msm: msm instance to use for the operations
+        skills: list of skills
+    """
+    skills = [msm.find_skill(s) for s in skills]
     for s in skills:
         if not s.is_local:
             print('Installing {}'.format(s))
@@ -116,15 +124,22 @@ def run_setup(msm, test_skills, extra_skills, num_random_skills):
             except MsmException:
                 pass
 
-    # collect feature files
-    for skill_name in test_skills:
+
+def collect_test_cases(msm, skills):
+    """Collect feature files and step files for each skill.
+
+    Arguments:
+        msm: msm instance to use for the operations
+        skills: list of skills
+    """
+    for skill_name in skills:
         skill = msm.find_skill(skill_name)
         behave_dir = join(skill.path, 'test', 'behave')
-        if Path(behave_dir).exists():
+        if exists(behave_dir):
             copy_feature_files(behave_dir, FEATURE_DIR)
 
             step_dir = join(behave_dir, 'steps')
-            if Path().exists():
+            if exists(step_dir):
                 copy_step_files(step_dir, join(FEATURE_DIR, 'steps'))
         else:
             # Generate feature file if no data exists yet
@@ -134,17 +149,6 @@ def run_setup(msm, test_skills, extra_skills, num_random_skills):
             feature = generate_feature(skill_name, skill.path)
             with open(join(FEATURE_DIR, skill_name + '.feature'), 'w') as f:
                 f.write(feature)
-
-    # Install random skills from uninstalled skill list
-    random_skills = [s for s in msm.all_skills if s not in msm.local_skills]
-    shuffle(random_skills)  # Make them random
-    random_skills = random_skills[:num_random_skills]
-    for s in random_skills:
-        msm.install(s)
-
-    print_install_report(msm.platform, test_skills,
-                         extra_skills + [s.name for s in random_skills])
-    return
 
 
 def print_install_report(platform, test_skills, extra_skills):
@@ -157,6 +161,44 @@ def print_install_report(platform, test_skills, extra_skills):
         })
     print(yml)
     print('----------------------------')
+
+
+def get_arguments(cmdline_args):
+    """Get arguments for test setup.
+
+    Parses the commandline and if specified applies configuration file.
+
+    Arguments:
+        cmdline_args (list): argv like list of arguments
+
+    Returns:
+        Argument parser NameSpace
+    """
+    parser = create_argument_parser()
+    args = parser.parse_args(cmdline_args)
+    return args
+
+
+def main(cmdline_args):
+    """Parse arguments and run test environment setup.
+
+    This installs and/or upgrades any skills needed for the tests and
+    collects the feature and step files for the skills.
+    """
+    args = get_arguments(cmdline_args)
+    if args.config:
+        apply_config(args.config, args)
+
+    msm = MycroftSkillsManager(args.platform, args.skills_dir)
+
+    random_skills = get_random_skills(msm, args.random_skills)
+    all_skills = args.test_skills + args.extra_skills + random_skills
+
+    install_or_upgrade_skills(msm, all_skills)
+    collect_test_cases(msm, args.test_skills)
+
+    print_install_report(msm.platform, args.test_skills,
+                         args.extra_skills + random_skills)
 
 
 if __name__ == '__main__':

--- a/test/integrationtests/voight_kampff/test_setup.py
+++ b/test/integrationtests/voight_kampff/test_setup.py
@@ -23,6 +23,7 @@ import sys
 import yaml
 
 from msm import MycroftSkillsManager
+from msm.exceptions import MsmException
 
 from .generate_feature import generate_feature
 
@@ -101,6 +102,11 @@ def run_setup(msm, test_skills, extra_skills, num_random_skills):
         if not s.is_local:
             print('Installing {}'.format(s))
             msm.install(s)
+        else:
+            try:
+                msm.update(s)
+            except MsmException:
+                pass
 
     # collect feature files
     for skill_name in test_skills:

--- a/test/integrationtests/voight_kampff/test_setup.py
+++ b/test/integrationtests/voight_kampff/test_setup.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import argparse
+from argparse import RawTextHelpFormatter
 from glob import glob
 from os.path import join, dirname, expanduser, basename
 from pathlib import Path
@@ -70,13 +71,20 @@ def load_config(config, args):
 def main(cmdline_args):
     """Parse arguments and run environment setup."""
     platforms = list(MycroftSkillsManager.SKILL_GROUPS)
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=RawTextHelpFormatter)
     parser.add_argument('-p', '--platform', choices=platforms)
-    parser.add_argument('-t', '--test-skills', default=[])
-    parser.add_argument('-s', '--extra-skills', default=[])
-    parser.add_argument('-r', '--random-skills', default=0)
+    parser.add_argument('-t', '--test-skills', default=[],
+                        help=('Comma-separated list of skills to test.\n'
+                              'Ex: "mycroft-weather, mycroft-stock"'))
+    parser.add_argument('-s', '--extra-skills', default=[],
+                        help=('Comma-separated list of extra skills to '
+                              'install.\n'
+                              'Ex: "cocktails, laugh"'))
+    parser.add_argument('-r', '--random-skills', default=0,
+                        help='Number of random skills to install.')
     parser.add_argument('-d', '--skills-dir')
-    parser.add_argument('-c', '--config')
+    parser.add_argument('-c', '--config',
+                        help='Path to test configuration file.')
 
     args = parser.parse_args(cmdline_args)
     if args.test_skills:

--- a/test/integrationtests/voight_kampff/tools.py
+++ b/test/integrationtests/voight_kampff/tools.py
@@ -20,6 +20,10 @@ import time
 from mycroft.messagebus import Message
 
 
+SLEEP_LENGTH = 0.25
+TIMEOUT = 10
+
+
 def emit_utterance(bus, utt):
     """Emit an utterance on the bus.
 
@@ -35,7 +39,7 @@ def emit_utterance(bus, utt):
                      context={'client_name': 'mycroft_listener'}))
 
 
-def wait_for_dialog(bus, dialogs, timeout=10):
+def wait_for_dialog(bus, dialogs, timeout=TIMEOUT):
     """Wait for one of the dialogs given as argument.
 
     Arguments:
@@ -43,11 +47,11 @@ def wait_for_dialog(bus, dialogs, timeout=10):
         dialogs (list): list of acceptable dialogs
         timeout (int): how long to wait for the messagem, defaults to 10 sec.
     """
-    for t in range(timeout):
+    for t in range(int(timeout * (1 / SLEEP_LENGTH))):
         for message in bus.get_messages('speak'):
             dialog = message.data.get('meta', {}).get('dialog')
             if dialog in dialogs:
                 bus.clear_messages()
                 return
-        time.sleep(1)
+        time.sleep(SLEEP_LENGTH)
     bus.clear_messages()

--- a/test/integrationtests/voight_kampff/tools.py
+++ b/test/integrationtests/voight_kampff/tools.py
@@ -1,0 +1,53 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Common tools to use when creating step files for behave tests."""
+
+import time
+
+from mycroft.messagebus import Message
+
+
+def emit_utterance(bus, utt):
+    """Emit an utterance on the bus.
+
+    Arguments:
+        bus (InterceptAllBusClient): Bus instance to listen on
+        dialogs (list): list of acceptable dialogs
+    """
+    bus.emit(Message('recognizer_loop:utterance',
+                     data={'utterances': [utt],
+                           'lang': 'en-us',
+                           'session': '',
+                           'ident': time.time()},
+                     context={'client_name': 'mycroft_listener'}))
+
+
+def wait_for_dialog(bus, dialogs, timeout=10):
+    """Wait for one of the dialogs given as argument.
+
+    Arguments:
+        bus (InterceptAllBusClient): Bus instance to listen on
+        dialogs (list): list of acceptable dialogs
+        timeout (int): how long to wait for the messagem, defaults to 10 sec.
+    """
+    for t in range(timeout):
+        for message in bus.get_messages('speak'):
+            dialog = message.data.get('meta', {}).get('dialog')
+            if dialog in dialogs:
+                bus.clear_messages()
+                return
+        time.sleep(1)
+    bus.clear_messages()


### PR DESCRIPTION
## Description
Takes in arguments for both `test_setup.py` and `behave` test runner. Parses any arguments for `test_setup` and runs the script, then passes any remaining arguments to behave.

## How to test
run: 
`mycroft-start vktest -t mycroft-weather --tags xfail`
or 
`mycroft-skill-testrunner vktest -t mycroft-weather --tags xfail`

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
