### PR TITLE
prevent audio playing between mic record and utt handling

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -304,36 +304,37 @@ class AudioService:
             Args:
                 message: message bus message, not used but required
         """
-        def __restore_volume():
+        def restore_volume():
             LOG.debug('restoring volume')
             self.current.restore_volume()
 
-        def wait_for_speak(bus, timeout=8):
+        def wait_for_speak(timeout=8):
             """Wait for a speak Message on the bus.
 
             Arguments:
                 bus (Mycroft MessageBus): Bus instance to listen on
                 timeout (int): how long to wait, defaults to 8 sec
             """
-            self.speak_msg_detected = False
+            speak_msg_detected = False
 
             def detected_speak(message=None):
-                self.speak_msg_detected = True
+                nonlocal speak_msg_detected
+                speak_msg_detected = True
             self.bus.on('speak', detected_speak)
             time.sleep(timeout)
             self.bus.remove('speak', detected_speak)
-            return self.speak_msg_detected
+            return speak_msg_detected
 
-        if self.current is None:
+        if self.current:
+            self.bus.on('recognizer_loop:speech.recognition.unknown',
+                        restore_volume)
+            speak_msg_detected = wait_for_speak(self.bus)
+            if not speak_msg_detected:
+                restore_volume()
+            self.bus.remove('recognizer_loop:speech.recognition.unknown',
+                            restore_volume)
+        else:
             LOG.debug("No audio service to restore volume of")
-            return None
-        self.bus.on('recognizer_loop:speech.recognition.unknown',
-                    __restore_volume)
-        speak_msg_detected = wait_for_speak(self.bus)
-        if not speak_msg_detected:
-            __restore_volume()
-        self.bus.remove('recognizer_loop:speech.recognition.unknown',
-                        __restore_volume)
 
     def play(self, tracks, prefered_service, repeat=False):
         """


### PR DESCRIPTION
## Description
This creates a separate `restore_volume` handler for the end of mic recording. Previously the same handler was used for speech and recording.

When the recording finishes, there should either be an utterance to be handled, or a `speech.recognition.unknown` message meaning the transcription failed because the user didn't say anything (or it was a false activation).

If the latter and no utterance was detected, then we immediately restore the volume. Otherwise we do not restore the volume, and the utterance is passed onto the intent handlers. Once Mycroft responds to that utterance, the `_restore_volume` handler attached to the `audio_output_end` message is triggered.

This means that if audio is playing and:
- a user says "Hey Mycroft, stop" 
  - then no more audio plays
- a user asks a question such as "Hey Mycroft, what's 7 times 3" 
  - then audio is paused until the response is complete. 
    Once the response has finished, audio resumes.

## Need to confirm
Are there other paths that I'm not considering?
Is there a chance that neither a failed transcription, nor Mycroft replying would occur and therefore leave the audio in an undesired state?

## How to test
> Hey Mycroft, what's the news
> Hey Mycroft, what time is it
> Hey Mycroft, stop

Ensure that no snippets of news audio are played during interactions. Should still play between questions.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
