### PR TITLE
Disable wake word upload for v20.2

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -534,14 +534,6 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             'model': str(model_hash)
         }
 
-    def _upload_wake_word(self, audio, metadata):
-        requests.post(
-            self.upload_url, files={
-                'audio': BytesIO(audio.get_wav_data()),
-                'metadata': StringIO(json.dumps(metadata))
-            }
-        )
-
     def trigger_listen(self):
         """Externally trigger listening."""
         LOG.debug('Listen triggered from external source.')

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -541,12 +541,16 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
     def _upload_wakeword(self, audio, metadata):
         """Upload the wakeword in a background thread."""
-        def upload(audio, metadata):
-            requests.post(self.upload_url,
-                          files={'audio': BytesIO(audio.get_wav_data()),
-                                 'metadata': StringIO(json.dumps(metadata))})
-
-        Thread(target=upload, daemon=True, args=(audio, metadata)).start()
+        LOG.debug(
+            "Wakeword uploading has been disabled. The API endpoint used in "
+            "Mycroft-core v20.2 and below has been deprecated. To contribute "
+            "new wakeword samples please upgrade to v20.8 or above."
+        )
+        # def upload(audio, metadata):
+        #     requests.post(self.upload_url,
+        #                   files={'audio': BytesIO(audio.get_wav_data()),
+        #                          'metadata': StringIO(json.dumps(metadata))})
+        # Thread(target=upload, daemon=True, args=(audio, metadata)).start()
 
     def _send_wakeword_info(self, emitter):
         """Send messagebus message indicating that a wakeword was received.


### PR DESCRIPTION
## Description
The API endpoint used to upload wake words will be deprecated in the near future and instead shifted to Selene. To ensure older devices are not making unnecessary post requests to a dead endpoint, this disables that request.

In looking at this, there also seems to be a duplicate and unused method that doesn't use threading, so this has been removed entirely.

## How to test
Ensure you are opted in and wake word upload is not disabled in your config. Set log level to debug and trigger the wake word. 

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
