### PR TITLE
CI: Reduce Jenkins reporting verbosity

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,89 +81,50 @@ pipeline {
                 }
                 failure {
                     script {
-                        // Create comment for Pull Requests
                         if (env.CHANGE_ID) {
+                            // Create comment for Pull Requests
                             echo 'Sending PR comment'
                             pullRequest.comment('Voight Kampff Integration Test Failed ([Results](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '))')
+                        } else {
+                            // if it's the build of a branch send failure email
+                            // containing a link to the Jenkins build, the
+                            // results report and the console log messages to
+                            // Mycroft developers, and the developers that
+                            // caused the build to fail.
+                            echo 'Sending Failure Email'
+                            emailext (
+                                attachLog: true,
+                                subject: "FAILED - Core Integration Tests - Build ${BRANCH_NAME} #${BUILD_NUMBER}",
+                                body: """
+                                    <p>
+                                        One or more integration tests failed. Use the
+                                        resources below to identify the issue and fix
+                                        the failing tests.
+                                    </p>
+                                    <br>
+                                    <p>
+                                        <a href='${BUILD_URL}'>
+                                            Jenkins Build Details
+                                        </a>
+                                        &nbsp(Requires account on Mycroft's Jenkins instance)
+                                    </p>
+                                    <br>
+                                    <p>
+                                        <a href='https://reports.mycroft.ai/core/${BRANCH_ALIAS}'>
+                                            Report of Test Results
+                                        </a>
+                                    </p>
+                                    <br>
+                                    <p>Console log is attached.</p>""",
+                                replyTo: 'devops@mycroft.ai',
+                                to: 'dev@mycroft.ai',
+                                recipientProviders: [
+                                    [$class:'CulpritsRecipientProvider'],
+                                    [$class:'DevelopersRecipientProvider']
+                                ]
+                            )
                         }
                     }
-                    // Send failure email containing a link to the Jenkins build
-                    // the results report and the console log messages to Mycroft
-                    // developers, the developers of the pull request and the
-                    // developers that caused the build to fail.
-                    echo 'Sending Failure Email'
-                    emailext (
-                        attachLog: true,
-                        subject: "FAILED - Core Integration Tests - Build ${BRANCH_NAME} #${BUILD_NUMBER}",
-                        body: """
-                            <p>
-                                One or more integration tests failed. Use the
-                                resources below to identify the issue and fix
-                                the failing tests.
-                            </p>
-                            <br>
-                            <p>
-                                <a href='${BUILD_URL}'>
-                                    Jenkins Build Details
-                                </a>
-                                &nbsp(Requires account on Mycroft's Jenkins instance)
-                            </p>
-                            <br>
-                            <p>
-                                <a href='https://reports.mycroft.ai/core/${BRANCH_ALIAS}'>
-                                    Report of Test Results
-                                </a>
-                            </p>
-                            <br>
-                            <p>Console log is attached.</p>""",
-                        replyTo: 'devops@mycroft.ai',
-                        to: 'dev@mycroft.ai',
-                        recipientProviders: [
-                            [$class: 'RequesterRecipientProvider'],
-                            [$class:'CulpritsRecipientProvider'],
-                            [$class:'DevelopersRecipientProvider']
-                        ]
-                    )
-                }
-                success {
-                    script {
-                        if (env.CHANGE_ID) {
-                            echo 'Sending PR comment'
-                            pullRequest.comment('Voight Kampff Integration Test Succeeded  ([Results](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '))')
-                        }
-                    }
-                    // Send success email containing a link to the Jenkins build
-                    // and the results report to Mycroft developers, the developers
-                    // of the pull request and the developers that caused the
-                    // last failed build.
-                    echo 'Sending Success Email'
-                    emailext (
-                        subject: "SUCCESS - Core Integration Tests - Build ${BRANCH_NAME} #${BUILD_NUMBER}",
-                        body: """
-                            <p>
-                                All integration tests passed. No further action required.
-                            </p>
-                            <br>
-                            <p>
-                                <a href='${BUILD_URL}'>
-                                    Jenkins Build Details
-                                </a>
-                                &nbsp(Requires account on Mycroft's Jenkins instance)
-                            </p>
-                            <br>
-                            <p>
-                                <a href='https://reports.mycroft.ai/core/${BRANCH_ALIAS}'>
-                                    Report of Test Results
-                                </a>
-                            </p>""",
-                        replyTo: 'devops@mycroft.ai',
-                        to: 'dev@mycroft.ai',
-                        recipientProviders: [
-                            [$class: 'RequesterRecipientProvider'],
-                            [$class:'CulpritsRecipientProvider'],
-                            [$class:'DevelopersRecipientProvider']
-                        ]
-                    )
                 }
             }
         }


### PR DESCRIPTION
# Description
- E-mails are only sent on failing branch builds
- PR comment is only sent on failure

The rationale here is that the build status is available from github so sending success emails / PR comments provides no extra useful information. A failure however is more likely to need immediate response from the PR author. Branch build failures will be reported by e-mail to the dev-team so these things can be caught quickly. This mirrors the behavior of Travis and PEP8-speaks.

See [this test run](https://hudson.mycroft.team/blue/organizations/jenkins/mycroft-core/detail/feature%2FJenkinsfile-verbosity/3/pipeline) for an example of e-mail notifications still being sent on failure.

## Contributor license agreement signed?
CLA [ Yes ]
