### PR TITLE
Service hooks

### DIFF
--- a/mycroft/audio/__main__.py
+++ b/mycroft/audio/__main__.py
@@ -34,7 +34,11 @@ def on_error(e='Unknown'):
     LOG.error('Audio service failed to launch ({}).'.format(repr(e)))
 
 
-def main(ready_hook=on_ready, error_hook=on_error):
+def on_stopping():
+    LOG.info('Audio service is shutting down...')
+
+
+def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
     """ Main function. Run when file is invoked. """
     try:
         reset_sigint_handler()
@@ -54,7 +58,10 @@ def main(ready_hook=on_ready, error_hook=on_error):
     else:
         create_daemon(bus.run_forever)
         ready_hook()
+
         wait_for_exit_signal()
+
+        stopping_hook()
         speech.shutdown()
         audio.shutdown()
 

--- a/mycroft/audio/__main__.py
+++ b/mycroft/audio/__main__.py
@@ -57,11 +57,14 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
         error_hook(e)
     else:
         create_daemon(bus.run_forever)
-        ready_hook()
+        if audio.wait_for_load() and len(audio.service) > 0:
+            # If at least one service exists, report ready
+            ready_hook()
+            wait_for_exit_signal()
+            stopping_hook()
+        else:
+            error_hook('No audio services loaded')
 
-        wait_for_exit_signal()
-
-        stopping_hook()
         speech.shutdown()
         audio.shutdown()
 

--- a/mycroft/client/enclosure/__main__.py
+++ b/mycroft/client/enclosure/__main__.py
@@ -23,6 +23,14 @@ from mycroft.util import (create_daemon, wait_for_exit_signal,
                           reset_sigint_handler)
 
 
+def on_ready():
+    LOG.info("Enclosure started!")
+
+
+def on_error(e='Unknown'):
+    LOG.error('Enclosure failed to start. ({})'.format(repr(e)))
+
+
 def create_enclosure(platform):
     """Create an enclosure based on the provided platform string.
 
@@ -51,7 +59,8 @@ def create_enclosure(platform):
     return enclosure
 
 
-def main():
+def main(ready_hook=on_ready, error_hook=on_error):
+    # Read the system configuration
     """Launch one of the available enclosure implementations.
 
     This depends on the configured platform and can currently either be
@@ -68,6 +77,7 @@ def main():
             LOG.debug("Enclosure started!")
             reset_sigint_handler()
             create_daemon(enclosure.run)
+            ready_hook()
             wait_for_exit_signal()
         except Exception as e:
             print(e)

--- a/mycroft/client/enclosure/__main__.py
+++ b/mycroft/client/enclosure/__main__.py
@@ -27,6 +27,10 @@ def on_ready():
     LOG.info("Enclosure started!")
 
 
+def on_stopping():
+    LOG.info('Enclosure is shutting down...')
+
+
 def on_error(e='Unknown'):
     LOG.error('Enclosure failed to start. ({})'.format(repr(e)))
 
@@ -59,7 +63,7 @@ def create_enclosure(platform):
     return enclosure
 
 
-def main(ready_hook=on_ready, error_hook=on_error):
+def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
     # Read the system configuration
     """Launch one of the available enclosure implementations.
 
@@ -79,6 +83,7 @@ def main(ready_hook=on_ready, error_hook=on_error):
             create_daemon(enclosure.run)
             ready_hook()
             wait_for_exit_signal()
+            stopping_hook()
         except Exception as e:
             print(e)
     else:

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -207,7 +207,7 @@ def connect_bus_events(bus):
     bus.on('message', create_echo_function('VOICE'))
 
 
-def main(ready_hook=on_ready, error_hook=on_error):
+def main(ready_hook=on_ready, error_hook=on_error, watchdog=lambda: None):
     global bus
     global loop
     global config
@@ -219,7 +219,7 @@ def main(ready_hook=on_ready, error_hook=on_error):
         config = Configuration.get()
 
         # Register handlers on internal RecognizerLoop bus
-        loop = RecognizerLoop()
+        loop = RecognizerLoop(watchdog)
         connect_loop_events(loop)
         connect_bus_events(bus)
         create_daemon(bus.run_forever)

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -175,6 +175,10 @@ def on_ready():
     LOG.info('Speech client is ready.')
 
 
+def on_stopping():
+    LOG.info('Speech service is shutting down...')
+
+
 def on_error(e='Unknown'):
     LOG.error('Audio service failed to launch ({}).'.format(repr(e)))
 
@@ -207,7 +211,8 @@ def connect_bus_events(bus):
     bus.on('message', create_echo_function('VOICE'))
 
 
-def main(ready_hook=on_ready, error_hook=on_error, watchdog=lambda: None):
+def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
+         watchdog=lambda: None):
     global bus
     global loop
     global config
@@ -229,6 +234,7 @@ def main(ready_hook=on_ready, error_hook=on_error, watchdog=lambda: None):
     else:
         ready_hook()
         wait_for_exit_signal()
+        stopping_hook()
 
 
 if __name__ == "__main__":

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -171,18 +171,15 @@ def handle_open():
     EnclosureAPI(bus).reset()
 
 
-def main():
-    global bus
-    global loop
-    global config
-    reset_sigint_handler()
-    PIDLock("voice")
-    bus = MessageBusClient()  # Mycroft messagebus, see mycroft.messagebus
-    Configuration.set_config_update_handlers(bus)
-    config = Configuration.get()
+def on_ready():
+    LOG.info('Speech client is ready.')
 
-    # Register handlers on internal RecognizerLoop bus
-    loop = RecognizerLoop()
+
+def on_error(e='Unknown'):
+    LOG.error('Audio service failed to launch ({}).'.format(repr(e)))
+
+
+def connect_loop_events(loop):
     loop.on('recognizer_loop:utterance', handle_utterance)
     loop.on('recognizer_loop:speech.recognition.unknown', handle_unknown)
     loop.on('speak', handle_speak)
@@ -192,6 +189,8 @@ def main():
     loop.on('recognizer_loop:record_end', handle_record_end)
     loop.on('recognizer_loop:no_internet', handle_no_internet)
 
+
+def connect_bus_events(bus):
     # Register handlers for events on main Mycroft messagebus
     bus.on('open', handle_open)
     bus.on('complete_intent_failure', handle_complete_intent_failure)
@@ -207,10 +206,29 @@ def main():
     bus.on('mycroft.stop', handle_stop)
     bus.on('message', create_echo_function('VOICE'))
 
-    create_daemon(bus.run_forever)
-    create_daemon(loop.run)
 
-    wait_for_exit_signal()
+def main(ready_hook=on_ready, error_hook=on_error):
+    global bus
+    global loop
+    global config
+    try:
+        reset_sigint_handler()
+        PIDLock("voice")
+        bus = MessageBusClient()  # Mycroft messagebus, see mycroft.messagebus
+        Configuration.set_config_update_handlers(bus)
+        config = Configuration.get()
+
+        # Register handlers on internal RecognizerLoop bus
+        loop = RecognizerLoop()
+        connect_loop_events(loop)
+        connect_bus_events(bus)
+        create_daemon(bus.run_forever)
+        create_daemon(loop.run)
+    except Exception as e:
+        error_hook(e)
+    else:
+        ready_hook()
+        wait_for_exit_signal()
 
 
 if __name__ == "__main__":

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -275,10 +275,15 @@ class RecognizerLoop(BaseEventEmitter):
     """ EventEmitter loop running speech recognition.
 
     Local wake word recognizer and remote general speech recognition.
+
+    Arguments:
+        watchdog: (callable) function to call periodically indicating
+                  operational status.
     """
 
-    def __init__(self):
+    def __init__(self, watchdog=None):
         super(RecognizerLoop, self).__init__()
+        self._watchdog = watchdog
         self.mute_calls = 0
         self._load_config()
 
@@ -305,7 +310,7 @@ class RecognizerLoop(BaseEventEmitter):
         # TODO - localization
         self.wakeup_recognizer = self.create_wakeup_recognizer()
         self.responsive_recognizer = ResponsiveRecognizer(
-            self.wakeword_recognizer)
+            self.wakeword_recognizer, self._watchdog)
         self.state = RecognizerLoopState()
 
     def create_wake_word_recognizer(self):

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -336,7 +336,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
     # Time between pocketsphinx checks for the wake word
     SEC_BETWEEN_WW_CHECKS = 0.2
 
-    def __init__(self, wake_word_recognizer):
+    def __init__(self, wake_word_recognizer, watchdog=None):
+        self._watchdog = watchdog or (lambda: None)  # Default to dummy func
         self.config = Configuration.get()
         listener_config = self.config.get('listener')
         self.upload_url = listener_config['wake_word_upload']['url']
@@ -474,6 +475,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
             # Periodically write the energy level to the mic level file.
             if num_chunks % 10 == 0:
+                self._watchdog()
                 self.write_mic_level(energy, source)
 
         return byte_data
@@ -654,6 +656,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             # Periodically output energy level stats. This can be used to
             # visualize the microphone input, e.g. a needle on a meter.
             if mic_write_counter % 3:
+                self._watchdog()
                 self.write_mic_level(energy, source)
             mic_write_counter += 1
 

--- a/mycroft/messagebus/service/__main__.py
+++ b/mycroft/messagebus/service/__main__.py
@@ -41,7 +41,11 @@ def on_error(e='Unknown'):
     LOG.info('Message bus failed to start ({})'.format(repr(e)))
 
 
-def main(ready_hook=on_ready, error_hook=on_error):
+def on_stopping():
+    LOG.info('Message bus is shutting down...')
+
+
+def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
     import tornado.options
     LOG.info('Starting message bus service...')
     reset_sigint_handler()
@@ -61,6 +65,7 @@ def main(ready_hook=on_ready, error_hook=on_error):
     create_daemon(ioloop.IOLoop.instance().start)
     ready_hook()
     wait_for_exit_signal()
+    stopping_hook()
 
 
 if __name__ == "__main__":

--- a/mycroft/messagebus/service/__main__.py
+++ b/mycroft/messagebus/service/__main__.py
@@ -33,7 +33,15 @@ from mycroft.util import (
 from mycroft.util.log import LOG
 
 
-def main():
+def on_ready():
+    LOG.info('Message bus service started!')
+
+
+def on_error(e='Unknown'):
+    LOG.info('Message bus failed to start ({})'.format(repr(e)))
+
+
+def main(ready_hook=on_ready, error_hook=on_error):
     import tornado.options
     LOG.info('Starting message bus service...')
     reset_sigint_handler()
@@ -51,7 +59,7 @@ def main():
     application = web.Application(routes, debug=True)
     application.listen(config.port, config.host)
     create_daemon(ioloop.IOLoop.instance().start)
-    LOG.info('Message bus service started!')
+    ready_hook()
     wait_for_exit_signal()
 
 

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -181,7 +181,12 @@ def on_error(e='Unknown'):
     LOG.info('Skill service failed to launch ({})'.format(repr(e)))
 
 
-def main(ready_hook=on_ready, error_hook=on_error, watchdog=None):
+def on_stopping():
+    LOG.info('Skill service is shutting down...')
+
+
+def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
+         watchdog=None):
     reset_sigint_handler()
     # Create PID file, prevent multiple instances of this service
     mycroft.lock.Lock('skills')
@@ -207,6 +212,7 @@ def main(ready_hook=on_ready, error_hook=on_error, watchdog=None):
         time.sleep(0.1)
     ready_hook()  # Report ready status
     wait_for_exit_signal()
+    stopping_hook()  # Report shutdown started
     shutdown(skill_manager, event_scheduler)
 
 

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -173,7 +173,15 @@ class DevicePrimer(object):
             wait_while_speaking()
 
 
-def main():
+def on_ready():
+    LOG.info('Skill service is ready.')
+
+
+def on_error(e='Unknown'):
+    LOG.info('Skill service failed to launch ({})'.format(repr(e)))
+
+
+def main(ready_hook=on_ready, error_hook=on_error):
     reset_sigint_handler()
     # Create PID file, prevent multiple instances of this service
     mycroft.lock.Lock('skills')
@@ -195,7 +203,9 @@ def main():
     device_primer = DevicePrimer(bus, config)
     device_primer.prepare_device()
     skill_manager.start()
-
+    while not skill_manager.is_alive():
+        time.sleep(0.1)
+    ready_hook()  # Report ready status
     wait_for_exit_signal()
     shutdown(skill_manager, event_scheduler)
 

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -110,14 +110,17 @@ def _shutdown_skill(instance):
 class SkillManager(Thread):
     _msm = None
 
-    def __init__(self, bus):
+    def __init__(self, bus, watchdog=None):
         """Constructor
 
         Arguments:
             bus (event emitter): Mycroft messagebus connection
+            watchdog (callable): optional watchdog function
         """
         super(SkillManager, self).__init__()
         self.bus = bus
+        # Set watchdog to argument or function returning None
+        self._watchdog = watchdog or (lambda: None)
         self._stop_event = Event()
         self._connected_event = Event()
         self.config = Configuration.get()
@@ -243,6 +246,7 @@ class SkillManager(Thread):
                     self.skill_updater.post_manifest()
                     self.upload_queue.send()
 
+                self._watchdog()
                 sleep(2)  # Pause briefly before beginning next scan
             except Exception:
                 LOG.exception('Something really unexpected has occured '


### PR DESCRIPTION
## Description
This adds a simple system of callback hooks to run mycroft as a service or through a single executable. It allows the definition of a wrapper script with handlers for ready states, error states and a watchdog to ensure the system is still running.

Example wrapper script for use with systemd:

```python
import sdnotify

from mycroft.skills.__main__ import main


n = sdnotify.SystemdNotifier()

def on_ready():
    n.notify("READY=1")

def on_stopped():
    n.notify("READY=0")

main(ready_hook=on_ready, stop_hook=on_stopped)
```

The current watchdog implementations are currently only for the speech client (voice data is received from the mic) and the skills process (skills are updated) due to their natural cyclic structure.
 
The reason for doing this is to be able to keep startup system requirements outside of core and allowing flexibility. For example these startup hooks can be done for a desktop launcher just as well as for a system service like systemd or finit.

## How to test
Create a similar wrapper but instead of sdnotify a simple custom print statement is used in the hooks.

## Contributor license agreement signed?
CLA [ Yes ]
