### PR TITLE
remove hardcoded timeouts - now in mycroft.conf

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -323,16 +323,6 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
     # before a phrase will be considered complete
     MIN_SILENCE_AT_END = 0.25
 
-    # TODO: Remove in 20.08
-    # The maximum seconds a phrase can be recorded,
-    # provided there is noise the entire time
-    RECORDING_TIMEOUT = 10.0
-
-    # TODO: Remove in 20.08
-    # The maximum time it will continue to record silence
-    # when not enough noise has been detected
-    RECORDING_TIMEOUT_WITH_SILENCE = 3.0
-
     # Time between pocketsphinx checks for the wake word
     SEC_BETWEEN_WW_CHECKS = 0.2
 
@@ -375,13 +365,12 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         # The maximum seconds a phrase can be recorded,
         # provided there is noise the entire time
         self.recording_timeout = listener_config.get('recording_timeout',
-                                                     self.RECORDING_TIMEOUT)
+                                                     10.0)
 
         # The maximum time it will continue to record silence
         # when not enough noise has been detected
         self.recording_timeout_with_silence = listener_config.get(
-            'recording_timeout_with_silence',
-            self.RECORDING_TIMEOUT_WITH_SILENCE)
+            'recording_timeout_with_silence', 3.0)
 
     @property
     def account_id(self):


### PR DESCRIPTION
## Description
Removes hardcoded recording timeout values that were moved to the default `mycroft.conf`.

They were left for backwards compatibility. Removing in preparation for 20.08

## How to test
- [ ] with default config say something short (like "time") and listener should timeout 3 seconds after your speech.
- [ ] with default config talk non-stop and listener should timeout after 10 seconds.
- [ ] set `listener.recording_timeout` parameter to 2.0 and ensure no utterance can exceed 2 seconds.
- [ ] set `listener.recording_timeout_with_silence` parameter to 10.0 and listener will record a full 10 seconds of silence.


## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
