### PR TITLE
Add Festival TTS engine

### DIFF
--- a/mycroft/tts/festival_tts.py
+++ b/mycroft/tts/festival_tts.py
@@ -23,7 +23,7 @@ class Festival(TTS):
 
     def execute(self, sentence, ident=None, listen=False):
         self.begin_audio()
-        subprocess.call("echo " + sentence + "| iconv -f utf8 -t latin1 | festival --tts --language catalan", shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        subprocess.call("echo \"" + sentence + "\" | iconv -f utf8 -t ISO-8859-15//TRANSLIT | festival --tts --language " + self.lang, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
         self.end_audio(listen)
 
 

--- a/mycroft/tts/festival_tts.py
+++ b/mycroft/tts/festival_tts.py
@@ -1,0 +1,59 @@
+# Copyright 2017 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import subprocess
+
+from mycroft.util.log import LOG
+
+from .tts import TTS, TTSValidator
+
+
+class Festival(TTS):
+    """TTS module for generating speech using Festival."""
+    def __init__(self, lang):
+        super(Festival, self).__init__(lang, FestivalValidator(self))
+
+    def get_tts(self, sentence, wav_file):
+        """Generate WAV from sentence, phonemes aren't supported.
+
+        Arguments:
+            sentence (str): sentence to generate audio for
+            wav_file (str): output file
+
+        Returns:
+            tuple ((str) file location, None)
+        """
+        subprocess.call(
+            ['echo', sentence, '|', 'text2wave', '-o', wav_file], shell=True)
+        LOG.info('Mycroft Festival: {}'.format(sentence))
+        return wav_file, None
+
+
+class FestivalValidator(TTSValidator):
+    def __init__(self, tts):
+        super(FestivalValidator, self).__init__(tts)
+
+    def validate_lang(self):
+        # TODO
+        pass
+
+    def validate_connection(self):
+        try:
+            subprocess.call(['festival', '--version'])
+        except Exception:
+            raise Exception(
+                'Festival is not installed. Run: sudo apt-get install festival')
+
+    def get_tts_class(self):
+        return Festival

--- a/mycroft/tts/festival_tts.py
+++ b/mycroft/tts/festival_tts.py
@@ -22,8 +22,16 @@ class Festival(TTS):
         super(Festival, self).__init__(lang, config, FestivalValidator(self))
 
     def execute(self, sentence, ident=None, listen=False):
+
+        toencoding = self.config.get('toencoding')
+
+        if toencoding != 'utf8':
+            cmd = "echo \"" + sentence + "\" | iconv -f utf8 -t " + toencoding + " | festival --tts --language " + self.lang
+        else:
+            cmd = "echo \"" + sentence + "\" | festival --tts --language " + self.lang
+
         self.begin_audio()
-        subprocess.call("echo \"" + sentence + "\" | iconv -f utf8 -t ISO-8859-15//TRANSLIT | festival --tts --language " + self.lang, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        subprocess.call(cmd, shell=True)
         self.end_audio(listen)
 
 

--- a/mycroft/tts/festival_tts.py
+++ b/mycroft/tts/festival_tts.py
@@ -14,30 +14,17 @@
 #
 import subprocess
 
-from mycroft.util.log import LOG
-
 from .tts import TTS, TTSValidator
 
 
 class Festival(TTS):
-    """TTS module for generating speech using Festival."""
-    def __init__(self, lang):
-        super(Festival, self).__init__(lang, FestivalValidator(self))
+    def __init__(self, lang, config):
+        super(Festival, self).__init__(lang, config, FestivalValidator(self))
 
-    def get_tts(self, sentence, wav_file):
-        """Generate WAV from sentence, phonemes aren't supported.
-
-        Arguments:
-            sentence (str): sentence to generate audio for
-            wav_file (str): output file
-
-        Returns:
-            tuple ((str) file location, None)
-        """
-        subprocess.call(
-            ['echo', sentence, '|', 'text2wave', '-o', wav_file], shell=True)
-        LOG.info('Mycroft Festival: {}'.format(sentence))
-        return wav_file, None
+    def execute(self, sentence, ident=None, listen=False):
+        self.begin_audio()
+        subprocess.call("echo " + sentence + "| iconv -f utf8 -t latin1 | festival --tts --language catalan", shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        self.end_audio(listen)
 
 
 class FestivalValidator(TTSValidator):

--- a/mycroft/tts/festival_tts.py
+++ b/mycroft/tts/festival_tts.py
@@ -23,12 +23,13 @@ class Festival(TTS):
 
     def execute(self, sentence, ident=None, listen=False):
 
-        toencoding = self.config.get('toencoding')
+        encoding = self.config.get('encoding')
+        cmd = "echo \"" + sentence + "\""
 
-        if toencoding != 'utf8':
-            cmd = "echo \"" + sentence + "\" | iconv -f utf8 -t " + toencoding + " | festival --tts --language " + self.lang
-        else:
-            cmd = "echo \"" + sentence + "\" | festival --tts --language " + self.lang
+        if encoding != 'utf8':
+            cmd += " | iconv -f utf8 -t " + encoding
+
+        cmd += " | festival --tts --language " + self.lang
 
         self.begin_audio()
         subprocess.call(cmd, shell=True)

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -465,6 +465,7 @@ class TTSValidator(metaclass=ABCMeta):
 
 
 class TTSFactory:
+    from mycroft.tts.festival_tts import Festival
     from mycroft.tts.espeak_tts import ESpeak
     from mycroft.tts.fa_tts import FATTS
     from mycroft.tts.google_tts import GoogleTTS
@@ -485,6 +486,7 @@ class TTSFactory:
         "google": GoogleTTS,
         "marytts": MaryTTS,
         "fatts": FATTS,
+        "festival": Festival,
         "espeak": ESpeak,
         "spdsay": SpdSay,
         "watson": WatsonTTS,


### PR DESCRIPTION
## Description
This PR adds Festival TTS engine suport #2640

## How to test
Just install festival tts engine and voices (Catalan is a good example). And set mycroft settings:
```
{
    "module": "festival",
    "festival": {
      "lang": "catalan",
      "toencoding": "ISO-8859-15//TRANSLIT"
    }
}

```
## Contributor license agreement signed?
I've request to sign it.