### PR TITLE
additional lang folders

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -118,7 +118,11 @@
     // priority skills to be loaded first
     "priority_skills": ["mycroft-pairing", "mycroft-volume"],
     // Time between updating skills in hours
-    "update_interval": 1.0
+    "update_interval": 1.0,
+    // Directory for aditional translations
+    "translations_dir": "~/.mycroft/translations",
+    // prefear translations over skills own translation
+    "prefere_translations": false
   },
 
   // Address of the REMOTE server

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -71,6 +71,10 @@ class SkillLoader:
         self.active = True
         self.config = Configuration.get()
 
+        t_dir = self.config.get('skills').get('translations_dir')
+        t_dir = os.path.expanduser(t_dir)
+        self.translations_dir = os.path.join(t_dir, self.skill_id)
+
     @property
     def is_blacklisted(self):
         """Boolean value representing whether or not a skill is blacklisted."""
@@ -86,8 +90,14 @@ class SkillLoader:
         Returns:
              bool: if the skill was loaded/reloaded
         """
+
         try:
-            self.last_modified = _get_last_modified_time(self.skill_directory)
+            result = [_get_last_modified_time(self.skill_directory)]
+            if os.path.exists(self.translations_dir):
+                result.append(_get_last_modified_time(
+                              self.translations_dir))
+            self.last_modified = max(result)
+
         except FileNotFoundError as e:
             LOG.error('Failed to get last_modification time '
                       '({})'.format(repr(e)))


### PR DESCRIPTION
aditional language

## Description
This tryes to add additional language folder as described in #2509

Additional lanuage folders are placed for each skill under ~/.mycroft/translations

Added settings for this in mycroft.cong under general skillsettings
```
  // General skill values
  "skills": {
    "translations_dir": "~/.mycroft/translations",
    // prefear translations over skills own translation
    "prefere_translations": false
    }
```
Added so the additional language folder is read when adding rescource files

It also add the additional language folder to the watching for changes in skill_loader so canges and addings to files at that place will reload the skill.


## How to test
* Use other language than en-us
* move files from hellow-world-skill (all files in other lang) from cocab and dialog older to ~/.mycroft/translations/mycroft-hello-world.mycroftai/<lang> - (so all resource files in same folder!
* See that mycroft picksup resource files from new place.
* make change in one file and se that he reloads skil and picksup changes

## Contributor license agreement signed?
CLA [ X] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)