### PR TITLE
Fix uploading settings meta

### DIFF
--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -48,8 +48,8 @@ class UploadQueue:
 
     def start(self):
         """Start processing of the queue."""
-        self.send()
         self.started = True
+        self.send()
 
     def stop(self):
         """Stop the queue, and hinder any further transmissions."""

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -41,6 +41,18 @@ class TestUploadQueue(TestCase):
         queue.send()
         self.assertEqual(len(queue), 0)
 
+    def test_upload_queue_preloaded(self):
+        queue = UploadQueue()
+        loaders = [Mock(), Mock(), Mock(), Mock()]
+        for i, l in enumerate(loaders):
+            queue.put(l)
+            self.assertEqual(len(queue), i + 1)
+        # Check that starting the queue will send all the items in the queue
+        queue.start()
+        self.assertEqual(len(queue), 0)
+        for l in loaders:
+            l.instance.settings_meta.upload.assert_called_once_with()
+
 
 class TestSkillManager(MycroftUnitTestBase):
     mock_package = 'mycroft.skills.skill_manager.'


### PR DESCRIPTION
## Description
This changes the order so the started flag is set before the settingsmeta
the send() method is called.

The send() method now exits if the started flag isn't set causing the
skill settings not to be uploaded.

The issue was introduced in PR #2529 when adding the possibility to stopping the upload loop.

## How to test
Startup mycroft-core and check the skills log so that settingsmeta are uploaded.

## Contributor license agreement signed?
CLA [ Yes ]