### PR TITLE
Fix settings changed check after skill handler

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -848,7 +848,7 @@ class MycroftSkill:
             """
             if self.settings != self._initial_settings:
                 save_settings(self.settings_write_path, self.settings)
-                self._initial_settings = self.settings
+                self._initial_settings = deepcopy(self.settings)
             if handler_info:
                 msg_type = handler_info + '.complete'
                 self.bus.emit(message.forward(msg_type, skill_data))


### PR DESCRIPTION
## Description
This issue was reported by @emphasize here https://github.com/MycroftAI/skill-reminder/issues/37. Mycroft doesn't detect changes because after the initial change the `_initial_settings` reference is refering to the same memory as the `settings` member. This was earlier fixed for the initial setup of `_initial_settings` but the check at the end of intent handler was overlooked.

## How to test
Use the reminder skill to set a couple of reminders, make sure they're all stored in the settings.json and not just the first.

## Contributor license agreement signed?
CLA [ Yes ]