### PR TITLE
revert iot dig_for_message

### DIFF
--- a/mycroft/skills/common_iot_skill.py
+++ b/mycroft/skills/common_iot_skill.py
@@ -456,11 +456,10 @@ class CommonIoTSkill(MycroftSkill, ABC):
             word_type:
         """
         if words:
-            message = dig_for_message()
-            self.bus.emit(message.forward(_BusKeys.REGISTER,
-                                          data={"skill_id": self.skill_id,
-                                                "type": word_type,
-                                                "words": list(words)}))
+            self.bus.emit(Message(_BusKeys.REGISTER,
+                                  data={"skill_id": self.skill_id,
+                                        "type": word_type,
+                                        "words": list(words)}))
 
     def register_entities_and_scenes(self):
         """


### PR DESCRIPTION
## Description
fixes #2635 
https://github.com/MycroftAI/mycroft-core/issues/2635

Reverts the code that assumes that the `CommonIoTSkill` asks for other skills to `register` instead of individual skills calling `register_words` of their own accord.

Discussion with author of the change being reverted ( @JarbasAI ) here:
https://chat.mycroft.ai/community/pl/w66y18fgj7ygt8u3j6pdsxsofc

## How to test
Try to install a skill that extends CommonIotSkill like the HomeAssistant branch

## Contributor license agreement signed?
CLA [X ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
