### PR TITLE
cps extend timeout

### DIFF
--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -241,6 +241,19 @@ class CommonPlaySkill(MycroftSkill, ABC):
         # self.CPS_play("http://zoosh.com/stream_music")
         pass
 
+    def CPS_extend_timeout(self, timeout=5):
+        """Request Common Play Framework to wait another {timeout} seconds
+        for an answer from this skill.
+
+        Arguments:
+            timeout (int): Number of seconds
+        """
+        self.bus.emit(Message('play:query.response',
+                              {"phrase": self.play_service_string,
+                               "searching": True,
+                               "timeout": timeout,
+                               "skill_id": self.skill_id}))
+
     def CPS_send_status(self, artist='', track='', album='', image='',
                         uri='', track_length=None, elapsed_time=None,
                         playlist_position=None,


### PR DESCRIPTION
adds ```CPS_extend_timeout``` util method to CommonPlaySkill 

usage
```python
 def CPS_match_query_phrase(self, phrase):  # , media_type
        # this skill takes long to return results
        self.CPS_extend_timeout(10)
```