### PR TITLE
Add Festival TTS support

### DIFF
--- a/mycroft/tts/festival_tts.py
+++ b/mycroft/tts/festival_tts.py
@@ -1,0 +1,62 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import subprocess
+
+from .tts import TTS, TTSValidator
+
+
+class Festival(TTS):
+    def __init__(self, lang, config):
+        super(Festival, self).__init__(lang, config, FestivalValidator(self))
+
+    def execute(self, sentence, ident=None, listen=False):
+
+        encoding = self.config.get('encoding', 'utf8')
+        lang = self.config.get('lang', self.lang)
+
+        text = subprocess.Popen(('echo', sentence), stdout=subprocess.PIPE)
+
+        if encoding != 'utf8':
+            convert_cmd = ('iconv', '-f', 'utf8', '-t', encoding)
+            converted_text = subprocess.Popen(convert_cmd,
+                                              stdin=text.stdout,
+                                              stdout=subprocess.PIPE)
+            text.wait()
+            text = converted_text
+
+        tts_cmd = ('festival', '--tts', '--language', lang)
+
+        self.begin_audio()
+        subprocess.call(tts_cmd, stdin=text.stdout)
+        self.end_audio(listen)
+
+
+class FestivalValidator(TTSValidator):
+    def __init__(self, tts):
+        super(FestivalValidator, self).__init__(tts)
+
+    def validate_lang(self):
+        # TODO
+        pass
+
+    def validate_connection(self):
+        try:
+            subprocess.call(['festival', '--version'])
+        except Exception:
+            raise Exception(
+                'Festival is missing. Run: sudo apt-get install festival')
+
+    def get_tts_class(self):
+        return Festival

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -465,6 +465,7 @@ class TTSValidator(metaclass=ABCMeta):
 
 
 class TTSFactory:
+    from mycroft.tts.festival_tts import Festival
     from mycroft.tts.espeak_tts import ESpeak
     from mycroft.tts.fa_tts import FATTS
     from mycroft.tts.google_tts import GoogleTTS
@@ -485,6 +486,7 @@ class TTSFactory:
         "google": GoogleTTS,
         "marytts": MaryTTS,
         "fatts": FATTS,
+        "festival": Festival,
         "espeak": ESpeak,
         "spdsay": SpdSay,
         "watson": WatsonTTS,


### PR DESCRIPTION
## Description
This PR adds Festival TTS engine suport #2640

## How to test
Just install festival tts engine and voices (Catalan is a good example). And set mycroft settings:
```
{
    "module": "festival",
    "festival": {
      "lang": "catalan",
      "encoding": "ISO-8859-15//TRANSLIT"
    }
}

```
## Contributor license agreement signed?
Yes, I do.