### PR TITLE
use long options and add --upgrade to arch linux pacman

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -342,7 +342,7 @@ function fedora_install() {
 
 
 function arch_install() {
-    $SUDO pacman --sync --upgrade --needed --noconfirm git python python-pip python-setuptools python-virtualenv python-gobject libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq pulseaudio pulseaudio-alsa
+    $SUDO pacman --upgrade --needed --noconfirm git python python-pip python-setuptools python-virtualenv python-gobject libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq pulseaudio pulseaudio-alsa
 
     pacman -Qs '^fann$' &> /dev/null || (
         git clone  https://aur.archlinux.org/fann.git

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -342,7 +342,7 @@ function fedora_install() {
 
 
 function arch_install() {
-    $SUDO pacman -S --needed --noconfirm git python python-pip python-setuptools python-virtualenv python-gobject libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq pulseaudio pulseaudio-alsa
+    $SUDO pacman --sync --upgrade --needed --noconfirm git python python-pip python-setuptools python-virtualenv python-gobject libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq pulseaudio pulseaudio-alsa
 
     pacman -Qs '^fann$' &> /dev/null || (
         git clone  https://aur.archlinux.org/fann.git


### PR DESCRIPTION
## Description
Arch Linux setup might fail on circumstances where --sync reveals newer versions of packages to be installed but setup does not allow updates of these packages.

## How to test

## Contributor license agreement signed?
CLA [yes]
