### PR TITLE
Fix enclosure shutdown

### DIFF
--- a/mycroft/client/enclosure/__main__.py
+++ b/mycroft/client/enclosure/__main__.py
@@ -17,6 +17,8 @@ import sys
 from mycroft.util.log import LOG
 from mycroft.messagebus.client import MessageBusClient
 from mycroft.configuration import Configuration, LocalConf, SYSTEM_CONFIG
+from mycroft.util import (create_daemon, wait_for_exit_signal,
+                          reset_sigint_handler)
 
 
 def main():
@@ -43,7 +45,9 @@ def main():
     if enclosure:
         try:
             LOG.debug("Enclosure started!")
-            enclosure.run()
+            reset_sigint_handler()
+            create_daemon(enclosure.run)
+            wait_for_exit_signal()
         except Exception as e:
             print(e)
         finally:

--- a/mycroft/client/enclosure/__main__.py
+++ b/mycroft/client/enclosure/__main__.py
@@ -12,36 +12,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import sys
+"""Entrypoint for enclosure service.
 
+This provides any "enclosure" specific functionality, for example GUI or
+control over the Mark-1 Faceplate.
+"""
+from mycroft.configuration import LocalConf, SYSTEM_CONFIG
 from mycroft.util.log import LOG
-from mycroft.messagebus.client import MessageBusClient
-from mycroft.configuration import Configuration, LocalConf, SYSTEM_CONFIG
 from mycroft.util import (create_daemon, wait_for_exit_signal,
                           reset_sigint_handler)
 
 
-def main():
-    # Read the system configuration
-    system_config = LocalConf(SYSTEM_CONFIG)
-    platform = system_config.get("enclosure", {}).get("platform")
+def create_enclosure(platform):
+    """Create an enclosure based on the provided platform string.
 
+    Arguments:
+        platform (str): platform name string
+
+    Returns:
+        Enclosure object
+    """
     if platform == "mycroft_mark_1":
-        LOG.debug("Creating Mark I Enclosure")
+        LOG.info("Creating Mark I Enclosure")
         from mycroft.client.enclosure.mark1 import EnclosureMark1
         enclosure = EnclosureMark1()
     elif platform == "mycroft_mark_2":
-        LOG.debug("Creating Mark II Enclosure")
+        LOG.info("Creating Mark II Enclosure")
         from mycroft.client.enclosure.mark2 import EnclosureMark2
         enclosure = EnclosureMark2()
     else:
-        LOG.debug("Creating generic enclosure, platform='{}'".format(platform))
+        LOG.info("Creating generic enclosure, platform='{}'".format(platform))
 
         # TODO: Mechanism to load from elsewhere.  E.g. read a script path from
         # the mycroft.conf, then load/launch that script.
         from mycroft.client.enclosure.generic import EnclosureGeneric
         enclosure = EnclosureGeneric()
 
+    return enclosure
+
+
+def main():
+    """Launch one of the available enclosure implementations.
+
+    This depends on the configured platform and can currently either be
+    mycroft_mark_1 or mycroft_mark_2, if unconfigured a generic enclosure with
+    only the GUI bus will be started.
+    """
+    # Read the system configuration
+    system_config = LocalConf(SYSTEM_CONFIG)
+    platform = system_config.get("enclosure", {}).get("platform")
+
+    enclosure = create_enclosure(platform)
     if enclosure:
         try:
             LOG.debug("Enclosure started!")
@@ -50,10 +71,8 @@ def main():
             wait_for_exit_signal()
         except Exception as e:
             print(e)
-        finally:
-            sys.exit()
     else:
-        LOG.debug("No enclosure available for this hardware, running headless")
+        LOG.info("No enclosure available for this hardware, running headless")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
The enclosure was not using the standard startup scheme and would not shutdown cleanly and had to be killed.

Resolves #2492.

## How to test
start the enclosure and then stop it and make sure it stops rather than kills:

The following is the expected output

```
./stop-mycroft.sh enclosure
Stopping enclosure (11244)...stopped.
```

## Contributor license agreement signed?
CLA [ Yes ]
