### PR TITLE
Remove the xmlrunner dep from requirements.txt, it isn't actually used anymore

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ tornado==6.0.3
 websocket-client==0.54.0
 requests-futures==0.9.5
 pyalsaaudio==0.8.2
-xmlrunner==1.7.7
 pyserial==3.0
 psutil==5.6.6
 pocketsphinx==0.1.0


### PR DESCRIPTION
## Description
Remove the xmlrunner dep from requirements.txt, it isn't actually used anymore (`grep -r xmlrunner` returns no usages anywhere).

## How to test
See if all tests still pass

## Contributor license agreement signed?
CLA [x]
