### PR TITLE
Update the ESpeak TTS plugin

### DIFF
--- a/mycroft/tts/espeak_tts.py
+++ b/mycroft/tts/espeak_tts.py
@@ -49,8 +49,8 @@ class ESpeakValidator(TTSValidator):
         try:
             subprocess.call(['espeak', '--version'])
         except Exception:
-            raise Exception(
-                'ESpeak is not installed. Run: sudo apt-get install espeak')
+            raise Exception('ESpeak is not installed. Please install it on '
+                            'your system and restart Mycroft.')
 
     def get_tts_class(self):
         return ESpeak

--- a/mycroft/tts/espeak_tts.py
+++ b/mycroft/tts/espeak_tts.py
@@ -18,14 +18,23 @@ from .tts import TTS, TTSValidator
 
 
 class ESpeak(TTS):
+    """TTS module for generating speech using ESpeak."""
     def __init__(self, lang, config):
         super(ESpeak, self).__init__(lang, config, ESpeakValidator(self))
 
-    def execute(self, sentence, ident=None, listen=False):
-        self.begin_audio()
-        subprocess.call(
-            ['espeak', '-v', self.lang + '+' + self.voice, sentence])
-        self.end_audio(listen)
+    def get_tts(self, sentence, wav_file):
+        """Generate WAV from sentence, phonemes aren't supported.
+
+        Arguments:
+            sentence (str): sentence to generate audio for
+            wav_file (str): output file
+
+        Returns:
+            tuple ((str) file location, None)
+        """
+        subprocess.call(['espeak', '-v', self.lang + '+' + self.voice,
+                         '-w', wav_file, sentence])
+        return wav_file, None
 
 
 class ESpeakValidator(TTSValidator):

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -187,7 +187,7 @@ class TTS(metaclass=ABCMeta):
 
     def load_spellings(self):
         """Load phonetic spellings of words as dictionary"""
-        path = join('text', self.lang, 'phonetic_spellings.txt')
+        path = join('text', self.lang.lower(), 'phonetic_spellings.txt')
         spellings_file = resolve_resource_file(path)
         if not spellings_file:
             return {}

--- a/test/unittests/tts/test_espeak_tts.py
+++ b/test/unittests/tts/test_espeak_tts.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest import mock
+
+from mycroft.tts.espeak_tts import ESpeak
+
+
+@mock.patch('mycroft.tts.tts.PlaybackThread')
+class TestMimic(unittest.TestCase):
+    @mock.patch('mycroft.tts.espeak_tts.subprocess')
+    def test_get_tts(self, mock_subprocess, _):
+        conf = {
+            "lang": "english-us",
+            "voice": "m1"
+        }
+        e = ESpeak('en-US', conf)
+        sentence = 'hello'
+        wav_filename = 'abc.wav'
+        wav, phonemes = e.get_tts(sentence, wav_filename)
+        self.assertTrue(phonemes is None)
+        mock_subprocess.call.called_with(['espeak', '-v',
+                                          conf['lang'] + '+' + conf['voice'],
+                                          '-w', wav_filename,
+                                          sentence])

--- a/test/unittests/tts/test_mimic_tts.py
+++ b/test/unittests/tts/test_mimic_tts.py
@@ -23,9 +23,9 @@ class TestMimic(unittest.TestCase):
         mock_device_api.return_value = device_instance_mock
         m = Mimic('en-US', {})
         wav, phonemes = m.get_tts('hello', 'abc.wav')
+        mock_subprocess.check_output.assert_called_once_with(
+            m.args + ['-o', 'abc.wav', '-t', 'hello'])
         self.assertEqual(phonemes, mock_subprocess.check_output().decode())
-        mock_subprocess.check_output_called_with(m.args + ['-o', 'abc.wav',
-                                                           '-t', 'hello'])
 
     def test_viseme(self, _, mock_device_api):
         mock_device_api.return_value = device_instance_mock

--- a/test/unittests/tts/test_tts.py
+++ b/test/unittests/tts/test_tts.py
@@ -120,7 +120,6 @@ class TestTTS(unittest.TestCase):
             self.assertEqual(read_phonemes, 'phonemes')  # assert stripped
 
     def test_ssml_support(self, _):
-
         sentence = "<speak>Prosody can be used to change the way words " \
                    "sound. The following words are " \
                    "<prosody volume='x-loud'> " \
@@ -174,6 +173,16 @@ class TestTTS(unittest.TestCase):
 
         self.assertEqual(mycroft.tts.TTS.remove_ssml(sentence),
                          sentence_no_ssml)
+
+    def test_load_spellings(self, _):
+        """Check that the spelling dictionary gets loaded."""
+        tts = MockTTS("en-US", {}, MockTTSValidator(None))
+        self.assertTrue(tts.spellings != {})
+
+    def test_load_spelling_missing(self, _):
+        """Test that a missing phonetic spelling dictionary counts as empty."""
+        tts = MockTTS("as-DF", {}, MockTTSValidator(None))
+        self.assertTrue(tts.spellings == {})
 
 
 class TestTTSFactory(unittest.TestCase):


### PR DESCRIPTION
## Description
The espeak output was done directly from the espeak executable and not through the TTS output queue, this makes the ESpeak module work more like mimic, mimic2 etc.

This should resolve #2579 allowing wait_while_speaking to work in a better fashion.

This also adds a simple test case for the espeak module and fixes a typo in a mimic-test

## How to test
Assert that ESpeak output works as previously.

## Contributor license agreement signed?
CLA [ Yes ]
