### PR TITLE
Add resource lock tests in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
         // building the Docker image.
         disableConcurrentBuilds()
         buildDiscarder(logRotator(numToKeepStr: '5'))
+        lock resource: 'VoightKampff'
     }
     stages {
         // Run the build in the against the dev branch to check for compile errors


### PR DESCRIPTION
## Description
Add a lock for the pipeline, different branches were able to run on top of each-other since each branch/pr gets a separate "job"

This lock is global across the pipeline and will force all branches to wait for the Lock to be free.

Things that needs this lock seems to be 
- identity file (multiple jobs may overwrite the identity in an incorrect way)
- allure data

The allure data could possibly be handled without the lock by creating a temporary directory for each run.