### PR TITLE
Improve readiness check for all services

### DIFF
--- a/mycroft/audio/__main__.py
+++ b/mycroft/audio/__main__.py
@@ -23,6 +23,7 @@ from mycroft.util import (
     wait_for_exit_signal
 )
 from mycroft.util.log import LOG
+from mycroft.util.process_utils import ProcessStatus, StatusCallbackMap
 
 import mycroft.audio.speech as speech
 from .audioservice import AudioService
@@ -48,20 +49,25 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
         check_for_signal("isSpeaking")
         whitelist = ['mycroft.audio.service']
         bus = start_message_bus_client("AUDIO", whitelist=whitelist)
+        callbacks = StatusCallbackMap(on_ready=ready_hook, on_error=error_hook,
+                                      on_stopping=stopping_hook)
+        status = ProcessStatus('audio', bus, callbacks)
+
         speech.init(bus)
 
         # Connect audio service instance to message bus
         audio = AudioService(bus)
+        status.set_started()
     except Exception as e:
-        error_hook(e)
+        status.set_error(e)
     else:
         if audio.wait_for_load() and len(audio.service) > 0:
             # If at least one service exists, report ready
-            ready_hook()
+            status.set_ready()
             wait_for_exit_signal()
-            stopping_hook()
+            status.set_stopping()
         else:
-            error_hook('No audio services loaded')
+            status.set_error('No audio services loaded')
 
         speech.shutdown()
         audio.shutdown()

--- a/mycroft/client/enclosure/generic/__init__.py
+++ b/mycroft/client/enclosure/generic/__init__.py
@@ -41,7 +41,8 @@ class EnclosureGeneric(Enclosure):
         super().__init__()
 
         # Notifications from mycroft-core
-        self.bus.on("enclosure.notify.no_internet", self.on_no_internet)
+        self.bus.on('enclosure.notify.no_internet', self.on_no_internet)
+        self.bus.on('mycroft.skills.trained', self.is_device_ready)
 
         # initiates the web sockets on display manager
         # NOTE: this is a temporary place to connect the display manager
@@ -54,6 +55,40 @@ class EnclosureGeneric(Enclosure):
             # receive the "speak".  This was sometimes happening too
             # quickly and the user wasn't notified what to do.
             Timer(5, self._do_net_check).start()
+
+    def is_device_ready(self, message):
+        is_ready = False
+        # Bus service assumed to be alive if messages sent and received
+        # Enclosure assumed to be alive if this method is running
+        services = {'audio': False, 'speech': False, 'skills': False}
+        start = time.monotonic()
+        while not is_ready:
+            is_ready = self.check_services_ready(services)
+            if is_ready:
+                break
+            elif time.monotonic() - start >= 60:
+                raise Exception('Timeout waiting for services start.')
+            else:
+                time.sleep(3)
+
+        if is_ready:
+            LOG.info("Mycroft is all loaded and ready to roll!")
+            self.bus.emit(Message('mycroft.ready'))
+
+        return is_ready
+
+    def check_services_ready(self, services):
+        """Report if all specified services are ready.
+
+        services (iterable): service names to check.
+        """
+        for ser in services:
+            services[ser] = False
+            response = self.bus.wait_for_response(Message(
+                                'mycroft.{}.is_ready'.format(ser)))
+            if response and response.data['status']:
+                services[ser] = True
+        return all([services[ser] for ser in services])
 
     def on_no_internet(self, event=None):
         if connected():

--- a/mycroft/client/enclosure/generic/__init__.py
+++ b/mycroft/client/enclosure/generic/__init__.py
@@ -42,6 +42,8 @@ class EnclosureGeneric(Enclosure):
 
         # Notifications from mycroft-core
         self.bus.on('enclosure.notify.no_internet', self.on_no_internet)
+        # TODO: this requires the Enclosure to be up and running before the
+        # training is complete.
         self.bus.on('mycroft.skills.trained', self.is_device_ready)
 
         # initiates the web sockets on display manager

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -172,23 +172,23 @@ class DevicePrimer(object):
 
 
 def on_started():
-    LOG.info('Skill service is starting up.')
+    LOG.info('Skills service is starting up.')
 
 
 def on_alive():
-    LOG.info('Skill service is alive.')
+    LOG.info('Skills service is alive.')
 
 
 def on_ready():
-    LOG.info('Skill service is ready.')
+    LOG.info('Skills service is ready.')
 
 
 def on_error(e='Unknown'):
-    LOG.info('Skill service failed to launch ({})'.format(repr(e)))
+    LOG.info('Skills service failed to launch ({})'.format(repr(e)))
 
 
 def on_stopping():
-    LOG.info('Skill service is shutting down...')
+    LOG.info('Skills service is shutting down...')
 
 
 def main(alive_hook=on_alive, started_hook=on_started, ready_hook=on_ready,
@@ -280,14 +280,14 @@ def _wait_for_internet_connection():
 
 
 def shutdown(skill_manager, event_scheduler):
-    LOG.info('Shutting down skill service')
+    LOG.info('Shutting down Skills service')
     if event_scheduler is not None:
         event_scheduler.shutdown()
     # Terminate all running threads that update skills
     if skill_manager is not None:
         skill_manager.stop()
         skill_manager.join()
-    LOG.info('Skill service shutdown complete!')
+    LOG.info('Skills service shutdown complete!')
 
 
 if __name__ == "__main__":

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -196,7 +196,7 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
     bus = start_message_bus_client("SKILLS")
     _register_intent_services(bus)
     event_scheduler = EventScheduler(bus)
-    callbacks = StatusCallbackMap(on_complete=ready_hook,
+    callbacks = StatusCallbackMap(on_ready=ready_hook,
                                   on_error=error_hook,
                                   on_stopping=stopping_hook)
     status = ProcessStatus('skills', bus, callbacks)

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -171,6 +171,14 @@ class DevicePrimer(object):
             wait_while_speaking()
 
 
+def on_started():
+    LOG.info('Skill service is starting up.')
+
+
+def on_alive():
+    LOG.info('Skill service is alive.')
+
+
 def on_ready():
     LOG.info('Skill service is ready.')
 
@@ -183,8 +191,8 @@ def on_stopping():
     LOG.info('Skill service is shutting down...')
 
 
-def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
-         watchdog=None):
+def main(alive_hook=on_alive, started_hook=on_started, ready_hook=on_ready,
+         error_hook=on_error, stopping_hook=on_stopping, watchdog=None):
     reset_sigint_handler()
     # Create PID file, prevent multiple instances of this service
     mycroft.lock.Lock('skills')
@@ -196,7 +204,9 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
     bus = start_message_bus_client("SKILLS")
     _register_intent_services(bus)
     event_scheduler = EventScheduler(bus)
-    callbacks = StatusCallbackMap(on_ready=ready_hook,
+    callbacks = StatusCallbackMap(on_started=started_hook,
+                                  on_alive=alive_hook,
+                                  on_ready=ready_hook,
                                   on_error=error_hook,
                                   on_stopping=stopping_hook)
     status = ProcessStatus('skills', bus, callbacks)

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -38,6 +38,7 @@ from mycroft.util import (
 )
 from mycroft.util.lang import set_active_lang
 from mycroft.util.log import LOG
+from mycroft.util.process_utils import ProcessStatus, StatusCallbackMap
 from .core import FallbackSkill
 from .event_scheduler import EventScheduler
 from .intent_service import IntentService
@@ -195,8 +196,14 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
     bus = start_message_bus_client("SKILLS")
     _register_intent_services(bus)
     event_scheduler = EventScheduler(bus)
+    callbacks = StatusCallbackMap(on_complete=ready_hook,
+                                  on_error=error_hook,
+                                  on_stopping=stopping_hook)
+    status = ProcessStatus('skills', bus, callbacks)
+
     skill_manager = _initialize_skill_manager(bus, watchdog)
 
+    status.set_started()
     _wait_for_internet_connection()
 
     if skill_manager is None:
@@ -207,9 +214,14 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
     skill_manager.start()
     while not skill_manager.is_alive():
         time.sleep(0.1)
-    ready_hook()  # Report ready status
+    status.set_alive()
+
+    while not skill_manager.is_all_loaded():
+        time.sleep(0.1)
+    status.set_ready()
+
     wait_for_exit_signal()
-    stopping_hook()  # Report shutdown started
+    process_status.set_stopping()
     shutdown(skill_manager, event_scheduler)
 
 

--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -221,7 +221,7 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
     status.set_ready()
 
     wait_for_exit_signal()
-    process_status.set_stopping()
+    status.set_stopping()
     shutdown(skill_manager, event_scheduler)
 
 

--- a/mycroft/skills/intent_services/padatious_service.py
+++ b/mycroft/skills/intent_services/padatious_service.py
@@ -84,8 +84,7 @@ class PadatiousService:
 
         self.finished_training_event.set()
         if not self.finished_initial_train:
-            LOG.info("Mycroft is all loaded and ready to roll!")
-            self.bus.emit(Message('mycroft.ready'))
+            self.bus.emit(Message('mycroft.skills.trained'))
             self.finished_initial_train = True
 
     def wait_and_train(self):

--- a/mycroft/skills/padatious_service.py
+++ b/mycroft/skills/padatious_service.py
@@ -103,8 +103,7 @@ class PadatiousService(FallbackSkill):
 
         self.finished_training_event.set()
         if not self.finished_initial_train:
-            LOG.info("Mycroft is all loaded and ready to roll!")
-            self.bus.emit(Message('mycroft.ready'))
+            self.bus.emit(Message('mycroft.skills.trained'))
             self.finished_initial_train = True
 
     def wait_and_train(self):

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -158,8 +158,6 @@ class SkillManager(Thread):
         self.bus.on('skillmanager.keep', self.deactivate_except)
         self.bus.on('skillmanager.activate', self.activate_skill)
         self.bus.on('mycroft.paired', self.handle_paired)
-        self.bus.on('mycroft.skills.is_alive', self.is_alive)
-        self.bus.on('mycroft.skills.all_loaded', self.is_all_loaded)
         self.bus.on(
             'mycroft.skills.settings.update',
             self.settings_downloader.download
@@ -353,17 +351,10 @@ class SkillManager(Thread):
 
     def is_alive(self, message=None):
         """Respond to is_alive status request."""
-        if message:
-            status = {'status': self._alive_status}
-            self.bus.emit(message.response(data=status))
         return self._alive_status
 
     def is_all_loaded(self, message=None):
         """ Respond to all_loaded status request."""
-        if message:
-            status = {'status': self._loaded_status}
-            self.bus.emit(message.response(data=status))
-
         return self._loaded_status
 
     def send_skill_list(self, _):

--- a/mycroft/util/process_utils.py
+++ b/mycroft/util/process_utils.py
@@ -1,6 +1,9 @@
+from collections import namedtuple
+from enum import IntEnum
 import json
 import logging
 import signal as sig
+import sys
 from threading import Event, Thread
 from time import sleep
 
@@ -152,3 +155,140 @@ def start_message_bus_client(service, bus=None, whitelist=None):
     LOG.info('Connected to messagebus')
 
     return bus
+
+
+class ProcessState(IntEnum):
+
+    """Oredered enum to make state checks easy.
+
+    For example Alive can be determined using >= ProcessState.ALIVE,
+    which will return True if the state is READY as well as ALIVE.
+    """
+    NOT_STARTED = 0
+    STARTED = 1
+    ERROR = 2
+    STOPPING = 3
+    ALIVE = 4
+    READY = 5
+
+
+# Process state change callback mappings.
+_STATUS_CALLBACKS = [
+    'on_started',
+    'on_alive',
+    'on_complete',
+    'on_error',
+    'on_stopping',
+]
+# namedtuple defaults only available on 3.7 and later python versions
+if sys.version_info < (3, 7):
+    StatusCallbackMap = namedtuple('CallbackMap', _STATUS_CALLBACKS)
+    StatusCallbackMap.__new__.__defaults__ = (None,) * 5
+else:
+    StatusCallbackMap = namedtuple(
+        'CallbackMap',
+        _STATUS_CALLBACKS,
+        defaults=(None,) * len(_STATUS_CALLBACKS),
+    )
+
+
+class ProcessStatus:
+    """Process status tracker.
+
+    The class tracks process status and execute callback methods on
+    state changes as well as replies to messagebus queries of the
+    process status.
+
+    Arguments:
+        name (str): process name, will be used to create the messagebus
+                    messagetype "mycroft.{name}...".
+        bus (MessageBusClient): Connection to the Mycroft messagebus.
+        callback_map (StatusCallbackMap): optionally, status callbacks for the
+                                          various status changes.
+    """
+
+    def __init__(self, name, bus, callback_map=None):
+
+        # Messagebus connection
+        self.bus = bus
+        self.name = name
+
+        self.callbacks = callback_map or StatusCallbackMap()
+        self.state = ProcessState.NOT_STARTED
+        self._register_handlers()
+
+    def _register_handlers(self):
+        """Register messagebus handlers for status queries."""
+        self.bus.on('mycroft.{}.is_alive'.format(self.name), self.check_alive)
+        self.bus.on('mycroft.{}.ready'.format(self.name), self.check_ready)
+        # The next one is for backwards compatibility
+        # TODO: remove in 21.02
+        self.bus.on(
+            'mycroft.{}.all_loaded'.format(self.name), self.check_ready
+        )
+
+    def check_alive(self, message=None):
+        """Respond to is_alive status request.
+
+        Arguments:
+            message: Optional message to respond to, if omitted no message
+                     is sent.
+
+        Returns:
+            bool, True if process is alive.
+        """
+        is_alive = self.state >= ProcessState.ALIVE
+
+        if message:
+            status = {'status': is_alive}
+            self.bus.emit(message.response(data=status))
+
+        return is_alive
+
+    def check_ready(self, message=None):
+        """Respond to all_loaded status request.
+
+        Arguments:
+            message: Optional message to respond to, if omitted no message
+                     is sent.
+
+        Returns:
+            bool, True if process is ready.
+        """
+        is_ready = self.state >= ProcessState.READY
+        if message:
+            status = {'status': is_ready}
+            self.bus.emit(message.response(data=status))
+
+        return is_ready
+
+    def set_started(self):
+        """Process is started."""
+        self.state = ProcessState.STARTED
+        if self.callbacks.on_started:
+            self.callbacks.on_started()
+
+    def set_alive(self):
+        """Basic loading is done."""
+        self.state = ProcessState.ALIVE
+        if self.callbacks.on_alive:
+            self.callbacks.on_alive()
+
+    def set_ready(self):
+        """All loading is done."""
+        self.state = ProcessState.READY
+        if self.callbacks.on_complete:
+            self.callbacks.on_complete()
+
+    def set_stopping(self):
+        """Process shutdown has started."""
+        self.state = ProcessState.STOPPING
+        if self.callbacks.on_stopping:
+            self.callbacks.on_stopping()
+
+    def set_error(self, err=''):
+        """An error has occured and the process is non-functional."""
+        # Intentionally leave is_started True
+        self.state = ProcessState.ERROR
+        if self.callbacks.on_error:
+            self.callbacks.on_error(err)

--- a/mycroft/util/process_utils.py
+++ b/mycroft/util/process_utils.py
@@ -176,10 +176,12 @@ class ProcessState(IntEnum):
 _STATUS_CALLBACKS = [
     'on_started',
     'on_alive',
-    'on_complete',
+    'on_ready',
     'on_error',
     'on_stopping',
 ]
+
+
 # namedtuple defaults only available on 3.7 and later python versions
 if sys.version_info < (3, 7):
     StatusCallbackMap = namedtuple('CallbackMap', _STATUS_CALLBACKS)
@@ -220,7 +222,8 @@ class ProcessStatus:
     def _register_handlers(self):
         """Register messagebus handlers for status queries."""
         self.bus.on('mycroft.{}.is_alive'.format(self.name), self.check_alive)
-        self.bus.on('mycroft.{}.ready'.format(self.name), self.check_ready)
+        self.bus.on('mycroft.{}.is_ready'.format(self.name),
+                    self.check_ready)
         # The next one is for backwards compatibility
         # TODO: remove in 21.02
         self.bus.on(
@@ -277,8 +280,8 @@ class ProcessStatus:
     def set_ready(self):
         """All loading is done."""
         self.state = ProcessState.READY
-        if self.callbacks.on_complete:
-            self.callbacks.on_complete()
+        if self.callbacks.on_ready:
+            self.callbacks.on_ready()
 
     def set_stopping(self):
         """Process shutdown has started."""

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -115,8 +115,6 @@ class TestSkillManager(MycroftUnitTestBase):
             'skillmanager.keep',
             'skillmanager.activate',
             'mycroft.paired',
-            'mycroft.skills.is_alive',
-            'mycroft.skills.all_loaded',
             'mycroft.skills.settings.update'
         ]
         self.assertListEqual(


### PR DESCRIPTION
## Description
Add a consistent interface to set and query the state of Mycroft Services improving the ability to check that Mycroft as a whole is ready for use. Full documentation at:
https://mycroft-ai.gitbook.io/docs/mycroft-technologies/mycroft-core#process-status-proposed

This adds a ProcessStatus object to key services providing a common interface for querying it's lifecycle status.
It also shifts the readiness check from the Padatious service to the Enclosure. Though is still triggered by the completion of the first Padatious training run.

Initial issue discussion at: #2639 
Previous closed PR's - #2642, #2645 

## How to test
Run unit tests.

Alternatively break a service preventing it from loading and check that the `mycroft.ready` message is not emitted (also logs "Mycroft is all loaded and ready to roll!" to the `enclosure.log`).

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
