### PR TITLE
Add wait_for_message method

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -308,26 +308,11 @@ class AudioService:
             LOG.debug('restoring volume')
             self.current.restore_volume()
 
-        def wait_for_speak(timeout=8):
-            """Wait for a speak Message on the bus.
-
-            Arguments:
-                timeout (int): how long to wait, defaults to 8 sec
-            """
-            speak_msg_detected = False
-
-            def detected_speak(message=None):
-                nonlocal speak_msg_detected
-                speak_msg_detected = True
-            self.bus.on('speak', detected_speak)
-            time.sleep(timeout)
-            self.bus.remove('speak', detected_speak)
-            return speak_msg_detected
-
         if self.current:
             self.bus.on('recognizer_loop:speech.recognition.unknown',
                         restore_volume)
-            speak_msg_detected = wait_for_speak()
+            speak_msg_detected = self.bus.wait_for_message('speak',
+                                                           timeout=8.0)
             if not speak_msg_detected:
                 restore_volume()
             self.bus.remove('recognizer_loop:speech.recognition.unknown',

--- a/mycroft/messagebus/client/__init__.py
+++ b/mycroft/messagebus/client/__init__.py
@@ -11,4 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .client import MessageBusClient
+from .client import MessageBusClient, MessageWaiter

--- a/mycroft/messagebus/client/client.py
+++ b/mycroft/messagebus/client/client.py
@@ -30,6 +30,53 @@ from mycroft.util.log import LOG
 from .threaded_event_emitter import ThreadedEventEmitter
 
 
+class MessageWaiter:
+    """Wait for a single message.
+
+    Encapsulate the wait for a message logic separating the setup from
+    the actual waiting act so the waiting can be setuo, actions can be
+    performed and _then_ the message can be waited for.
+
+    Argunments:
+        bus: Bus to check for messages on
+        message_type: message type to wait for
+    """
+    def __init__(self, bus, message_type):
+        self.bus = bus
+        self.msg_type = message_type
+        self.received_msg = None
+        # Setup response handler
+        self.bus.once(message_type, self._handler)
+
+    def _handler(self, message):
+        """Receive response data."""
+        self.received_msg = message
+
+    def wait(self, timeout=3.0):
+        """Wait for message.
+
+        Arguments:
+            timeout (int or float): seconds to wait for message
+
+        Returns:
+            Message or None
+        """
+        start_time = time.monotonic()
+        while self.received_msg is None:
+            time.sleep(0.2)
+            if time.monotonic() - start_time > timeout:
+                try:
+                    self.bus.remove(self.msg_type, self._handler)
+                except (ValueError, KeyError):
+                    # ValueError occurs on pyee 5.0.1 removing handlers
+                    # registered with once.
+                    # KeyError may theoretically occur if the event occurs as
+                    # the handler is removed
+                    pass
+                break
+        return self.received_msg
+
+
 class MessageBusClient:
     def __init__(self, host=None, port=None, route=None, ssl=None):
         config_overrides = dict(host=host, port=port, route=route, ssl=ssl)
@@ -120,6 +167,19 @@ class MessageBusClient:
             LOG.warning('Could not send {} message because connection '
                         'has been closed'.format(message.msg_type))
 
+    def wait_for_message(self, message_type, timeout=3.0):
+        """Wait for a message of a specific type.
+
+        Arguments:
+            message_type (str): the message type of the expected message
+            timeout: seconds to wait before timeout, defaults to 3
+
+        Returns:
+            The received message or None if the response timed out
+        """
+
+        return MessageWaiter(self, message_type).wait(timeout)
+
     def wait_for_response(self, message, reply_type=None, timeout=3.0):
         """Send a message and wait for a response.
 
@@ -132,32 +192,11 @@ class MessageBusClient:
         Returns:
             The received message or None if the response timed out
         """
-        response = None
-
-        def handler(message):
-            """Receive response data."""
-            nonlocal response
-            response = message
-
-        # Setup response handler
-        self.once(reply_type or message.msg_type + '.response', handler)
-        # Send request
+        message_type = reply_type or message.msg_type + '.response'
+        waiter = MessageWaiter(self, message_type)  # Setup response handler
+        # Send message and wait for it's response
         self.emit(message)
-        # Wait for response
-        start_time = time.monotonic()
-        while response is None:
-            time.sleep(0.2)
-            if time.monotonic() - start_time > timeout:
-                try:
-                    self.remove(reply_type, handler)
-                except (ValueError, KeyError):
-                    # ValueError occurs on pyee 1.0.1 removing handlers
-                    # registered with once.
-                    # KeyError may theoretically occur if the event occurs as
-                    # the handler is removed
-                    pass
-                return None
-        return response
+        return waiter.wait()
 
     def on(self, event_name, func):
         self.emitter.on(event_name, func)


### PR DESCRIPTION
## Description
Adds `wait_for_message()` method and refactors the common code shared with `wait_for_response()` into a separate class.

## How to test
Make sure integration tests pass and that for example `get_response()` in skills work. and the :skills cli command

## Contributor license agreement signed?
CLA [ Yes ]