### PR TITLE
Feature: add process status to check service readiness

### DIFF
--- a/mycroft/audio/__main__.py
+++ b/mycroft/audio/__main__.py
@@ -21,6 +21,7 @@ from mycroft.messagebus.client import MessageBusClient
 from mycroft.util import reset_sigint_handler, wait_for_exit_signal, \
     create_daemon, create_echo_function, check_for_signal
 from mycroft.util.log import LOG
+from mycroft.util.process_utils import ProcessStatus
 
 import mycroft.audio.speech as speech
 from .audioservice import AudioService
@@ -45,6 +46,8 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
         check_for_signal("isSpeaking")
         bus = MessageBusClient()  # Connect to the Mycroft Messagebus
         Configuration.set_config_update_handlers(bus)
+        status = ProcessStatus('audio', bus, on_ready=ready_hook,
+                               on_error=error_hook, on_stopping=stopping_hook)
         speech.init(bus)
 
         LOG.info("Starting Audio Services")
@@ -53,15 +56,16 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
 
         # Connect audio service instance to message bus
         audio = AudioService(bus)
+        status.set_started()
     except Exception as e:
         error_hook(e)
     else:
         create_daemon(bus.run_forever)
         if audio.wait_for_load() and len(audio.service) > 0:
             # If at least one service exists, report ready
-            ready_hook()
+            status.set_ready()
             wait_for_exit_signal()
-            stopping_hook()
+            status.set_stopping()
         else:
             error_hook('No audio services loaded')
 

--- a/mycroft/client/enclosure/generic/__init__.py
+++ b/mycroft/client/enclosure/generic/__init__.py
@@ -41,7 +41,8 @@ class EnclosureGeneric(Enclosure):
         super().__init__()
 
         # Notifications from mycroft-core
-        self.bus.on("enclosure.notify.no_internet", self.on_no_internet)
+        self.bus.on('enclosure.notify.no_internet', self.on_no_internet)
+        self.bus.on('mycroft.skills.trained', self.is_device_ready)
 
         # initiates the web sockets on display manager
         # NOTE: this is a temporary place to connect the display manager
@@ -54,6 +55,36 @@ class EnclosureGeneric(Enclosure):
             # receive the "speak".  This was sometimes happening too
             # quickly and the user wasn't notified what to do.
             Timer(5, self._do_net_check).start()
+
+    def is_device_ready(self, message):
+        is_ready = False
+        # Bus service assumed to be alive if messages sent and received
+        # Enclosure assumed to be alive if this method is running
+        services = {'audio': {}, 'speech': {}, 'skills': {}}
+        start = time.monotonic()
+        while not is_ready:
+            is_ready = self.check_services_ready(services)
+            if is_ready:
+                break
+            elif time.monotonic() - start >= 60:
+                raise Exception('Timeout waiting for services start.')
+            else:
+                time.sleep(3)
+
+        if is_ready:
+            LOG.info("Mycroft is all loaded and ready to roll!")
+            self.bus.emit(Message('mycroft.ready'))
+
+        return is_ready
+
+    def check_services_ready(self, services):
+        for s in services:
+            services[s]['is_ready'] = False
+            response = self.bus.wait_for_response(Message(
+                                'mycroft.{}.is_ready'.format(s)))
+            if response and response.data['status']:
+                services[s]['is_ready'] = True
+        return all([services[s]['is_ready'] for s in services])
 
     def on_no_internet(self, event=None):
         if connected():

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -25,6 +25,7 @@ from mycroft.messagebus.message import Message
 from mycroft.util import create_daemon, wait_for_exit_signal, \
     reset_sigint_handler, create_echo_function
 from mycroft.util.log import LOG
+from mycroft.util.process_utils import ProcessStatus
 
 bus = None  # Mycroft messagebus connection
 lock = Lock()
@@ -222,6 +223,8 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
         bus = MessageBusClient()  # Mycroft messagebus, see mycroft.messagebus
         Configuration.set_config_update_handlers(bus)
         config = Configuration.get()
+        status = ProcessStatus('speech', bus, on_ready=ready_hook,
+                               on_error=error_hook, on_stopping=stopping_hook)
 
         # Register handlers on internal RecognizerLoop bus
         loop = RecognizerLoop(watchdog)
@@ -229,12 +232,13 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
         connect_bus_events(bus)
         create_daemon(bus.run_forever)
         create_daemon(loop.run)
+        status.set_started()
     except Exception as e:
         error_hook(e)
     else:
-        ready_hook()
+        status.set_ready()
         wait_for_exit_signal()
-        stopping_hook()
+        status.set_stopping()
 
 
 if __name__ == "__main__":

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -40,6 +40,7 @@ from mycroft.util import (
 )
 from mycroft.util.lang import set_active_lang
 from mycroft.util.log import LOG
+from mycroft.util.process_utils import ProcessStatus
 from .core import FallbackSkill
 from .event_scheduler import EventScheduler
 from .intent_service import IntentService
@@ -198,8 +199,13 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
     bus = _start_message_bus_client()
     _register_intent_services(bus)
     event_scheduler = EventScheduler(bus)
+    status = ProcessStatus('skills', bus, on_started=ready_hook,
+                           on_error=error_hook,
+                           on_stopping=stopping_hook)
+
     skill_manager = _initialize_skill_manager(bus, watchdog)
 
+    status.set_started()
     _wait_for_internet_connection()
 
     if skill_manager is None:
@@ -210,9 +216,14 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
     skill_manager.start()
     while not skill_manager.is_alive():
         time.sleep(0.1)
-    ready_hook()  # Report ready status
+    status.set_alive()
+
+    while not skill_manager.is_all_loaded():
+        time.sleep(0.1)
+    status.set_ready()
+
     wait_for_exit_signal()
-    stopping_hook()  # Report shutdown started
+    process_status.set_stopping()
     shutdown(skill_manager, event_scheduler)
 
 

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -199,9 +199,8 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
     bus = _start_message_bus_client()
     _register_intent_services(bus)
     event_scheduler = EventScheduler(bus)
-    status = ProcessStatus('skills', bus, on_started=ready_hook,
-                           on_error=error_hook,
-                           on_stopping=stopping_hook)
+    status = ProcessStatus('skills', bus, on_ready=ready_hook,
+                           on_error=error_hook, on_stopping=stopping_hook)
 
     skill_manager = _initialize_skill_manager(bus, watchdog)
 
@@ -223,7 +222,7 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
     status.set_ready()
 
     wait_for_exit_signal()
-    process_status.set_stopping()
+    status.set_stopping()
     shutdown(skill_manager, event_scheduler)
 
 

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -103,8 +103,7 @@ class PadatiousService(FallbackSkill):
 
         self.finished_training_event.set()
         if not self.finished_initial_train:
-            LOG.info("Mycroft is all loaded and ready to roll!")
-            self.bus.emit(Message('mycroft.ready'))
+            self.bus.emit(Message('mycroft.skills.trained'))
             self.finished_initial_train = True
 
     def wait_and_train(self):

--- a/mycroft/util/process_utils.py
+++ b/mycroft/util/process_utils.py
@@ -125,7 +125,7 @@ def create_echo_function(name, whitelist=None):
 
 class ProcessStatus:
     def __init__(self, name, bus,
-                 on_started=None, on_alive=None, on_complete=None,
+                 on_started=None, on_alive=None, on_ready=None,
                  on_stopping=None, on_error=None):
         # Messagebus connection
         self.bus = bus
@@ -134,7 +134,7 @@ class ProcessStatus:
         # Callback functions
         self.on_started = on_started
         self.on_alive = on_alive
-        self.on_complete = on_complete
+        self.on_ready = on_ready
         self.on_error = on_error
 
         # State variables
@@ -146,7 +146,7 @@ class ProcessStatus:
 
     def _register_handlers(self):
         self.bus.on('mycroft.{}.is_alive'.format(self.name), self.check_alive)
-        self.bus.on('mycroft.{}.ready'.format(self.name),
+        self.bus.on('mycroft.{}.is_ready'.format(self.name),
                     self.check_ready)
         self.bus.on('mycroft.{}.all_loaded'.format(self.name),
                     self.check_ready)
@@ -184,8 +184,8 @@ class ProcessStatus:
         """All loading is done."""
         self.is_alive = True
         self.is_ready = True
-        if self.on_complete:
-            self.on_complete()
+        if self.on_ready:
+            self.on_ready()
 
     def set_stopping(self):
         self.is_ready = False

--- a/mycroft/util/process_utils.py
+++ b/mycroft/util/process_utils.py
@@ -203,5 +203,5 @@ class ProcessStatus:
     def set_error(self, err=''):
         self.is_ready = False
         self.is_alive = False
-        if self.on_stopping:
-            self.on_ready(err)
+        if self.on_error:
+            self.on_error(err)

--- a/mycroft/util/process_utils.py
+++ b/mycroft/util/process_utils.py
@@ -190,7 +190,7 @@ class ProcessStatus:
     def set_stopping(self):
         self.is_ready = False
         if self.on_stopping:
-            self.on_stopping(err)
+            self.on_stopping()
 
     def set_error(self, err=''):
         self.is_ready = False

--- a/mycroft/util/process_utils.py
+++ b/mycroft/util/process_utils.py
@@ -145,11 +145,20 @@ class ProcessStatus:
         self._register_handlers()
 
     def _register_handlers(self):
+        self.bus.on('mycroft.{}.is_started'.format(self.name),
+                    self.check_started)
         self.bus.on('mycroft.{}.is_alive'.format(self.name), self.check_alive)
         self.bus.on('mycroft.{}.is_ready'.format(self.name),
                     self.check_ready)
         self.bus.on('mycroft.{}.all_loaded'.format(self.name),
                     self.check_ready)
+
+    def check_started(self, message=None):
+        """Respond to is_started status request."""
+        if message:
+            status = {'status': self.is_started}
+            self.bus.emit(message.response(data=status))
+        return self.is_started
 
     def check_alive(self, message=None):
         """Respond to is_alive status request."""
@@ -160,7 +169,6 @@ class ProcessStatus:
 
     def check_ready(self, message=None):
         """ Respond to all_loaded status request."""
-        print("CHECKING READY!")
         if message:
             status = {'status': self.is_ready}
             self.bus.emit(message.response(data=status))


### PR DESCRIPTION
## Description
Add more detailed check on service readiness during boot.

This adds a ProcessStatus object to key services providing a common interface for querying it's lifecycle status.
It also shifts the readiness check from the Padatious service to the Enclosure. Though is still triggered by the completion of the first Padatious training run.

Much cleaner implementation of #2642 
Initial issue discussion at: #2639 

## How to test
Break a service preventing it from loading and check that the `mycroft.ready` message is not emitted (also logs "Mycroft is all loaded and ready to roll!" to the `enclosure.log`).

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
