### PR TITLE
Fix custom timeout for wait_for_response()

### DIFF
--- a/mycroft/messagebus/client/client.py
+++ b/mycroft/messagebus/client/client.py
@@ -196,7 +196,7 @@ class MessageBusClient:
         waiter = MessageWaiter(self, message_type)  # Setup response handler
         # Send message and wait for it's response
         self.emit(message)
-        return waiter.wait()
+        return waiter.wait(timeout)
 
     def on(self, event_name, func):
         self.emitter.on(event_name, func)


### PR DESCRIPTION
## Description
When rebasing #2599, an extra "I didn't catch that occurred after QA answers. Turned out the wait_for_response() method didn't forward the timeout causing the 3.0 second default to always be used. This fixes that issue.

## Contributor license agreement signed?
CLA [ Yes ]