### PR TITLE
upgrade Lingua Franca to 0.2.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ google-api-python-client==1.6.4
 fasteners==0.14.1
 PyYAML==5.1.2
 
-lingua-franca==0.2.0
+lingua-franca==0.2.1
 msm==0.8.7
 msk==0.3.14
 adapt-parser==0.3.4


### PR DESCRIPTION
Apparently the VSCode PR extension doesn't want to edit the template before creating a PR.

Upgrades Lingua Franca. Release notes at that repo. I have mixed feelings about this PR.

On the one hand, this release fixes critical flaws in extract_number(). On the other hand, there is another PR pending at Lingua Franca which would solve other, less critical, but equally frustrating issues with the same parser. At Ake's discretion, that PR could turn directly into a 0.2.2 release, putting a bow on the problem.

## Contributor license agreement signed?
CLA [ Yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
