### PR TITLE
set active lang to configured if missing from STT and normalize

### DIFF
--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -149,6 +149,19 @@ class ContextManager:
         return result
 
 
+def _get_message_lang(message):
+    """Get the language from the message or the default language.
+
+    Arguments:
+        message: message to check for language code.
+
+    Returns:
+        The languge code from the message or the default language.
+    """
+    default_lang = Configuration.get().get('lang', 'en-us')
+    return message.data.get('lang', default_lang)
+
+
 class IntentService:
     def __init__(self, bus):
         self.config = Configuration.get().get('context', {})
@@ -212,7 +225,7 @@ class IntentService:
 
     def reset_converse(self, message):
         """Let skills know there was a problem with speech recognition"""
-        lang = message.data.get('lang', "en-us")
+        lang = _get_message_lang(message)
         set_active_lang(lang)
         for skill in copy(self.active_skills):
             self.do_converse(None, skill[0], lang, message)
@@ -318,8 +331,7 @@ class IntentService:
             message (Message): The messagebus data
         """
         try:
-            # Get language of the utterance
-            lang = message.data.get('lang', "en-us")
+            lang = _get_message_lang(message)
             set_active_lang(lang)
 
             utterances = message.data.get('utterances', [])

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -159,7 +159,7 @@ def _get_message_lang(message):
         The languge code from the message or the default language.
     """
     default_lang = Configuration.get().get('lang', 'en-us')
-    return message.data.get('lang', default_lang)
+    return message.data.get('lang', default_lang).lower()
 
 
 class IntentService:


### PR DESCRIPTION
## Description
I ran across this when checking some questions I had surrounding [mycroft-timer PR #77](https://github.com/MycroftAI/mycroft-timer/pull/77)

If the STT doesn't send a lang code fallback to configured language instead of hardcoded en-us. This should at least be more correct than the previous behaviour.

## How to test
Check that Mycroft operates as usual and that the new unittest passes

## Contributor license agreement signed?
CLA [ Yes ]