### PR TITLE
Bugfix/add context decorator

### DIFF
--- a/mycroft/skills/context.py
+++ b/mycroft/skills/context.py
@@ -15,13 +15,16 @@
 from functools import wraps
 
 """
-    Helper decorators for handling context from skills.
+Helper decorators for handling context from skills.
 """
 
 
 def adds_context(context, words=''):
-    """
-        Adds context to context manager.
+    """Decorator adding context to the Adapt context manager.
+
+    Arguments:
+        context (str): context Keyword to insert
+        words (str): optional string content of Keyword
     """
     def context_add_decorator(func):
         @wraps(func)
@@ -34,8 +37,10 @@ def adds_context(context, words=''):
 
 
 def removes_context(context):
-    """
-        Removes context from the context manager.
+    """Decorator removing context from the Adapt context manager.
+
+    Arguments:
+        context (str): Context keyword to remove
     """
     def context_removes_decorator(func):
         @wraps(func)

--- a/mycroft/skills/context.py
+++ b/mycroft/skills/context.py
@@ -30,7 +30,7 @@ def adds_context(context, words=''):
         @wraps(func)
         def func_wrapper(*args, **kwargs):
             ret = func(*args, **kwargs)
-            args[0].set_context(context)
+            args[0].set_context(context, words)
             return ret
         return func_wrapper
     return context_add_decorator

--- a/test/unittests/skills/test_context.py
+++ b/test/unittests/skills/test_context.py
@@ -1,0 +1,42 @@
+from unittest import TestCase, mock
+
+from mycroft.skills.context import adds_context, removes_context
+"""
+Tests for the adapt context decorators.
+"""
+
+
+class ContextSkillMock(mock.Mock):
+    """Mock class to apply decorators on."""
+    @adds_context('DestroyContext')
+    def handler_adding_context(self):
+        pass
+
+    @adds_context('DestroyContext', 'exterminate')
+    def handler_adding_context_with_words(self):
+        pass
+
+    @removes_context('DestroyContext')
+    def handler_removing_context(self):
+        pass
+
+
+class TestContextDecorators(TestCase):
+    def test_adding_context(self):
+        """Check that calling handler adds the correct Keyword."""
+        skill = ContextSkillMock()
+        skill.handler_adding_context()
+        skill.set_context.assert_called_once_with('DestroyContext', '')
+
+    def test_adding_context_with_words(self):
+        """Ensure that decorated handler adds Keyword and content."""
+        skill = ContextSkillMock()
+        skill.handler_adding_context_with_words()
+        skill.set_context.assert_called_once_with('DestroyContext',
+                                                  'exterminate')
+
+    def test_removing_context(self):
+        """Make sure the decorated handler removes the specified context."""
+        skill = ContextSkillMock()
+        skill.handler_removing_context()
+        skill.remove_context.assert_called_once_with('DestroyContext')


### PR DESCRIPTION
## Description
Using the `@adds_context` decorator would never pass along the optional content to the `set_context()`-method. This corrects the behavior and adds test cases covering the decorators.

## How to test
Ensure unittests pass

## Contributor license agreement signed?
CLA [ Yes ]
