### PR TITLE
have a default if run without a core param

### DIFF
--- a/scripts/install-mimic.sh
+++ b/scripts/install-mimic.sh
@@ -18,7 +18,7 @@
 set -Ee
 
 MIMIC_DIR=mimic
-CORES=$1
+CORES=${1:-1}
 MIMIC_VERSION=1.2.0.2
 
 # for ubuntu precise in travis, that does not provide pkg-config:


### PR DESCRIPTION
## Description
install-mimic.sh can have no core parameter passed, this adds a default.

## How to test
Run install-mimic.sh without any parameters. The make will use one core, a relatively safe value.

## Contributor license agreement signed?
CLA [x]
