### PR TITLE
Feature - check if services ready on boot

### DIFF
--- a/mycroft/audio/__main__.py
+++ b/mycroft/audio/__main__.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-"""
-    Mycroft audio service.
+"""Mycroft audio service.
 
     This handles playback of audio and speech
 """
@@ -27,23 +26,48 @@ import mycroft.audio.speech as speech
 from .audioservice import AudioService
 
 
-def main():
+def on_ready():
+    LOG.info('Audio service is ready.')
+
+
+def on_error(e='Unknown'):
+    LOG.error('Audio service failed to launch ({}).'.format(repr(e)))
+
+
+def on_stopping():
+    LOG.info('Audio service is shutting down...')
+
+
+def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
     """ Main function. Run when file is invoked. """
-    reset_sigint_handler()
-    check_for_signal("isSpeaking")
-    bus = MessageBusClient()  # Connect to the Mycroft Messagebus
-    Configuration.set_config_update_handlers(bus)
-    speech.init(bus)
+    try:
+        reset_sigint_handler()
+        check_for_signal("isSpeaking")
+        bus = MessageBusClient()  # Connect to the Mycroft Messagebus
+        Configuration.set_config_update_handlers(bus)
+        speech.init(bus)
 
-    LOG.info("Starting Audio Services")
-    bus.on('message', create_echo_function('AUDIO', ['mycroft.audio.service']))
-    audio = AudioService(bus)  # Connect audio service instance to message bus
-    create_daemon(bus.run_forever)
+        LOG.info("Starting Audio Services")
+        bus.on('message', create_echo_function('AUDIO',
+                                               ['mycroft.audio.service']))
 
-    wait_for_exit_signal()
+        # Connect audio service instance to message bus
+        audio = AudioService(bus)
+    except Exception as e:
+        error_hook(e)
+    else:
+        create_daemon(bus.run_forever)
+        if audio.wait_for_load() and len(audio.service) > 0:
+            # If at least one service exists, report ready
+            ready_hook()
+            wait_for_exit_signal()
+            stopping_hook()
+        else:
+            error_hook('No audio services loaded')
 
-    speech.shutdown()
-    audio.shutdown()
+        speech.shutdown()
+        audio.shutdown()
 
 
-main()
+if __name__ == '__main__':
+    main()

--- a/mycroft/client/enclosure/__main__.py
+++ b/mycroft/client/enclosure/__main__.py
@@ -23,6 +23,18 @@ from mycroft.util import (create_daemon, wait_for_exit_signal,
                           reset_sigint_handler)
 
 
+def on_ready():
+    LOG.info("Enclosure started!")
+
+
+def on_stopping():
+    LOG.info('Enclosure is shutting down...')
+
+
+def on_error(e='Unknown'):
+    LOG.error('Enclosure failed to start. ({})'.format(repr(e)))
+
+
 def create_enclosure(platform):
     """Create an enclosure based on the provided platform string.
 
@@ -51,7 +63,8 @@ def create_enclosure(platform):
     return enclosure
 
 
-def main():
+def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
+    # Read the system configuration
     """Launch one of the available enclosure implementations.
 
     This depends on the configured platform and can currently either be
@@ -68,7 +81,9 @@ def main():
             LOG.debug("Enclosure started!")
             reset_sigint_handler()
             create_daemon(enclosure.run)
+            ready_hook()
             wait_for_exit_signal()
+            stopping_hook()
         except Exception as e:
             print(e)
     else:

--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -275,10 +275,15 @@ class RecognizerLoop(BaseEventEmitter):
     """ EventEmitter loop running speech recognition.
 
     Local wake word recognizer and remote general speech recognition.
+
+    Arguments:
+        watchdog: (callable) function to call periodically indicating
+                  operational status.
     """
 
-    def __init__(self):
+    def __init__(self, watchdog=None):
         super(RecognizerLoop, self).__init__()
+        self._watchdog = watchdog
         self.mute_calls = 0
         self._load_config()
 
@@ -305,7 +310,7 @@ class RecognizerLoop(BaseEventEmitter):
         # TODO - localization
         self.wakeup_recognizer = self.create_wakeup_recognizer()
         self.responsive_recognizer = ResponsiveRecognizer(
-            self.wakeword_recognizer)
+            self.wakeword_recognizer, self._watchdog)
         self.state = RecognizerLoopState()
 
     def create_wake_word_recognizer(self):

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -336,7 +336,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
     # Time between pocketsphinx checks for the wake word
     SEC_BETWEEN_WW_CHECKS = 0.2
 
-    def __init__(self, wake_word_recognizer):
+    def __init__(self, wake_word_recognizer, watchdog=None):
+        self._watchdog = watchdog or (lambda: None)  # Default to dummy func
         self.config = Configuration.get()
         listener_config = self.config.get('listener')
         self.upload_url = listener_config['wake_word_upload']['url']
@@ -474,6 +475,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
             # Periodically write the energy level to the mic level file.
             if num_chunks % 10 == 0:
+                self._watchdog()
                 self.write_mic_level(energy, source)
 
         return byte_data
@@ -654,6 +656,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             # Periodically output energy level stats. This can be used to
             # visualize the microphone input, e.g. a needle on a meter.
             if mic_write_counter % 3:
+                self._watchdog()
                 self.write_mic_level(energy, source)
             mic_write_counter += 1
 

--- a/mycroft/messagebus/service/__main__.py
+++ b/mycroft/messagebus/service/__main__.py
@@ -33,7 +33,19 @@ from mycroft.util import (
 from mycroft.util.log import LOG
 
 
-def main():
+def on_ready():
+    LOG.info('Message bus service started!')
+
+
+def on_error(e='Unknown'):
+    LOG.info('Message bus failed to start ({})'.format(repr(e)))
+
+
+def on_stopping():
+    LOG.info('Message bus is shutting down...')
+
+
+def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
     import tornado.options
     LOG.info('Starting message bus service...')
     reset_sigint_handler()
@@ -51,8 +63,9 @@ def main():
     application = web.Application(routes, debug=True)
     application.listen(config.port, config.host)
     create_daemon(ioloop.IOLoop.instance().start)
-    LOG.info('Message bus service started!')
+    ready_hook()
     wait_for_exit_signal()
+    stopping_hook()
 
 
 if __name__ == "__main__":

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -103,8 +103,7 @@ class PadatiousService(FallbackSkill):
 
         self.finished_training_event.set()
         if not self.finished_initial_train:
-            LOG.info("Mycroft is all loaded and ready to roll!")
-            self.bus.emit(Message('mycroft.ready'))
+            self.bus.emit(Message('mycroft.skills.trained'))
             self.finished_initial_train = True
 
     def wait_and_train(self):

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -110,14 +110,17 @@ def _shutdown_skill(instance):
 class SkillManager(Thread):
     _msm = None
 
-    def __init__(self, bus):
+    def __init__(self, bus, watchdog=None):
         """Constructor
 
         Arguments:
             bus (event emitter): Mycroft messagebus connection
+            watchdog (callable): optional watchdog function
         """
         super(SkillManager, self).__init__()
         self.bus = bus
+        # Set watchdog to argument or function returning None
+        self._watchdog = watchdog or (lambda: None)
         self._stop_event = Event()
         self._connected_event = Event()
         self.config = Configuration.get()
@@ -243,6 +246,7 @@ class SkillManager(Thread):
                     self.skill_updater.post_manifest()
                     self.upload_queue.send()
 
+                self._watchdog()
                 sleep(2)  # Pause briefly before beginning next scan
             except Exception:
                 LOG.exception('Something really unexpected has occured '


### PR DESCRIPTION
**DO NOT MERGE**

## Description
Some example code following on from issue #2639 

This shifts the `mycroft.ready` message from the Padatious Service to the Enclosure.

It sends a request to each service over the message bus to respond if it's alive. As such it assumes that both the bus and the enclosure services are alive as they're required for successfully transmission of the messages.

In it's current state it will always timeout as there's no handler added to the Skills service. I'm sure there's also a better way to handle checking the speech service, and general refactoring is needed.

## How to test
Boot Mycroft - should startup, train all intents, then check each service for 2 mins and timeout.

Remove skills service from list to check and it should emit `mycroft.ready` as normal.

## Questions
* Is this a useful approach? 
* Does it matter that it relies on the enclosure running?
* Presuming we have watchdogs running on each service, what do we do if the boot completely times out? Restart the device?
