### PR TITLE
Check the skill directory and XDG_CONFIG_DIR for settings

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -21,7 +21,10 @@ import traceback
 from itertools import chain
 from os import walk
 from os.path import join, abspath, dirname, basename, exists
+from pathlib import Path
 from threading import Event, Timer
+
+from xdg import BaseDirectory
 
 from adapt.intent import Intent, IntentBuilder
 
@@ -123,16 +126,6 @@ class MycroftSkill:
         #: Member variable containing the absolute path of the skill's root
         #: directory. E.g. /opt/mycroft/skills/my-skill.me/
         self.root_dir = dirname(abspath(sys.modules[self.__module__].__file__))
-        if use_settings:
-            self.settings = get_local_settings(self.root_dir, self.name)
-            self._initial_settings = deepcopy(self.settings)
-        else:
-            self.settings = None
-
-        #: Set to register a callback method that will be called every time
-        #: the skills settings are updated. The referenced method should
-        #: include any logic needed to handle the updated settings.
-        self.settings_change_callback = None
 
         self.gui = SkillGUI(self)
 
@@ -141,6 +134,18 @@ class MycroftSkill:
         self.bind(bus)
         #: Mycroft global configuration. (dict)
         self.config_core = Configuration.get()
+
+        self.settings = None
+        self.settings_write_path = None
+
+        if use_settings:
+            self._init_settings()
+
+        #: Set to register a callback method that will be called every time
+        #: the skills settings are updated. The referenced method should
+        #: include any logic needed to handle the updated settings.
+        self.settings_change_callback = None
+
         self.dialog_renderer = None
 
         #: Filesystem access to skill specific folder.
@@ -156,6 +161,37 @@ class MycroftSkill:
         # Delegator classes
         self.event_scheduler = EventSchedulerInterface(self.name)
         self.intent_service = IntentServiceInterface()
+
+    def _init_settings(self):
+        """Setup skill settings."""
+
+        # To not break existing setups,
+        # save to skill directory if the file exists already
+        self.settings_write_path = Path(self.root_dir)
+
+        # Otherwise save to XDG_CONFIG_DIR
+        if not self.settings_write_path.joinpath('settings.json').exists():
+            self.settings_write_path = Path(BaseDirectory.save_config_path(
+                'mycroft', 'skills', basename(self.root_dir)))
+
+        # To not break existing setups,
+        # read from skill directory if the settings file exists there
+        settings_read_path = Path(self.root_dir)
+
+        # Then, check XDG_CONFIG_DIR
+        if not settings_read_path.joinpath('settings.json').exists():
+            for dir in BaseDirectory.load_config_paths('mycroft',
+                                                       'skills',
+                                                       basename(
+                                                           self.root_dir)):
+                path = Path(dir)
+                # If there is a settings file here, use it
+                if path.joinpath('settings.json').exists():
+                    settings_read_path = path
+                    break
+
+        self.settings = get_local_settings(settings_read_path, self.name)
+        self._initial_settings = deepcopy(self.settings)
 
     @property
     def enclosure(self):
@@ -271,7 +307,7 @@ class MycroftSkill:
             if remote_settings is not None:
                 LOG.info('Updating settings for skill ' + self.name)
                 self.settings.update(**remote_settings)
-                save_settings(self.root_dir, self.settings)
+                save_settings(self.settings_write_path, self.settings)
                 if self.settings_change_callback is not None:
                     self.settings_change_callback()
 
@@ -544,7 +580,7 @@ class MycroftSkill:
 
             if not voc or not exists(voc):
                 raise FileNotFoundError(
-                        'Could not find {}.voc file'.format(voc_filename))
+                    'Could not find {}.voc file'.format(voc_filename))
             # load vocab and flatten into a simple list
             vocab = read_vocab_file(voc)
             self.voc_match_cache[cache_key] = list(chain(*vocab))
@@ -811,7 +847,7 @@ class MycroftSkill:
             """Store settings and indicate that the skill handler has completed
             """
             if self.settings != self._initial_settings:
-                save_settings(self.root_dir, self.settings)
+                save_settings(self.settings_write_path, self.settings)
                 self._initial_settings = self.settings
             if handler_info:
                 msg_type = handler_info + '.complete'
@@ -1232,8 +1268,9 @@ class MycroftSkill:
         self.settings_change_callback = None
 
         # Store settings
-        if self.settings != self._initial_settings:
-            save_settings(self.root_dir, self.settings)
+        if self.settings != self._initial_settings and Path(
+                self.root_dir).exists():
+            save_settings(self.settings_write_path, self.settings)
 
         if self.settings_meta:
             self.settings_meta.stop()

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -93,18 +93,22 @@ def get_local_settings(skill_dir, skill_name) -> dict:
 def save_settings(skill_dir, skill_settings):
     """Save skill settings to file."""
     settings_path = Path(skill_dir).joinpath('settings.json')
-    if Path(skill_dir).exists():
-        with open(str(settings_path), 'w') as settings_file:
-            try:
-                json.dump(skill_settings, settings_file)
-            except Exception:
-                LOG.exception('error saving skill settings to '
-                              '{}'.format(settings_path))
-            else:
-                LOG.info('Skill settings successfully saved to '
-                         '{}' .format(settings_path))
-    else:
-        LOG.info('Skill folder no longer exists, can\'t save settings.')
+
+    # Either the file already exists in /opt, or we are writing
+    # to XDG_CONFIG_DIR and always have the permission to make
+    # sure the file always exists
+    if not Path(settings_path).exists():
+        settings_path.touch(mode=0o644)
+
+    with open(str(settings_path), 'w') as settings_file:
+        try:
+            json.dump(skill_settings, settings_file)
+        except Exception:
+            LOG.exception('error saving skill settings to '
+                          '{}'.format(settings_path))
+        else:
+            LOG.info('Skill settings successfully saved to '
+                     '{}' .format(settings_path))
 
 
 def get_display_name(skill_name: str):

--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -259,7 +259,8 @@ class SkillLoader:
         if first_run:
             LOG.info("First run of " + self.skill_id)
             self.instance.settings["__mycroft_skill_firstrun"] = False
-            save_settings(self.skill_directory, self.instance.settings)
+            save_settings(self.instance.settings_write_path,
+                          self.instance.settings)
             intro = self.instance.get_intro_message()
             if intro:
                 self.instance.speak(intro)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -25,3 +25,4 @@ fann2==1.0.7
 padaos==0.1.9
 precise-runner==0.2.1
 petact==0.1.2
+pyxdg==0.26


### PR DESCRIPTION
## Description
This makes the skills read their settings from either XDG_CONFIG_DIR or `/etc/mycroft` (if `XDG_CONFIG_DIR` is unset), and write to XDG_CONFIG_DIR. This however happens only if `/opt/mycroft/skills/<skillname>/settings.json` (the current default location) doesn't already exist, to make sure we don't break existing setups.

## How to test
1. Run `mycroft-skills` like before and verify if all skills still load correctly
2. Quit the running process
3. **Move** a `settings.json` from any skill to either `~/.config/mycroft/skills/<skillname>/settings.json` or `/etc/mycroft/skills/<skillname>/settings.json`. For `skill-pairing` the skillname would be "PairingSkill" for example
4. Run `mycroft-skills` again and verify if the affected skill still loads correctly and if it saves it settings to `~/.config/mycroft/skills/<skillname>/settings.json`.

## Contributor license agreement signed?
CLA [x]
