### PR TITLE
upgrade Lingua Franca to v0.2.2

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -16,7 +16,7 @@ python-dateutil==2.6.0
 fasteners==0.14.1
 PyYAML==5.1.2
 
-lingua-franca==0.2.1
+lingua-franca==0.2.2
 msm==0.8.7
 msk==0.3.15
 adapt-parser==0.3.6


### PR DESCRIPTION
## Description
Update requirements to latest Lingua Franca v0.2.2 - see the [release notes](https://github.com/MycroftAI/lingua-franca/releases/tag/0.2.2). Primarily bug fixes.

## How to test
Run unit tests

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
