### PR TITLE
Add 'vktest clear' command

### DIFF
--- a/bin/mycroft-skill-testrunner
+++ b/bin/mycroft-skill-testrunner
@@ -20,12 +20,38 @@ DIR="$( dirname "$SOURCE" )"
 # Enter the Mycroft venv
 source "$DIR/../venv-activate.sh" -q
 
+function vktest-clear() {
+    FEATURES_DIR="$DIR/../test/integrationtests/voight_kampff/features"
+    num_feature_files=$(ls $FEATURES_DIR | wc -l) 
+    if [ $num_feature_files -gt "2" ] ; then
+        echo "Removing Feature files"
+        rm ${DIR}/../test/integrationtests/voight_kampff/features/*.feature
+    fi
+    STEPS_DIR="$FEATURES_DIR/steps"
+    num_steps_files=$(ls $STEPS_DIR | wc -l)
+    if [ $num_steps_files -gt "2" ] ; then
+        echo "Removing Custom Step files"
+        TMP_DIR="$STEPS_DIR/tmp"
+        mkdir $TMP_DIR
+        mv "$STEPS_DIR/configuration.py" $TMP_DIR
+        mv "$STEPS_DIR/utterance_responses.py" $TMP_DIR
+        rm ${STEPS_DIR}/*.py
+        mv ${TMP_DIR}/* $STEPS_DIR
+        rmdir $TMP_DIR
+    fi
+    echo "Voight Kampff tests clear."
+}
+
 # Invoke the individual skill tester
 if [ "$#" -eq 0 ] ; then
     python -m test.integrationtests.skills.runner .
 elif [ "$1" = "vktest" ] ; then
-    shift
-    python -m test.integrationtests.voight_kampff "$@"
+    if [ "$2" = "clear" ] ; then
+        vktest-clear
+    else
+        shift
+        python -m test.integrationtests.voight_kampff "$@"
+    fi
 else
     python -m test.integrationtests.skills.runner $@
 fi

--- a/bin/mycroft-skill-testrunner
+++ b/bin/mycroft-skill-testrunner
@@ -23,14 +23,16 @@ source "$DIR/../venv-activate.sh" -q
 function vktest-clear() {
     FEATURES_DIR="$DIR/../test/integrationtests/voight_kampff/features"
     num_feature_files=$(ls $FEATURES_DIR | wc -l) 
+    # A clean directory will have `steps/` and `environment.py`
     if [ $num_feature_files -gt "2" ] ; then
-        echo "Removing Feature files"
+        echo "Removing Feature files..."
         rm ${DIR}/../test/integrationtests/voight_kampff/features/*.feature
+        rm ${DIR}/../test/integrationtests/voight_kampff/features/*.config.json
     fi
     STEPS_DIR="$FEATURES_DIR/steps"
     num_steps_files=$(ls $STEPS_DIR | wc -l)
     if [ $num_steps_files -gt "2" ] ; then
-        echo "Removing Custom Step files"
+        echo "Removing Custom Step files..."
         TMP_DIR="$STEPS_DIR/tmp"
         mkdir $TMP_DIR
         mv "$STEPS_DIR/configuration.py" $TMP_DIR

--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -238,8 +238,7 @@ case ${_opt} in
         pytest test/integrationtests/skills/discover_tests.py "$@"
         ;;
     "vktest")
-        source-venv
-        python -m test.integrationtests.voight_kampff "$@"
+        source "$DIR/bin/mycroft-skill-testrunner" vktest "$@"
         ;;
     "audiotest")
         launch-process ${_opt}


### PR DESCRIPTION
## Description
Adds a new sub-command to `vktest` allowing developers to quickly clear any Skill Feature or Step files from the Voight Kampff directory.

To avoid duplication, all the logic is contained in `bin/skill-test-runner` and `start-mycroft.sh` calls that.

Had to do some file dancing to retain existing files. Any better suggestions welcomed...

## How to test
Test a Skill then remove the files.
```
mycroft-start vktest -t mycroft-timer
mycroft-start vktest clear
mycroft-skill-testrunner vktest -t mycroft-weather
mycroft-skill-testrunner vktest clear
```

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
