### PR TITLE
Always install default skills before initial load

### DIFF
--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -226,6 +226,10 @@ class SkillManager(Thread):
         """Load skills and update periodically from disk and internet."""
         self._remove_git_locks()
         self._connected_event.wait()
+        if not self.skill_updater.defaults_installed():
+            LOG.info('Not all default skills are installed, '
+                     'performing skill update...')
+            self.skill_updater.update_skills()
         self._load_on_startup()
 
         # Sync backend and skills.

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -219,6 +219,15 @@ class SkillUpdater:
                 raise
         self.installed_skills.add(skill.name)
 
+    def defaults_installed(self):
+        """Check if all default skills are installed.
+
+        Returns:
+            True if all default skills are installed, else False.
+        """
+        defaults = self.msm.list_all_defaults()[self.msm.platform]
+        return all([skill.is_local for skill in defaults])
+
     def _get_device_skill_state(self, skill_name):
         """Get skill data structure from name."""
         device_skill_state = {}

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -31,6 +31,11 @@ ONE_HOUR = 3600
 FIVE_MINUTES = 300  # number of seconds in a minute
 
 
+def skill_is_blacklisted(skill):
+    blacklist = Configuration.get()['skills']['blacklisted_skills']
+    return os.path.basename(skill.path) in blacklist or skill.name in blacklist
+
+
 class SkillUpdater:
     """Class facilitating skill update / install actions.
 
@@ -225,7 +230,10 @@ class SkillUpdater:
         Returns:
             True if all default skills are installed, else False.
         """
-        defaults = self.msm.list_all_defaults()[self.msm.platform]
+        defaults = []
+        for skill in self.msm.default_skills.values():
+            if not skill_is_blacklisted(skill):
+                defaults.append(skill)
         return all([skill.is_local for skill in defaults])
 
     def _get_device_skill_state(self, skill_name):


### PR DESCRIPTION
## Description
Following the discussion in #2639, this adds a check for the default skills before considered being initialized, if a default skill is missing the a skill update will occur before the mycroft.skills.initialized message is sent to trigger Padatious training. The check seem to be quite fast due to msm caching and will not cause the skills startup time to be delayed unless a skill is really missing.

This checks if all default skills are installed before continuing with
initial load.

For devices with no skills installed on first start this should ensure
that skills are installed before sending the mycroft.skills.initialized
to start precise training and generating the mycroft.ready message

## How to test
Remove a default skill and check that the skill is installed during startup.

## Contributor license agreement signed?
CLA [ Yes ]