### PR TITLE
Add configurable API url to Watson TTS

### DIFF
--- a/mycroft/tts/ibm_tts.py
+++ b/mycroft/tts/ibm_tts.py
@@ -16,7 +16,6 @@
 from .tts import TTSValidator
 from .remote_tts import RemoteTTS
 from mycroft.configuration import Configuration
-from mycroft.util import remove_last_slash
 from requests.auth import HTTPBasicAuth
 
 
@@ -32,7 +31,8 @@ class WatsonTTS(RemoteTTS):
         user = self.config.get("user") or self.config.get("username")
         password = self.config.get("password")
         api_key = self.config.get("apikey")
-        self.url = remove_api_path(self.config.get("url", self.url), api_path)
+        if self.url.endswith(api_path):
+            self.url = self.url[:-len(api_path)]
 
         if api_key is None:
             self.auth = HTTPBasicAuth(user, password)
@@ -69,11 +69,3 @@ class WatsonTTSValidator(TTSValidator):
 
     def get_tts_class(self):
         return WatsonTTS
-
-
-def remove_api_path(url, api_path):
-    """Remove api_path as RemoteTTS.__request method appends it"""
-    url = remove_last_slash(url)
-    if url.endswith(api_path):
-        url = url[:-len(api_path)]
-    return url

--- a/mycroft/tts/ibm_tts.py
+++ b/mycroft/tts/ibm_tts.py
@@ -16,6 +16,7 @@
 from .tts import TTSValidator
 from .remote_tts import RemoteTTS
 from mycroft.configuration import Configuration
+from mycroft.util import remove_last_slash
 from requests.auth import HTTPBasicAuth
 
 
@@ -23,13 +24,16 @@ class WatsonTTS(RemoteTTS):
     PARAMS = {'accept': 'audio/wav'}
 
     def __init__(self, lang, config,
-                 url="https://stream.watsonplatform.net/text-to-speech/api"):
-        super(WatsonTTS, self).__init__(lang, config, url, '/v1/synthesize',
+                 url='https://stream.watsonplatform.net/text-to-speech/api',
+                 api_path='/v1/synthesize'):
+        super(WatsonTTS, self).__init__(lang, config, url, api_path,
                                         WatsonTTSValidator(self))
         self.type = "wav"
         user = self.config.get("user") or self.config.get("username")
         password = self.config.get("password")
         api_key = self.config.get("apikey")
+        self.url = remove_api_path(self.config.get("url", self.url), api_path)
+
         if api_key is None:
             self.auth = HTTPBasicAuth(user, password)
         else:
@@ -63,3 +67,11 @@ class WatsonTTSValidator(TTSValidator):
 
     def get_tts_class(self):
         return WatsonTTS
+
+
+def remove_api_path(url, api_path):
+    """Remove api_path as RemoteTTS.__request method appends it"""
+    url = remove_last_slash(url)
+    if url.endswith(api_path):
+        url = url[:-len(api_path)]
+    return url

--- a/mycroft/tts/ibm_tts.py
+++ b/mycroft/tts/ibm_tts.py
@@ -43,6 +43,8 @@ class WatsonTTS(RemoteTTS):
         params = self.PARAMS.copy()
         params['LOCALE'] = self.lang
         params['voice'] = self.voice
+        params['X-Watson-Learning-Opt-Out'] = self.config.get(
+                                           'X-Watson-Learning-Opt-Out', 'true')
         params['text'] = sentence.encode('utf-8')
         return params
 

--- a/mycroft/tts/remote_tts.py
+++ b/mycroft/tts/remote_tts.py
@@ -17,7 +17,7 @@ import re
 from requests_futures.sessions import FuturesSession
 
 from .tts import TTS
-from mycroft.util import remove_last_slash, play_wav
+from mycroft.util import play_wav
 from mycroft.util.log import LOG
 
 
@@ -41,7 +41,7 @@ class RemoteTTS(TTS):
         super(RemoteTTS, self).__init__(lang, config, validator)
         self.api_path = api_path
         self.auth = None
-        self.url = remove_last_slash(url)
+        self.url = config.get('url', url).rstrip('/')
         self.session = FuturesSession()
 
     def execute(self, sentence, ident=None, listen=False):


### PR DESCRIPTION
## Description
The new IBM Watson TTS service now provides a unique url for your TTS
API resource. This adds a configuration option to override the default
url. As the url provided by IBM contains the api_path, we check for it 
and if found remove it, as the RemoteTTS.__request method appends it 
when making the call.

## How to test
Create an IBM cloud account and add Watson TTS as described in the [docs](https://mycroft-ai.gitbook.io/docs/using-mycroft-ai/customizations/tts-engine#ibm-watson).
Add a `url` attribute to your config using the url provided with your API key. This can be added with or without the API path "/v1/synthesize", and with or without trailing slashes.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
