### PR TITLE
Allow building Mycroft with loose requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 from setuptools import setup, find_packages
+import os
 import os.path
 
 BASEDIR = os.path.abspath(os.path.dirname(__file__))
@@ -44,6 +45,9 @@ def required(requirements_file):
     """ Read requirements file and remove comments and empty lines. """
     with open(os.path.join(BASEDIR, requirements_file), 'r') as f:
         requirements = f.read().splitlines()
+        if 'MYCROFT_LOOSE_REQUIREMENTS' in os.environ:
+            print('USING LOOSE REQUIREMENTS!')
+            requirements = [r.replace('==', '>=') for r in requirements]
         return [pkg for pkg in requirements
                 if pkg.strip() and not pkg.startswith("#")]
 


### PR DESCRIPTION
## Description
Allow pip install to use "loose" requirements (>= instead of ==) by setting the `MYCROFT_LOOSE_REQUIREMENTS` environment variable.

The intention of this is to allow installs with desktop packages instead of using pip to be smoother while allowing the git installation to still guarantee the expected module versions. (Discussed in #2517).

This will not be guaranteed to work, but allows packagers for distributions to install their own versions of the Mycroft dependencies through their packaging manager.

Example
`MYCROFT_LOOSE_REQUIREMENTS=true pip install .`

## How to test
Create a test virtual environment, activate it and run `MYCROFT_LOOSE_REQUIREMENTS=true pip install .` Make sure the installed versions are of the packages are the latest (for example requests should be the latest version), (depending on the arch and system this MAY FAIL to setup due to fann2 1.1.2 which has a broken install on some systems. If this occurs install the 1.0.7 version separately.

## Contributor license agreement signed?
CLA [ Yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
