### PR TITLE
Issues-2516 - Resolved IBM Cloud integration issue

### DIFF
--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -15,8 +15,10 @@
 import re
 import json
 from abc import ABCMeta, abstractmethod
+from collections import OrderedDict
 from requests import post, put, exceptions
 from speech_recognition import Recognizer
+from urllib import parse
 from queue import Queue
 from threading import Thread
 
@@ -108,14 +110,84 @@ class WITSTT(TokenSTT):
         return self.recognizer.recognize_wit(audio, self.token)
 
 
-class IBMSTT(BasicSTT):
+class IBMSTT(TokenSTT):
+    """
+        IBM Speech to Text
+        Enables IBM Speech to Text access using API key. To use IBM as a
+        service provider, it must be configured locally in your config file. An
+        IBM Cloud account with Speech to Text enabled is required (limited free
+        tier may be available). STT config should match the following format:
+
+        "stt": {
+            "module": "ibm",
+            "ibm": {
+                "lang": "en-US",
+                "credential": {
+                    "token": "YOUR_API_KEY"
+                },
+                "url": "URL_FROM_SERVICE"
+            }
+        }
+    """
     def __init__(self):
         super(IBMSTT, self).__init__()
 
     def execute(self, audio, language=None):
+        if not self.token:
+            raise ValueError('API key (token) for IBM Cloud is not defined.')
+        url_base = self.config.get('url', '')
+        if not url_base:
+            raise ValueError('URL for IBM Cloud is not defined.')
+
         self.lang = language or self.lang
-        return self.recognizer.recognize_ibm(audio, self.username,
-                                             self.password, self.lang)
+        supported_languages = [
+            'ar-AR', 'pt-BR', 'zh-CN', 'nl-NL', 'en-GB', 'en-US', 'fr-FR',
+            'de-DE', 'it-IT', 'ja-JP', 'ko-KR', 'es-AR', 'es-ES', 'es-CL',
+            'es-CO', 'es-MX', 'es-PE'
+        ]
+        if self.lang not in supported_languages:
+            raise ValueError(
+                'Unsupported language "{}" for IBM STT.'.format(self.lang))
+
+        audio_model = 'BroadbandModel'
+        if audio.sample_rate < 16000 and not self.lang == 'ar-AR':
+            audio_model = 'NarrowbandModel'
+
+        params = OrderedDict()  # Ensures testability, as {dict} is unordered
+        params['model'] = '{}_{}'.format(self.lang, audio_model)
+        params['profanity_filter'] = 'false'
+        url = url_base + '/v1/recognize?' + parse.urlencode(params)
+
+        headers = {
+            'Content-Type': 'audio/x-flac',
+            'X-Watson-Learning-Opt-Out': 'true'
+        }
+
+        response = post(url, auth=('apikey', self.token), headers=headers,
+                        data=audio.get_flac_data())
+
+        if response.status_code == 200:
+            result = json.loads(response.text)
+            if result.get('error_code') is None:
+                if ('results' not in result or len(result['results']) < 1 or
+                        'alternatives' not in result['results'][0]):
+                    raise Exception(
+                        'Transcription failed. Invalid or empty results.')
+                transcription = []
+                for utterance in result['results']:
+                    if 'alternatives' not in utterance:
+                        raise Exception(
+                            'Transcription failed. Invalid or empty results.')
+                    for hypothesis in utterance['alternatives']:
+                        if 'transcript' in hypothesis:
+                            transcription.append(hypothesis['transcript'])
+                return '\n'.join(transcription)
+        elif response.status_code == 401:  # Unauthorized
+            raise Exception('Invalid API key for IBM Cloud.')
+        else:
+            raise Exception(
+                'Request to IBM Cloud failed. Code: {} Body: {}'.format(
+                    response.status_code, response.text))
 
 
 class YandexSTT(STT):

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -121,7 +121,6 @@ class IBMSTT(TokenSTT):
         "stt": {
             "module": "ibm",
             "ibm": {
-                "lang": "en-US",
                 "credential": {
                     "token": "YOUR_API_KEY"
                 },

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -17,7 +17,6 @@ import json
 from abc import ABCMeta, abstractmethod
 from requests import post, put, exceptions
 from speech_recognition import Recognizer
-from urllib import parse
 from queue import Queue
 from threading import Thread
 

--- a/test/unittests/stt/test_stt.py
+++ b/test/unittests/stt/test_stt.py
@@ -35,13 +35,18 @@ class TestSTT(unittest.TestCase):
                     'google': {'credential': {'token': 'FOOBAR'}},
                     'bing': {'credential': {'token': 'FOOBAR'}},
                     'houndify': {'credential': {'client_id': 'FOO',
-                                                "client_key": "BAR"}},
+                                                "client_key": 'BAR'}},
                     'google_cloud': {
                         'credential': {
                             'json': {}
                         }
                     },
-                    'ibm': {'credential': {'token': 'FOOBAR'}},
+                    'ibm': {
+                        'credential': {
+                            'token': 'FOOBAR'
+                        },
+                        'url': 'https://test.com/'
+                    },
                     'kaldi': {'uri': 'https://test.com'},
                     'mycroft': {'uri': 'https://test.com'}
                 },
@@ -164,26 +169,61 @@ class TestSTT(unittest.TestCase):
         stt.execute(audio)
         self.assertTrue(stt.recognizer.recognize_google_cloud.called)
 
+    @patch('mycroft.stt.post')
     @patch.object(Configuration, 'get')
-    def test_ibm_stt(self, mock_get):
-        mycroft.stt.Recognizer = MagicMock
+    def test_ibm_stt(self, mock_get, mock_post):
+        import json
+
         config = base_config()
         config.merge(
             {
                 'stt': {
                     'module': 'ibm',
                     'ibm': {
-                        'credential': {'username': 'FOO', 'password': 'BAR'}
+                        'credential': {
+                            'token': 'FOOBAR'
+                        },
+                        'url': 'https://test.com'
                     },
                 },
                 'lang': 'en-US'
-            })
+            }
+        )
         mock_get.return_value = config
 
+        requests_object = MagicMock()
+        requests_object.status_code = 200
+        requests_object.text = json.dumps({
+            'results': [
+                {
+                    'alternatives': [
+                        {
+                            'confidence': 0.96,
+                            'transcript': 'sample response'
+                        }
+                    ],
+                    'final': True
+                }
+            ],
+            'result_index': 0
+        })
+        mock_post.return_value = requests_object
+
         audio = MagicMock()
+        audio.sample_rate = 16000
+
         stt = mycroft.stt.IBMSTT()
         stt.execute(audio)
-        self.assertTrue(stt.recognizer.recognize_ibm.called)
+
+        test_url_base = 'https://test.com/v1/recognize?'
+        test_url_params = 'model=en-US_BroadbandModel&profanity_filter=false'
+        mock_post.assert_called_with(test_url_base + test_url_params,
+                                     auth=('apikey', 'FOOBAR'),
+                                     headers={
+                                         'Content-Type': 'audio/x-flac',
+                                         'X-Watson-Learning-Opt-Out': 'true'
+                                     },
+                                     data=audio.get_flac_data())
 
     @patch.object(Configuration, 'get')
     def test_wit_stt(self, mock_get):

--- a/test/unittests/stt/test_stt.py
+++ b/test/unittests/stt/test_stt.py
@@ -215,15 +215,18 @@ class TestSTT(unittest.TestCase):
         stt = mycroft.stt.IBMSTT()
         stt.execute(audio)
 
-        test_url_base = 'https://test.com/v1/recognize?'
-        test_url_params = 'model=en-US_BroadbandModel&profanity_filter=false'
-        mock_post.assert_called_with(test_url_base + test_url_params,
+        test_url_base = 'https://test.com/v1/recognize'
+        mock_post.assert_called_with(test_url_base,
                                      auth=('apikey', 'FOOBAR'),
                                      headers={
                                          'Content-Type': 'audio/x-flac',
                                          'X-Watson-Learning-Opt-Out': 'true'
                                      },
-                                     data=audio.get_flac_data())
+                                     data=audio.get_flac_data(),
+                                     params={
+                                         'model': 'en-US_BroadbandModel',
+                                         'profanity_filter': 'false'
+                                     })
 
     @patch.object(Configuration, 'get')
     def test_wit_stt(self, mock_get):


### PR DESCRIPTION
## Description
This is a rewrite of the IBM Cloud Text to Speech connector. Resolves #2516. Previously, we were using the speech_recognition package to interface with IBM Cloud. However, recently IBM moved from user / pass-based auth to api key-based auth. This fix moves all functionality for IBM Cloud into the mycroft-core codebase (using the requests package).

## How to test
Create an IBM Cloud account, if you do not already have one. Enable "Speech to Text" to receive an API Key and URL. Setup Mycroft config file according to documented format (see codebase).

Once configured, start Mycroft in debug mode. Test different scenarios (wakeword + phrase, wakeword + silence) to ensure acceptance of functionality. Error message on silence is specific to this integration, so can be used to validate IBM plugin is being used. Usage can also be confirmed in IBM Cloud usage dashboard (https://cloud.ibm.com/billing/usage) and digging into the service usage report.

Unit test covers basic functionality (generation of request) and mocks the response. Additional tests could be added to test malformed responses, but I wanted to adhere to current test pattern.

## Contributor license agreement signed?
CLA [ Yes ]
