### PR TITLE
Do not call max if files list is empty

### DIFF
--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -99,7 +99,10 @@ def _get_last_modified_time(path):
                 all_files.append(os.path.join(root_dir, f))
 
     # check files of interest in the skill root directory
-    return max(os.path.getmtime(f) for f in all_files)
+    if all_files:
+        return max(os.path.getmtime(f) for f in all_files)
+    else:
+        return 0
 
 
 class SkillLoader:


### PR DESCRIPTION
## Description
Method that checks modified date of files attempts to call `max()` even if the list of files is empty. Results in:
```
ValueError: max() arg is an empty sequence
```

This change checks if the list is populated first.

## How to test
Run dev branch on a Mark 1, after booting uninstall a Skill.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
