### PR TITLE
Add VK test - specific skill should not reply

### DIFF
--- a/test/integrationtests/voight_kampff/__init__.py
+++ b/test/integrationtests/voight_kampff/__init__.py
@@ -14,4 +14,5 @@
 #
 
 from .tools import (emit_utterance, wait_for_dialog, then_wait,
-                    mycroft_responses, print_mycroft_responses)
+                    then_wait_fail, mycroft_responses,
+                    print_mycroft_responses)

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -26,7 +26,8 @@ from behave import given, when, then
 from mycroft.messagebus import Message
 from mycroft.audio import wait_while_speaking
 
-from test.integrationtests.voight_kampff import mycroft_responses, then_wait
+from test.integrationtests.voight_kampff import (mycroft_responses, then_wait,
+                                                 then_wait_fail)
 
 
 TIMEOUT = 10
@@ -144,6 +145,24 @@ def then_dialog(context, skill, dialog):
         assert_msg += mycroft_responses(context)
 
     assert passed, assert_msg or 'Mycroft didn\'t respond'
+
+
+@then('"{skill}" should not reply')
+def then_do_not_reply(context, skill):
+
+    def check_all_dialog(message):
+        msg_skill = message.data.get('meta').get('skill')
+        utt = message.data['utterance'].lower()
+        skill_responded = skill == msg_skill
+        debug_msg = ("{} responded with '{}'. \n".format(skill, utt)
+                     if skill_responded else '')
+        return (skill_responded, debug_msg)
+
+    passed, debug = then_wait_fail('speak', check_all_dialog, context)
+    if not passed:
+        assert_msg = debug
+        assert_msg += mycroft_responses(context)
+    assert passed, assert_msg or '{} responded'.format(skill)
 
 
 @then('"{skill}" should reply with "{example}"')

--- a/test/integrationtests/voight_kampff/tools.py
+++ b/test/integrationtests/voight_kampff/tools.py
@@ -51,6 +51,23 @@ def then_wait(msg_type, criteria_func, context, timeout=TIMEOUT):
     return False, debug
 
 
+def then_wait_fail(msg_type, criteria_func, context, timeout=TIMEOUT):
+    """Wait for a specified time, failing if criteria is fulfilled.
+
+    Arguments:
+        msg_type: message type to watch
+        criteria_func: Function to determine if a message fulfilling the
+                       test case has been found.
+        context: behave context
+        timeout: Time allowance for a message fulfilling the criteria
+
+    Returns:
+        tuple (bool, str) test status and debug output
+    """
+    status, debug = then_wait(msg_type, criteria_func, context, timeout)
+    return (not status, debug)
+
+
 def mycroft_responses(context):
     """Collect and format mycroft responses from context.
 


### PR DESCRIPTION
## Description
Adds a test tool opposite to then_wait. Instead of the test succeeding when the criteria is met, the test fails if the given criteria is detected.

This is then used to test if a specific Skill responds to an utterance.

## Improvements needed
It feels like there is a better way to do this, but it's working for me right now, so thought I'd put it out in the world for critique. Suggestions welcome. 

Would also prefer to utilize MSM to search for the name of the skill in the test which would add more flexibility to what test authors enter. Currently it requires that you enter the class name of the Skill.

## How to test
With the following feature file for the News Skill:
```
Feature: mycroft-news

  Scenario Outline: play music with names similar to news channels
    Given an english speaking user
     When the user says "<play some music>"
     Then "NewsSkill" should not reply

    Examples:
      | play some music |
      | what time is it |
      | what's the weather |
      | play the bbc news |
      | what's news |
```

First two should pass, last two should fail.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
