### PR TITLE
Build Snap as part of the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,6 +167,32 @@ pipeline {
                 }
             }
         }
+        // Build snap package for release
+        stage('Build development Snap package') {
+            when {
+                anyOf {
+                    branch 'dev'
+                }
+            }
+            steps {
+                echo "Launching package build for ${env.BRANCH_NAME}"
+                build (job: '../Mycroft-snap/dev', wait: false,
+                       parameters: [[$class: 'StringParameterValue',
+                                     name: 'BRANCH', value: env.BRANCH_NAME]])
+            }
+        }
+
+        stage('Build Release Snap package') {
+            when {
+                tag "release/v*.*.*"
+            }
+            steps {
+                echo "Launching package build for ${env.TAG_NAME}"
+                build (job: '../Mycroft-snap/dev', wait: false,
+                       parameters: [[$class: 'StringParameterValue',
+                                     name: 'BRANCH', value: env.TAG_NAME]])
+            }
+        }
         // Build a voight_kampff image for major releases.  This will be used
         // by the mycroft-skills repository to test skill changes.  Skills are
         // tested against major releases to determine if they play nicely with


### PR DESCRIPTION
## Description
Launch snap build on push to dev and release tag

This will trigger the Job for the Mycroft-snap sending the branch/tag  as a
parameter.

Requires the ci job for snapcraft-mycroft-core to be merged.

## Contributor license agreement signed?
CLA [ Yes ]
