### PR TITLE
Move mute stage of __init__() after creating lock

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -50,13 +50,13 @@ class MutableStream:
         assert wrapped_stream is not None
         self.wrapped_stream = wrapped_stream
 
-        self.muted = muted
-        if muted:
-            self.mute()
-
         self.SAMPLE_WIDTH = pyaudio.get_sample_size(format)
         self.muted_buffer = b''.join([b'\x00' * self.SAMPLE_WIDTH])
         self.read_lock = Lock()
+
+        self.muted = muted
+        if muted:
+            self.mute()
 
     def mute(self):
         """Stop the stream and set the muted flag."""


### PR DESCRIPTION
## Description
During a test the speech client became unresponsive and this was seen in the logs:
```
  File "/opt/venvs/mycroft-core/lib/python3.7/site-packages/mycroft/client/speech/mic.py", line 134, in __enter__
    return self._start()
  File "/opt/venvs/mycroft-core/lib/python3.7/site-packages/mycroft/client/speech/mic.py", line 146, in _start
    ), self.format, self.muted)
  File "/opt/venvs/mycroft-core/lib/python3.7/site-packages/mycroft/client/speech/mic.py", line 55, in __init__
    self.mute()
  File "/opt/venvs/mycroft-core/lib/python3.7/site-packages/mycroft/client/speech/mic.py", line 63, in mute
    with self.read_lock:
AttributeError: 'MutableStream' object has no attribute 'read_lock'
```

If the mic is restarted while muted the lock hadn't been created when the mute method is called causing this issue.


## Contributor license agreement signed?
CLA [ Yes ]
