### PR TITLE
Plugin system for stt, tts and audioservices

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -118,9 +118,16 @@ class PocketsphinxHotWord(HotWordEngine):
         return file_name
 
     def create_config(self, dict_name, config):
+        """If language config doesn't exist then
+        we use default language (english) config as a fallback.
+        """
         model_file = join(RECOGNIZER_DIR, 'model', self.lang, 'hmm')
         if not exists(model_file):
-            LOG.error('PocketSphinx model not found at ' + str(model_file))
+            LOG.error(
+                'PocketSphinx model not found at "{}". '.format(model_file) +
+                'Falling back to en-us model'
+            )
+            model_file = join(RECOGNIZER_DIR, 'model', 'en-us', 'hmm')
         config.set_string('-hmm', model_file)
         config.set_string('-dict', dict_name)
         config.set_string('-keyphrase', self.key_phrase)

--- a/mycroft/util/plugins.py
+++ b/mycroft/util/plugins.py
@@ -1,0 +1,56 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Common functions for loading plugins."""
+
+import pkg_resources
+
+from .log import LOG
+
+
+def find_plugins(plug_type):
+    """Finds all plugins matching specific entrypoint type.
+
+    Arguments:
+        plug_type (str): plugin entrypoint string to retrieve
+
+    Returns:
+        dict mapping plugin names to plugin entrypoints
+    """
+    return {
+        entry_point.name: entry_point.load()
+        for entry_point
+        in pkg_resources.iter_entry_points(plug_type)
+    }
+
+
+def load_plugin(plug_type, plug_name):
+    """Load a specific plugin from a specific plugin type.
+
+    Arguments:
+        plug_type: (str) plugin type name. Ex. "mycroft.plugin.tts".
+        plug_name: (str) specific plugin name
+
+    Returns:
+        Loaded plugin Object or None if no matching object was found.
+    """
+    plugins = find_plugins(plug_type)
+    if plug_name in plugins:
+        ret = plugins[plug_name]
+    else:
+        LOG.warning('Could not find the plugin {}.{}'.format(plug_type,
+                                                             plug_name))
+        ret = None
+
+    return ret

--- a/test/unittests/util/test_plugins.py
+++ b/test/unittests/util/test_plugins.py
@@ -1,0 +1,56 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from unittest import TestCase, mock
+
+import mycroft.util.plugins as mycroft_plugins
+
+
+def get_plug_mock(name):
+    load_mock = mock.Mock(name=name)
+    load_mock.name = name
+    plug_mock = mock.Mock(name=name)
+    plug_mock.name = name
+    plug_mock.load.return_value = load_mock
+    return plug_mock
+
+
+def mock_iter_entry_points(plug_type):
+    """Function to return mocked plugins."""
+    plugs = {
+        'mycroft.plugins.tts': [get_plug_mock('dummy'),
+                                get_plug_mock('remote')],
+        'mycroft.plugins.stt': [get_plug_mock('dummy'),
+                                get_plug_mock('deepspeech')]
+    }
+    return plugs.get(plug_type, [])
+
+
+@mock.patch('mycroft.util.plugins.pkg_resources')
+class TestPlugins(TestCase):
+    def test_load_existing(self, mock_pkg_res):
+        """Ensure that plugin objects are returned if found."""
+        mock_pkg_res.iter_entry_points.side_effect = mock_iter_entry_points
+
+        # Load a couple of existing modules and verify that they're Ok
+        plug = mycroft_plugins.load_plugin('mycroft.plugins.tts', 'dummy')
+        self.assertEqual(plug.name, 'dummy')
+        plug = mycroft_plugins.load_plugin('mycroft.plugins.stt', 'deepspeech')
+        self.assertEqual(plug.name, 'deepspeech')
+
+    def test_load_nonexisting(self, mock_pkg_res):
+        """Ensure that the return value is None when no plugin is found."""
+        mock_pkg_res.iter_entry_points.side_effect = mock_iter_entry_points
+        plug = mycroft_plugins.load_plugin('mycroft.plugins.tts', 'blah')
+        self.assertEqual(plug, None)


### PR DESCRIPTION
## Description
This adds a simple plugin system for loading external stt, tts and audioservices. The "plugins" are pip install-able modules presenting one or more entrypoints with a entrypoint group defined in setup.py ([Example](https://github.com/forslund/mycroft-tts-plugin-gtts/blob/master/setup.py))

TTS group: "mycroft.plugin.tts"
STT group: "mycroft.plugin.stt"
Audioservice group: "mycroft.plugin.audioservice"
Wake-word group: "mycroft.plugin.wake_word"

STT and TTS loads a single object for the specified module (as specified in the config), while audioservice loads all found audioservices and append to the list of builtins services. 

This system makes it easier to quickly add third-party services without changing core, it also makes it easier for users to select things like Polly where the requirement will automatically be installed together with the TTS module.

The detection system is based on the documentation for python packaging. [Link](https://packaging.python.org/guides/creating-and-discovering-plugins/)

-Future work: hotword engines. Can the same system be leveraged for skills? Update and reloading needs to be considered...-
@jarbasAl contributed an implementation of hot/wake-word engine plugins. There is a test plugin available [here](https://github.com/JarbasAl/dummy_wakeword_plugin)

## How to test
`mycroft-pip install git+https://github.com/forslund/mycroft-tts-plugin-gtts.git`

Then set the tts module to `google_tts_plug` assert that the google tts voice is heard

## Contributor license agreement signed?
CLA [ Yes ]
