### PR TITLE
Voight Kampff given timeout

### DIFF
--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -97,6 +97,7 @@ def before_all(context):
     sleep(10)
 
     context.bus = bus
+    context.step_timeout = 10  # Reset the step_timeout to 10 seconds
     context.matched_message = None
     context.log = log
     context.original_config = {}
@@ -139,6 +140,7 @@ def after_scenario(context, scenario):
     wait_while_speaking()
     context.bus.clear_messages()
     context.matched_message = None
+    context.step_timeout = 10  # Reset the step_timeout to 10 seconds
 
     if context.original_config:
         # something has changed, reset changes by done in the context

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -123,6 +123,20 @@ def given_english(context):
     context.lang = 'en-us'
 
 
+@given('a {timeout} seconds timeout')
+@given('a {timeout} second timeout')
+def given_timeout(context, timeout):
+    """Set the timeout for the steps in this scenario."""
+    context.step_timeout = float(timeout)
+
+
+@given('a {timeout} minutes timeout')
+@given('a {timeout} minute timeout')
+def given_timeout(context, timeout):
+    """Set the timeout for the steps in this scenario."""
+    context.step_timeout = float(timeout) * 60
+
+
 @when('the user says "{text}"')
 def when_user_says(context, text):
     context.bus.emit(Message('recognizer_loop:utterance',
@@ -233,6 +247,7 @@ def then_user_follow_up(context, text):
 
 @then('mycroft should send the message "{message_type}"')
 def then_messagebus_message(context, message_type):
+    """Set a timeout for the current Scenario."""
     cnt = 0
     while context.bus.get_messages(message_type) == []:
         if cnt > int(TIMEOUT * (1.0 / SLEEP_LENGTH)):

--- a/test/integrationtests/voight_kampff/tools.py
+++ b/test/integrationtests/voight_kampff/tools.py
@@ -23,7 +23,7 @@ from mycroft.messagebus import Message
 TIMEOUT = 10
 
 
-def then_wait(msg_type, criteria_func, context, timeout=TIMEOUT):
+def then_wait(msg_type, criteria_func, context, timeout=None):
     """Wait for a specified time for criteria to be fulfilled.
 
     Arguments:
@@ -31,11 +31,13 @@ def then_wait(msg_type, criteria_func, context, timeout=TIMEOUT):
         criteria_func: Function to determine if a message fulfilling the
                        test case has been found.
         context: behave context
-        timeout: Time allowance for a message fulfilling the criteria
+        timeout: Time allowance for a message fulfilling the criteria, if
+                 provided will override the normal normal step timeout.
 
     Returns:
         tuple (bool, str) test status and debug output
     """
+    timeout = timeout or context.step_timeout
     start_time = time.monotonic()
     debug = ''
     while time.monotonic() < start_time + timeout:
@@ -51,7 +53,7 @@ def then_wait(msg_type, criteria_func, context, timeout=TIMEOUT):
     return False, debug
 
 
-def then_wait_fail(msg_type, criteria_func, context, timeout=TIMEOUT):
+def then_wait_fail(msg_type, criteria_func, context, timeout=None):
     """Wait for a specified time, failing if criteria is fulfilled.
 
     Arguments:

--- a/test/integrationtests/voight_kampff/tools.py
+++ b/test/integrationtests/voight_kampff/tools.py
@@ -110,14 +110,20 @@ def emit_utterance(bus, utt):
                      context={'client_name': 'mycroft_listener'}))
 
 
-def wait_for_dialog(bus, dialogs, timeout=TIMEOUT):
+def wait_for_dialog(bus, dialogs, context=None, timeout=None):
     """Wait for one of the dialogs given as argument.
 
     Arguments:
         bus (InterceptAllBusClient): Bus instance to listen on
         dialogs (list): list of acceptable dialogs
-        timeout (int): how long to wait for the messagem, defaults to 10 sec.
+        context (behave Context): optional context providing scenario timeout
+        timeout (int): how long to wait for the message, defaults to timeout
+                       provided by context or 10 seconds
     """
+    if context:
+        timeout = timeout or context.step_timeout
+    else:
+        timeout = timeout or TIMEOUT
     start_time = time.monotonic()
     while time.monotonic() < start_time + timeout:
         for message in bus.get_messages('speak'):


### PR DESCRIPTION
## Description
Following some discussions with @krisgesling.

This adds a couple of given statements for setting the timeout for each of the steps in the scenario. After scenario completion the step timeout is returned to to original 10 seconds. Hopefully we won't be needed to go above 10 seconds in too many cases, but the option can be good to have for computation heavy tasks or tasks relying on an external data source.

## How to test
Create a simple test for a skill and add a 25 second delay (to not trigger within the retry) before the speak command. ensure that this test fails then add a `And a 30 second timeout` after the given step.

## Contributor license agreement signed?
CLA [ Yes ]