### PR TITLE
Refactor intent service

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -43,7 +43,6 @@ from mycroft.util.log import LOG
 from .core import FallbackSkill
 from .event_scheduler import EventScheduler
 from .intent_service import IntentService
-from .padatious_service import PadatiousService
 from .skill_manager import SkillManager
 
 RASPBERRY_PI_PLATFORMS = ('mycroft_mark_1', 'picroft', 'mycroft_mark_2pi')
@@ -240,12 +239,6 @@ def _register_intent_services(bus):
         bus: messagebus client to register the services on
     """
     service = IntentService(bus)
-    try:
-        PadatiousService(bus, service)
-    except Exception as e:
-        LOG.exception('Failed to create padatious handlers '
-                      '({})'.format(repr(e)))
-
     # Register handler to trigger fallback system
     bus.on('intent_failure', FallbackSkill.make_intent_failure_handler(bus))
 

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -240,7 +240,13 @@ def _register_intent_services(bus):
     """
     service = IntentService(bus)
     # Register handler to trigger fallback system
+    bus.on(
+        'mycroft.skills.fallback',
+        FallbackSkill.make_intent_failure_handler(bus)
+    )
+    # Backwards compatibility TODO: remove in 20.08
     bus.on('intent_failure', FallbackSkill.make_intent_failure_handler(bus))
+    return service
 
 
 def _initialize_skill_manager(bus, watchdog):

--- a/mycroft/skills/adapt_service.py
+++ b/mycroft/skills/adapt_service.py
@@ -1,0 +1,247 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""An intent parsing service using the Adapt parser."""
+from adapt.context import ContextManagerFrame
+from adapt.engine import IntentDeterminationEngine
+from adapt.intent import IntentBuilder
+
+import time
+
+from mycroft.util.log import LOG
+
+
+class AdaptIntent(IntentBuilder):
+    def __init__(self, name=''):
+        super().__init__(name)
+
+
+def workaround_one_of_context(best_intent):
+    """ Handle Adapt issue with context injection combined with one_of.
+
+    For all entries in the intent result where the value is None try to
+    populate using a value from the __tags__ structure.
+    """
+    for key in best_intent:
+        if best_intent[key] is None:
+            for t in best_intent['__tags__']:
+                if key in t:
+                    best_intent[key] = t[key][0]['entities'][0]['key']
+    return best_intent
+
+
+class ContextManager:
+    """Adapt Context Manager
+
+    Use to track context throughout the course of a conversational session.
+    How to manage a session's lifecycle is not captured here.
+    """
+
+    def __init__(self, timeout):
+        self.frame_stack = []
+        self.timeout = timeout * 60  # minutes to seconds
+
+    def clear_context(self):
+        self.frame_stack = []
+
+    def remove_context(self, context_id):
+        self.frame_stack = [(f, t) for (f, t) in self.frame_stack
+                            if context_id in f.entities[0].get('data', [])]
+
+    def inject_context(self, entity, metadata=None):
+        """
+        Args:
+            entity(object): Format example...
+                               {'data': 'Entity tag as <str>',
+                                'key': 'entity proper name as <str>',
+                                'confidence': <float>'
+                               }
+            metadata(object): dict, arbitrary metadata about entity injected
+        """
+        metadata = metadata or {}
+        try:
+            if len(self.frame_stack) > 0:
+                top_frame = self.frame_stack[0]
+            else:
+                top_frame = None
+            if top_frame and top_frame[0].metadata_matches(metadata):
+                top_frame[0].merge_context(entity, metadata)
+            else:
+                frame = ContextManagerFrame(entities=[entity],
+                                            metadata=metadata.copy())
+                self.frame_stack.insert(0, (frame, time.time()))
+        except (IndexError, KeyError):
+            pass
+
+    def get_context(self, max_frames=None, missing_entities=None):
+        """ Constructs a list of entities from the context.
+
+        Args:
+            max_frames(int): maximum number of frames to look back
+            missing_entities(list of str): a list or set of tag names,
+            as strings
+
+        Returns:
+            list: a list of entities
+        """
+        missing_entities = missing_entities or []
+
+        relevant_frames = [frame[0] for frame in self.frame_stack if
+                           time.time() - frame[1] < self.timeout]
+        if not max_frames or max_frames > len(relevant_frames):
+            max_frames = len(relevant_frames)
+
+        missing_entities = list(missing_entities)
+        context = []
+        last = ''
+        depth = 0
+        for i in range(max_frames):
+            frame_entities = [entity.copy() for entity in
+                              relevant_frames[i].entities]
+            for entity in frame_entities:
+                entity['confidence'] = entity.get('confidence', 1.0) \
+                                       / (2.0 + depth)
+            context += frame_entities
+
+            # Update depth
+            if entity['origin'] != last or entity['origin'] == '':
+                depth += 1
+            last = entity['origin']
+
+        result = []
+        if len(missing_entities) > 0:
+            for entity in context:
+                if entity.get('data') in missing_entities:
+                    result.append(entity)
+                    # NOTE: this implies that we will only ever get one
+                    # of an entity kind from context, unless specified
+                    # multiple times in missing_entities. Cannot get
+                    # an arbitrary number of an entity kind.
+                    missing_entities.remove(entity.get('data'))
+        else:
+            result = context
+
+        # Only use the latest instance of each keyword
+        stripped = []
+        processed = []
+        for f in result:
+            keyword = f['data'][0][1]
+            if keyword not in processed:
+                stripped.append(f)
+                processed.append(keyword)
+        result = stripped
+        return result
+
+
+class AdaptService:
+    def __init__(self, config):
+        self.config = config
+        self.engine = IntentDeterminationEngine()
+        # Context related intializations
+        self.context_keywords = self.config.get('keywords', [])
+        self.context_max_frames = self.config.get('max_frames', 3)
+        self.context_timeout = self.config.get('timeout', 2)
+        self.context_greedy = self.config.get('greedy', False)
+        self.context_manager = ContextManager(self.context_timeout)
+
+    def update_context(self, intent):
+        """Updates context with keyword from the intent.
+
+        NOTE: This method currently won't handle one_of intent keywords
+              since it's not using quite the same format as other intent
+              keywords. This is under investigation in adapt, PR pending.
+
+        Args:
+            intent: Intent to scan for keywords
+        """
+        for tag in intent['__tags__']:
+            if 'entities' not in tag:
+                continue
+            context_entity = tag['entities'][0]
+            if self.context_greedy:
+                self.context_manager.inject_context(context_entity)
+            elif context_entity['data'][0][1] in self.context_keywords:
+                self.context_manager.inject_context(context_entity)
+
+    def match_intent(self, raw_utt, norm_utt, lang):
+        """Run the Adapt engine to search for an matching intent
+
+        Args:
+            raw_utt (list):  list of utterances
+            norm_utt (list): same list of utterances, normalized
+            lang (string):   language code, e.g "en-us"
+
+        Returns:
+            Intent structure, or None if no match was found.
+        """
+        best_intent = None
+
+        def take_best(intent, utt):
+            nonlocal best_intent
+            best = best_intent.get('confidence', 0.0) if best_intent else 0.0
+            conf = intent.get('confidence', 0.0)
+            if conf > best:
+                best_intent = intent
+                # TODO - Shouldn't Adapt do this?
+                best_intent['utterance'] = utt
+
+        for idx, utt in enumerate(raw_utt):
+            try:
+                intents = [i for i in self.engine.determine_intent(
+                    utt, 100,
+                    include_tags=True,
+                    context_manager=self.context_manager)]
+                if intents:
+                    take_best(intents[0], utt)
+
+                # Also test the normalized version, but set the utterance to
+                # the raw version so skill has access to original STT
+                norm_intents = [i for i in self.engine.determine_intent(
+                    norm_utt[idx], 100,
+                    include_tags=True,
+                    context_manager=self.context_manager)]
+                if norm_intents:
+                    take_best(norm_intents[0], utt)
+            except Exception as e:
+                LOG.exception(e)
+
+        if best_intent:
+            try:
+                best_intent = workaround_one_of_context(best_intent)
+            except LookupError:
+                LOG.error('Error during workaround_one_of_context')
+
+        return best_intent
+
+    def register_vocab(self, start_concept, end_concept, alias_of, regex_str):
+        """Register vocabulary."""
+        if regex_str:
+            self.engine.register_regex_entity(regex_str)
+        else:
+            self.engine.register_entity(
+                start_concept, end_concept, alias_of=alias_of)
+
+    def register_intent(self, intent):
+        self.engine.register_intent_parser(intent)
+
+    def detach_skill(self, skill_id):
+        new_parsers = [
+            p for p in self.engine.intent_parsers if
+            not p.name.startswith(skill_id)]
+        self.engine.intent_parsers = new_parsers
+
+    def detach_intent(self, intent_name):
+        new_parsers = [
+            p for p in self.engine.intent_parsers if p.name != intent_name]
+        self.engine.intent_parsers = new_parsers

--- a/mycroft/skills/intent_services/__init__.py
+++ b/mycroft/skills/intent_services/__init__.py
@@ -1,0 +1,3 @@
+from .adapt_service import AdaptService, AdaptIntent
+from .base import IntentMatch
+from .padatious_service import PadatiousService

--- a/mycroft/skills/intent_services/__init__.py
+++ b/mycroft/skills/intent_services/__init__.py
@@ -1,3 +1,4 @@
 from .adapt_service import AdaptService, AdaptIntent
 from .base import IntentMatch
+from .fallback_service import FallbackService
 from .padatious_service import PadatiousService

--- a/mycroft/skills/intent_services/adapt_service.py
+++ b/mycroft/skills/intent_services/adapt_service.py
@@ -28,20 +28,6 @@ class AdaptIntent(IntentBuilder):
         super().__init__(name)
 
 
-def workaround_one_of_context(best_intent):
-    """ Handle Adapt issue with context injection combined with one_of.
-
-    For all entries in the intent result where the value is None try to
-    populate using a value from the __tags__ structure.
-    """
-    for key in best_intent:
-        if best_intent[key] is None:
-            for t in best_intent['__tags__']:
-                if key in t:
-                    best_intent[key] = t[key][0]['entities'][0]['key']
-    return best_intent
-
-
 class ContextManager:
     """Adapt Context Manager
 
@@ -210,11 +196,6 @@ class AdaptService:
                 LOG.exception(e)
 
         if best_intent:
-            try:
-                best_intent = workaround_one_of_context(best_intent)
-            except LookupError:
-                LOG.error('Error during workaround_one_of_context')
-
             self.update_context(best_intent)
             skill_id = best_intent['intent_type'].split(":")[0]
             return IntentMatch(

--- a/mycroft/skills/intent_services/adapt_service.py
+++ b/mycroft/skills/intent_services/adapt_service.py
@@ -183,17 +183,18 @@ class AdaptService:
                 # TODO - Shouldn't Adapt do this?
                 best_intent['utterance'] = utt
 
-        for idx, utt in enumerate(utterances):
-            try:
-                intents = [i for i in self.engine.determine_intent(
-                    utt, 100,
-                    include_tags=True,
-                    context_manager=self.context_manager)]
-                if intents:
-                    take_best(intents[0], utt)
+        for utt_tup in utterances:
+            for utt in utt_tup:
+                try:
+                    intents = [i for i in self.engine.determine_intent(
+                        utt, 100,
+                        include_tags=True,
+                        context_manager=self.context_manager)]
+                    if intents:
+                        take_best(intents[0], utt_tup[0])
 
-            except Exception as e:
-                LOG.exception(e)
+                except Exception as e:
+                    LOG.exception(e)
 
         if best_intent:
             self.update_context(best_intent)

--- a/mycroft/skills/intent_services/base.py
+++ b/mycroft/skills/intent_services/base.py
@@ -1,0 +1,14 @@
+
+
+from collections import namedtuple
+
+
+# Intent match response tuple containing
+# intent_service: Name of the service that matched the intent
+# intent_type: intent name (used to call intent handler over the message bus)
+# intent_data: data provided by the intent match
+# skill_id: the skill this handler belongs to
+IntentMatch = namedtuple('IntentMatch',
+                         ['intent_service', 'intent_type',
+                          'intent_data', 'skill_id']
+                         )

--- a/mycroft/skills/intent_services/fallback_service.py
+++ b/mycroft/skills/intent_services/fallback_service.py
@@ -1,0 +1,65 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Intent service for Mycroft's fallback system."""
+from collections import namedtuple
+from .base import IntentMatch
+
+FallbackRange = namedtuple('FallbackRange', ['start', 'stop'])
+
+
+class FallbackService:
+    """Intent Service handling fallback skills."""
+    def __init__(self, bus):
+        self.bus = bus
+
+    def _fallback_range(self, utterances, lang, message, fb_range):
+        """Send fallback request for a specified priority range.
+
+        Arguments:
+            combined (list): List of unique versions of utterances
+            lang (str): Langauge code
+            message: Message for session context
+            fb_range (FallbackRange): fallback order start and stop.
+
+        Returns:
+            IntentMatch or None
+        """
+        msg = message.reply(
+            'mycroft.skills.fallback',
+            data={'utterance': utterances[0],
+                  'lang': lang,
+                  'fallback_range': (fb_range.start, fb_range.stop)}
+        )
+        response = self.bus.wait_for_response(msg, timeout=10)
+        if response and response.data['handled']:
+            ret = IntentMatch('Fallback', None, {}, None)
+        else:
+            ret = None
+        return ret
+
+    def high_prio(self, utterances, lang, message):
+        """Pre-padatious fallbacks."""
+        return self._fallback_range(utterances, lang, message,
+                                    FallbackRange(0, 5))
+
+    def medium_prio(self, utterances, lang, message):
+        """General fallbacks."""
+        return self._fallback_range(utterances, lang, message,
+                                    FallbackRange(5, 90))
+
+    def low_prio(self, utterances, lang, message):
+        """Low prio fallbacks with general matching such as chat-bot."""
+        return self._fallback_range(utterances, lang, message,
+                                    FallbackRange(90, 101))

--- a/mycroft/skills/intent_services/fallback_service.py
+++ b/mycroft/skills/intent_services/fallback_service.py
@@ -28,7 +28,8 @@ class FallbackService:
         """Send fallback request for a specified priority range.
 
         Arguments:
-            combined (list): List of unique versions of utterances
+            utterances (list): List of tuples,
+                               utterances and normalized version
             lang (str): Langauge code
             message: Message for session context
             fb_range (FallbackRange): fallback order start and stop.
@@ -38,7 +39,7 @@ class FallbackService:
         """
         msg = message.reply(
             'mycroft.skills.fallback',
-            data={'utterance': utterances[0],
+            data={'utterance': utterances[0][0],
                   'lang': lang,
                   'fallback_range': (fb_range.start, fb_range.stop)}
         )

--- a/mycroft/skills/intent_services/padatious_service.py
+++ b/mycroft/skills/intent_services/padatious_service.py
@@ -1,0 +1,205 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from functools import lru_cache
+from subprocess import call
+from threading import Event
+from time import time as get_time, sleep
+
+from os.path import expanduser, isfile
+
+from mycroft.configuration import Configuration
+from mycroft.messagebus.message import Message
+from mycroft.util.log import LOG
+from .base import IntentMatch
+
+
+class PadatiousService:
+    """Service class for padatious intent matching."""
+    def __init__(self, bus, config):
+        self.padatious_config = config
+        self.bus = bus
+        intent_cache = expanduser(self.padatious_config['intent_cache'])
+
+        try:
+            from padatious import IntentContainer
+        except ImportError:
+            LOG.error('Padatious not installed. Please re-run dev_setup.sh')
+            try:
+                call(['notify-send', 'Padatious not installed',
+                      'Please run build_host_setup and dev_setup again'])
+            except OSError:
+                pass
+            return
+
+        self.container = IntentContainer(intent_cache)
+
+        self._bus = bus
+        self.bus.on('padatious:register_intent', self.register_intent)
+        self.bus.on('padatious:register_entity', self.register_entity)
+        self.bus.on('detach_intent', self.handle_detach_intent)
+        self.bus.on('detach_skill', self.handle_detach_skill)
+        self.bus.on('mycroft.skills.initialized', self.train)
+        self.bus.on('intent.service.padatious.get', self.handle_get_padatious)
+        self.bus.on('intent.service.padatious.manifest.get',
+                    self.handle_manifest)
+        self.bus.on('intent.service.padatious.entities.manifest.get',
+                    self.handle_entity_manifest)
+
+        self.finished_training_event = Event()
+        self.finished_initial_train = False
+
+        self.train_delay = self.padatious_config['train_delay']
+        self.train_time = get_time() + self.train_delay
+
+        self.registered_intents = []
+        self.registered_entities = []
+
+    def train(self, message=None):
+        padatious_single_thread = Configuration.get()[
+            'padatious']['single_thread']
+        if message is None:
+            single_thread = padatious_single_thread
+        else:
+            single_thread = message.data.get('single_thread',
+                                             padatious_single_thread)
+
+        self.finished_training_event.clear()
+
+        LOG.info('Training... (single_thread={})'.format(single_thread))
+        self.container.train(single_thread=single_thread)
+        LOG.info('Training complete.')
+
+        self.finished_training_event.set()
+        if not self.finished_initial_train:
+            LOG.info("Mycroft is all loaded and ready to roll!")
+            self.bus.emit(Message('mycroft.ready'))
+            self.finished_initial_train = True
+
+    def wait_and_train(self):
+        if not self.finished_initial_train:
+            return
+        sleep(self.train_delay)
+        if self.train_time < 0.0:
+            return
+
+        if self.train_time <= get_time() + 0.01:
+            self.train_time = -1.0
+            self.train()
+
+    def __detach_intent(self, intent_name):
+        """ Remove an intent if it has been registered.
+
+        Arguments:
+            intent_name (str): intent identifier
+        """
+        if intent_name in self.registered_intents:
+            self.registered_intents.remove(intent_name)
+            self.container.remove_intent(intent_name)
+
+    def handle_detach_intent(self, message):
+        self.__detach_intent(message.data.get('intent_name'))
+
+    def handle_detach_skill(self, message):
+        skill_id = message.data['skill_id']
+        remove_list = [i for i in self.registered_intents if skill_id in i]
+        for i in remove_list:
+            self.__detach_intent(i)
+
+    def _register_object(self, message, object_name, register_func):
+        file_name = message.data['file_name']
+        name = message.data['name']
+
+        LOG.debug('Registering Padatious ' + object_name + ': ' + name)
+
+        if not isfile(file_name):
+            LOG.warning('Could not find file ' + file_name)
+            return
+
+        register_func(name, file_name)
+        self.train_time = get_time() + self.train_delay
+        self.wait_and_train()
+
+    def register_intent(self, message):
+        self.registered_intents.append(message.data['name'])
+        self._register_object(message, 'intent', self.container.load_intent)
+
+    def register_entity(self, message):
+        self.registered_entities.append(message.data)
+        self._register_object(message, 'entity', self.container.load_entity)
+
+    def match_intent(self, utt, lang):
+        if not self.finished_training_event.is_set():
+            LOG.debug('Waiting for Padatious training to finish...')
+            return False
+
+        LOG.debug("Padatious fallback attempt: {}".format(utt))
+        intent = self.calc_intent(utt)
+
+        intent.matches['utterance'] = utt
+        return intent.name, intent.matches
+
+    def _match_level(self, combined, limit):
+        padatious_intent = None
+        LOG.debug('Padatious Matching confidence > {}'.format(limit))
+        for utt in combined:
+            _intent = self.calc_intent(utt)
+            if _intent:
+                best = padatious_intent.conf if padatious_intent else 0.0
+                if best < _intent.conf:
+                    padatious_intent = _intent
+
+        if padatious_intent.conf > limit:
+            skill_id = padatious_intent.name.split(':')[0]
+            return IntentMatch(
+                'Padatious', padatious_intent.name, padatious_intent.matches,
+                skill_id
+            )
+        else:
+            return None
+
+    def match_high(self, combined, lang, _):
+        return self._match_level(combined, 0.95)
+
+    def match_medium(self, combined, lang, _):
+        return self._match_level(combined, 0.8)
+
+    def match_low(self, combined, lang, _):
+        return self._match_level(combined, 0.5)
+
+    def handle_get_padatious(self, message):
+        utterance = message.data["utterance"]
+        norm = message.data.get('norm_utt', utterance)
+        intent = self.calc_intent(utterance)
+        if not intent and norm != utterance:
+            intent = PadatiousService.instance.calc_intent(norm)
+        if intent:
+            intent = intent.__dict__
+        self.bus.emit(message.reply("intent.service.padatious.reply",
+                                    {"intent": intent}))
+
+    def handle_manifest(self, message):
+        self.bus.emit(message.reply("intent.service.padatious.manifest",
+                                    {"intents": self.registered_intents}))
+
+    def handle_entity_manifest(self, message):
+        self.bus.emit(
+            message.reply("intent.service.padatious.entities.manifest",
+                          {"entities": self.registered_entities}))
+
+    # NOTE: This cache will keep a reference to this class (PadatiousService),
+    # but we can live with that since it is used as a singleton.
+    @lru_cache(maxsize=2)  # 2 catches both raw and normalized utts in cache
+    def calc_intent(self, utt):
+        return self.container.calc_intent(utt)

--- a/mycroft/skills/intent_services/padatious_service.py
+++ b/mycroft/skills/intent_services/padatious_service.py
@@ -150,15 +150,17 @@ class PadatiousService:
         intent.matches['utterance'] = utt
         return intent.name, intent.matches
 
-    def _match_level(self, combined, limit):
+    def _match_level(self, utterances, limit):
         padatious_intent = None
         LOG.debug('Padatious Matching confidence > {}'.format(limit))
-        for utt in combined:
-            _intent = self.calc_intent(utt)
-            if _intent:
-                best = padatious_intent.conf if padatious_intent else 0.0
-                if best < _intent.conf:
-                    padatious_intent = _intent
+        for utt in utterances:
+            for variant in utt:
+                intent = self.calc_intent(variant)
+                if intent:
+                    best = padatious_intent.conf if padatious_intent else 0.0
+                    if best < intent.conf:
+                        padatious_intent = intent
+                        padatious_intent.matches['utterance'] = utt[0]
 
         if padatious_intent.conf > limit:
             skill_id = padatious_intent.name.split(':')[0]
@@ -169,14 +171,14 @@ class PadatiousService:
         else:
             return None
 
-    def match_high(self, combined, lang, _):
-        return self._match_level(combined, 0.95)
+    def match_high(self, utterances, lang, _):
+        return self._match_level(utterances, 0.95)
 
-    def match_medium(self, combined, lang, _):
-        return self._match_level(combined, 0.8)
+    def match_medium(self, utterances, lang, _):
+        return self._match_level(utterances, 0.8)
 
-    def match_low(self, combined, lang, _):
-        return self._match_level(combined, 0.5)
+    def match_low(self, utterances, lang, _):
+        return self._match_level(utterances, 0.5)
 
     def handle_get_padatious(self, message):
         utterance = message.data["utterance"]

--- a/test/unittests/skills/test_intent_service.py
+++ b/test/unittests/skills/test_intent_service.py
@@ -113,7 +113,7 @@ class ConversationTest(TestCase):
                                 data={'lang': 'en-US',
                                       'utterances': hello})
         result = self.intent_service._converse(hello, 'en-US', utterance_msg)
-
+        self.intent_service.add_active_skill(result.skill_id)
         # Check that the active skill list was updated to set the responding
         # Skill first.
         first_active_skill = self.intent_service.active_skills[0][0]

--- a/test/unittests/skills/test_intent_service.py
+++ b/test/unittests/skills/test_intent_service.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 #
 from unittest import TestCase, mock
+
+from adapt.intent import IntentBuilder
+
 from mycroft.configuration import Configuration
 from mycroft.messagebus import Message
 from mycroft.skills.intent_service import (ContextManager, IntentService,
@@ -208,3 +211,119 @@ class TestLanguageExtraction(TestCase):
         self.assertEqual(_get_message_lang(msg), 'de-de')
         msg = Message('test msg', data={'lang': 'sv-se'})
         self.assertEqual(_get_message_lang(msg), 'sv-se')
+
+
+def create_vocab_msg(keyword, value):
+    """Create a message for registering an adapt keyword."""
+    return Message('register_vocab',
+                   {'start': value, 'end': keyword})
+
+
+def get_last_message(bus):
+    """Get last sent message on mock bus."""
+    last = bus.emit.call_args
+    return last[0][0]
+
+
+class TestIntentServiceApi(TestCase):
+    def setUp(self):
+        self.intent_service = IntentService(mock.Mock())
+
+    def setup_simple_adapt_intent(self):
+        msg = create_vocab_msg('testKeyword', 'test')
+        self.intent_service.handle_register_vocab(msg)
+
+        intent = IntentBuilder('skill:testIntent').require('testKeyword')
+        msg = Message('register_intent', intent.__dict__)
+        self.intent_service.handle_register_intent(msg)
+
+    def test_get_adapt_intent(self):
+        self.setup_simple_adapt_intent()
+        # Check that the intent is returned
+        msg = Message('intent.service.adapt.get', data={'utterance': 'test'})
+        self.intent_service.handle_get_adapt(msg)
+
+        reply = get_last_message(self.intent_service.bus)
+        self.assertEqual(reply.data['intent']['intent_type'],
+                         'skill:testIntent')
+
+    def test_get_adapt_intent_no_match(self):
+        """Check that if the intent doesn't match at all None is returned."""
+        self.setup_simple_adapt_intent()
+        # Check that no intent is matched
+        msg = Message('intent.service.adapt.get', data={'utterance': 'five'})
+        self.intent_service.handle_get_adapt(msg)
+        reply = get_last_message(self.intent_service.bus)
+        self.assertEqual(reply.data['intent'], None)
+
+    def test_get_intent(self):
+        """Check that the registered adapt intent is triggered."""
+        self.setup_simple_adapt_intent()
+        # Check that the intent is returned
+        msg = Message('intent.service.adapt.get', data={'utterance': 'test'})
+        self.intent_service.handle_get_intent(msg)
+
+        reply = get_last_message(self.intent_service.bus)
+        self.assertEqual(reply.data['intent']['intent_type'],
+                         'skill:testIntent')
+
+    def test_get_intent_no_match(self):
+        """Check that if the intent doesn't match at all None is returned."""
+        self.setup_simple_adapt_intent()
+        # Check that no intent is matched
+        msg = Message('intent.service.intent.get', data={'utterance': 'five'})
+        self.intent_service.handle_get_intent(msg)
+        reply = get_last_message(self.intent_service.bus)
+        self.assertEqual(reply.data['intent'], None)
+
+    def test_get_intent_manifest(self):
+        """Check that if the intent doesn't match at all None is returned."""
+        self.setup_simple_adapt_intent()
+        # Check that no intent is matched
+        msg = Message('intent.service.intent.get', data={'utterance': 'five'})
+        self.intent_service.handle_get_intent(msg)
+        reply = get_last_message(self.intent_service.bus)
+        self.assertEqual(reply.data['intent'], None)
+
+    def test_get_adapt_intent_manifest(self):
+        """Make sure the manifest returns a list of Intent Parser objects."""
+        self.setup_simple_adapt_intent()
+        msg = Message('intent.service.adapt.manifest.get')
+        self.intent_service.handle_manifest(msg)
+        reply = get_last_message(self.intent_service.bus)
+        self.assertEqual(reply.data['intents'][0]['name'],
+                         'skill:testIntent')
+
+    def test_get_adapt_vocab_manifest(self):
+        self.setup_simple_adapt_intent()
+        msg = Message('intent.service.adapt.vocab.manifest.get')
+        self.intent_service.handle_vocab_manifest(msg)
+        reply = get_last_message(self.intent_service.bus)
+        value = reply.data['vocab'][0]['start']
+        keyword = reply.data['vocab'][0]['end']
+        self.assertEqual(keyword, 'testKeyword')
+        self.assertEqual(value, 'test')
+
+    def test_get_no_match_after_detach(self):
+        """Check that a removed intent doesn't match."""
+        self.setup_simple_adapt_intent()
+        # Check that no intent is matched
+        msg = Message('detach_intent',
+                      data={'intent_name': 'skill:testIntent'})
+        self.intent_service.handle_detach_intent(msg)
+        msg = Message('intent.service.adapt.get', data={'utterance': 'test'})
+        self.intent_service.handle_get_adapt(msg)
+        reply = get_last_message(self.intent_service.bus)
+        self.assertEqual(reply.data['intent'], None)
+
+    def test_get_no_match_after_detach_skill(self):
+        """Check that a removed skill's intent doesn't match."""
+        self.setup_simple_adapt_intent()
+        # Check that no intent is matched
+        msg = Message('detach_intent',
+                      data={'skill_id': 'skill'})
+        self.intent_service.handle_detach_skill(msg)
+        msg = Message('intent.service.adapt.get', data={'utterance': 'test'})
+        self.intent_service.handle_get_adapt(msg)
+        reply = get_last_message(self.intent_service.bus)
+        self.assertEqual(reply.data['intent'], None)


### PR DESCRIPTION
## Description
The intent handling has been spread out over a bunch of files and this sort of collects it back into a single location makes the entire flow viewable from a single handler for the old `recognizer_loop:utterance` message.

The resolution order is the same as before only expressed as a single list instead of a series of checks and fallbacks interlaced.

- Converse
- Padatious High Confidence
- Adapt
- Fallback High priority
- Padatious Medium Confidence
- Fallback Medium priority
- Padatious Last ditch effort
- Fallback Low priority

This collects the many parts of where intent is handled into a single
location handling the entire flow.

The idea is that, in the end, all the skill calling should be done from
this method. The main intent parsers does this but the converse and
fallback still calls directly.

Future work: Converse and fallback still triggers handlers directly.

## How to test
Best way to test this is to make sure the voight kampff tests are still passing.

## Contributor license agreement signed?
CLA [ Yes ]
