### PR TITLE
Voight kampff config given

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -28,8 +28,8 @@ from .locations import (DEFAULT_CONFIG, SYSTEM_CONFIG, USER_CONFIG,
 
 
 def is_remote_list(values):
-    ''' check if this list corresponds to a backend formatted collection of
-    dictionaries '''
+    """Check if list corresponds to a backend formatted collection of dicts
+    """
     for v in values:
         if not isinstance(v, dict):
             return False
@@ -39,13 +39,11 @@ def is_remote_list(values):
 
 
 def translate_remote(config, setting):
-    """
-        Translate config names from server to equivalents usable
-        in mycroft-core.
+    """Translate config names from server to equivalents for mycroft-core.
 
-        Args:
-                config:     base config to populate
-                settings:   remote settings to be translated
+    Arguments:
+        config:     base config to populate
+        settings:   remote settings to be translated
     """
     IGNORED_SETTINGS = ["uuid", "@type", "active", "user", "device"]
 
@@ -69,12 +67,11 @@ def translate_remote(config, setting):
 
 
 def translate_list(config, values):
-    """
-        Translate list formated by mycroft server.
+    """Translate list formated by mycroft server.
 
-        Args:
-            config (dict): target config
-            values (list): list from mycroft server config
+    Arguments:
+        config (dict): target config
+        values (list): list from mycroft server config
     """
     for v in values:
         module = v["@type"]
@@ -85,9 +82,7 @@ def translate_list(config, values):
 
 
 class LocalConf(dict):
-    """
-        Config dict from file.
-    """
+    """Config dictionary from file."""
     def __init__(self, path):
         super(LocalConf, self).__init__()
         if path:
@@ -95,11 +90,10 @@ class LocalConf(dict):
             self.load_local(path)
 
     def load_local(self, path):
-        """
-            Load local json file into self.
+        """Load local json file into self.
 
-            Args:
-                path (str): file to load
+        Arguments:
+            path (str): file to load
         """
         if exists(path) and isfile(path):
             try:
@@ -115,10 +109,10 @@ class LocalConf(dict):
             LOG.debug("Configuration '{}' not defined, skipping".format(path))
 
     def store(self, path=None):
-        """
-            Cache the received settings locally. The cache will be used if
-            the remote is unreachable to load settings that are as close
-            to the user's as possible
+        """Cache the received settings locally.
+
+        The cache will be used if the remote is unreachable to load settings
+        that are as close to the user's as possible.
         """
         path = path or self.path
         with open(path, 'w') as f:
@@ -129,9 +123,7 @@ class LocalConf(dict):
 
 
 class RemoteConf(LocalConf):
-    """
-        Config dict fetched from mycroft.ai
-    """
+    """Config dictionary fetched from mycroft.ai."""
     def __init__(self, cache=None):
         super(RemoteConf, self).__init__(None)
 
@@ -176,18 +168,23 @@ class RemoteConf(LocalConf):
 
 
 class Configuration:
+    """Namespace for operations on the configuration singleton."""
     __config = {}  # Cached config
     __patch = {}  # Patch config that skills can update to override config
 
     @staticmethod
     def get(configs=None, cache=True):
-        """
-            Get configuration, returns cached instance if available otherwise
-            builds a new configuration dict.
+        """Get configuration
 
-            Args:
-                configs (list): List of configuration dicts
-                cache (boolean): True if the result should be cached
+        Returns cached instance if available otherwise builds a new
+        configuration dict.
+
+        Arguments:
+            configs (list): List of configuration dicts
+            cache (boolean): True if the result should be cached
+
+        Returns:
+            (dict) configuration dictionary.
         """
         if Configuration.__config:
             return Configuration.__config
@@ -196,14 +193,14 @@ class Configuration:
 
     @staticmethod
     def load_config_stack(configs=None, cache=False):
-        """
-            load a stack of config dicts into a single dict
+        """Load a stack of config dicts into a single dict
 
-            Args:
-                configs (list): list of dicts to load
-                cache (boolean): True if result should be cached
+        Arguments:
+            configs (list): list of dicts to load
+            cache (boolean): True if result should be cached
 
-            Returns: merged dict of all configuration files
+        Returns:
+            (dict) merged dict of all configuration files
         """
         if not configs:
             configs = [LocalConf(DEFAULT_CONFIG), RemoteConf(),
@@ -242,20 +239,19 @@ class Configuration:
 
     @staticmethod
     def updated(message):
-        """
-            handler for configuration.updated, triggers an update
-            of cached config.
+        """Handler for configuration.updated,
+
+        Triggers an update of cached config.
         """
         Configuration.load_config_stack(cache=True)
 
     @staticmethod
     def patch(message):
-        """
-            patch the volatile dict usable by skills
+        """Patch the volatile dict usable by skills
 
-            Args:
-                message: Messagebus message should contain a config
-                         in the data payload.
+        Arguments:
+            message: Messagebus message should contain a config
+                     in the data payload.
         """
         config = message.data.get("config", {})
         merge_dict(Configuration.__patch, config)

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -233,11 +233,12 @@ class Configuration:
     def set_config_update_handlers(bus):
         """Setup websocket handlers to update config.
 
-        Args:
+        Arguments:
             bus: Message bus client instance
         """
         bus.on("configuration.updated", Configuration.updated)
         bus.on("configuration.patch", Configuration.patch)
+        bus.on("configuration.patch.clear", Configuration.patch_clear)
 
     @staticmethod
     def updated(message):
@@ -258,4 +259,15 @@ class Configuration:
         """
         config = message.data.get("config", {})
         merge_dict(Configuration.__patch, config)
+        Configuration.load_config_stack(cache=True)
+
+    @staticmethod
+    def patch_clear(message):
+        """Clear the config patch space.
+
+        Arguments:
+            message: Messagebus message should contain a config
+                     in the data payload.
+        """
+        Configuration.__patch = {}
         Configuration.load_config_stack(cache=True)

--- a/mycroft/res/text/en-us/configurations.json
+++ b/mycroft/res/text/en-us/configurations.json
@@ -1,0 +1,33 @@
+{
+  "unit system": {
+    "metric": {"system_unit": "metric"},
+    "imperial": {"system_unit": "imperial"}
+  },
+  "location": {
+    "stockholm": {
+      "location": {
+        "city": {
+          "name": "Stockholm",
+          "state": {
+            "code": "SE.18",
+            "country": {
+              "code": "SE",
+              "name": "Sweden"
+            },
+            "name": "Stockholm"
+          }
+        },
+        "coordinate": {
+          "latitude": 59.38306,
+          "longitude": 16.66667
+        },
+        "timezone": {
+          "code": "Europe/Stockholm",
+          "dst_offset": 7200000,
+          "name": "Europe/Stockholm",
+          "offset": 3600000
+        }
+      }
+    }
+  }
+}

--- a/test/integrationtests/voight_kampff/features/steps/configuration.py
+++ b/test/integrationtests/voight_kampff/features/steps/configuration.py
@@ -1,0 +1,105 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+from os.path import join, exists
+import time
+
+from behave import given
+from mycroft.messagebus import Message
+from mycroft.util import resolve_resource_file
+
+
+def patch_config(context, patch):
+    """Apply patch to config and wait for it to take effect.
+
+    Arguments:
+        context: Behave context for test
+        patch: patch to apply
+    """
+    # store originals in context
+    for key in patch:
+        # If this patch is redefining an already changed key don't update
+        if key not in context.original_config:
+            context.original_config[key] = context.config.get(key)
+
+    # Patch config
+    patch_config_msg = Message('configuration.patch', {'config': patch})
+    context.bus.emit(patch_config_msg)
+
+    # Wait until one of the keys has been updated
+    key = list(patch.keys())[0]
+    while context.config.get(key) != patch[key]:
+        time.sleep(0.5)
+
+
+def get_config_file_definition(configs_path, config, value):
+    """Read config definition file and return the matching patch dict.
+
+    Arguments:
+        configs_path: path to the configuration patch json file
+        config: config value to fetch from the file
+        value: predefined value to fetch
+
+    Returns:
+        Patch dictionary or None.
+    """
+    with open(configs_path) as f:
+        configs = json.load(f)
+        return configs.get(config, {}).get(value)
+
+
+def get_global_config_definition(context, config, value):
+    """Get config definitions included with Mycroft.
+
+    Arguments:
+        context: behave test context
+        config: config value to fetch from the file
+        value: predefined value to fetch
+
+    Returns:
+        Patch dictionary or None.
+    """
+    configs_path = resolve_resource_file(join('text', context.lang,
+                                              'configurations.json'))
+    return get_config_file_definition(configs_path, config, value)
+
+
+def get_feature_config_definition(context, config, value):
+    """Get config feature specific config defintion
+
+    Arguments:
+        context: behave test context
+        config: config value to fetch from the file
+        value: predefined value to fetch
+
+    Returns:
+        Patch dictionary or None.
+    """
+    feature_config = context.feature.filename.replace('.feature',
+                                                      '.config.json')
+    if exists(feature_config):
+        return get_config_file_definition(feature_config, config, value)
+    else:
+        return None
+
+
+@given('the user\'s {config} is {value}')
+def given_config(context, config, value):
+    """Patch the configuration with a specific config."""
+    config = config.strip('"')
+    value = value.strip('"')
+    patch_dict = (get_feature_config_definition(context, config, value) or
+                  get_global_config_definition(context, config, value))
+    patch_config(context, patch_dict)

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -1,4 +1,4 @@
-# Copyright 2017 Mycroft AI Inc.
+# Copyright 2020 Mycroft AI Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/integrationtests/voight_kampff/test_setup.py
+++ b/test/integrationtests/voight_kampff/test_setup.py
@@ -38,6 +38,13 @@ that anyi specified extra skills also gets installed into the environment.
 FEATURE_DIR = join(dirname(__file__), 'features') + '/'
 
 
+def copy_config_definition_files(source, destination):
+    """Copy all feature files from source to destination."""
+    # Copy feature files to the feature directory
+    for f in glob(join(source, '*.config.json')):
+        shutil.copyfile(f, join(destination, basename(f)))
+
+
 def copy_feature_files(source, destination):
     """Copy all feature files from source to destination."""
     # Copy feature files to the feature directory
@@ -141,6 +148,7 @@ def collect_test_cases(msm, skills):
         behave_dir = join(skill.path, 'test', 'behave')
         if exists(behave_dir):
             copy_feature_files(behave_dir, FEATURE_DIR)
+            copy_config_definition_files(behave_dir, FEATURE_DIR)
 
             step_dir = join(behave_dir, 'steps')
             if exists(step_dir):

--- a/test/integrationtests/voight_kampff/test_setup.py
+++ b/test/integrationtests/voight_kampff/test_setup.py
@@ -32,7 +32,7 @@ The script sets up the selected tests in the feature directory so they can
 be found and executed by the behave framework.
 
 The script also ensures that the skills marked for testing are installed and
-that anyi specified extra skills also gets installed into the environment.
+that any specified extra skills also gets installed into the environment.
 """
 
 FEATURE_DIR = join(dirname(__file__), 'features') + '/'


### PR DESCRIPTION
## Description
Adds the `Given the user's {config} is {value}` step implementation

This will patch the configuration with a section from a dictionary that
can either be a global (shipped in
`mycroft/res/{lang}/configurations.json`) or shipped with the test
definition. The file should be named the same as the feature file but
instead of `.feature` the extension should be `.config.json`.

`mycroft/res/text/en-us/configurations.json` contains a couple of
pre-defined configurations that can be applied
- units (metric/imperial)
- location (Stockholm)

After each scenario any applied patch will be cleared

In addition this PR adds the message configuration.patch.clear to clear an applied patch.

If this is approach is good enough it resolves #2547.

## How to test

## Contributor license agreement signed?
CLA [ Yes ]
