### PR TITLE
Add pytest.ini and make it ignore the wake_word directory

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = test
+norecursedirs = wake_word


### PR DESCRIPTION
## Description
Those tests aren't actually meant to be ran with Pytest, so let's skip them.
Fixes https://github.com/MycroftAI/mycroft-core/issues/2572

## How to test
Run `pytest` in the root of the project without this MR and observe the `wake_word` tests failing. Then run it again _with_ this PR and notice the tests succeeding.

## Contributor license agreement signed?
CLA [x]
