### PR TITLE
sleep after skills loaded for any final setup

### DIFF
--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -90,6 +90,12 @@ def before_all(context):
         else:
             sleep(1)
 
+    # Temporary bugfix - First test to run sometimes fails
+    # Sleeping to see if something isn't finished setting up when tests start
+    # More info in Jira Ticket MYC-370
+    # TODO - remove and fix properly dependant on if failures continue
+    sleep(10)
+
     context.bus = bus
     context.matched_message = None
     context.log = log


### PR DESCRIPTION
This is a test to see if sleeping after a Skills report being loaded improves the stability of the first Voight Kampff tests in a Jenkins environment.

**DO NOT MERGE**