### PR TITLE
remove previously deprecated error message

### DIFF
--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -460,11 +460,6 @@ class SkillManager(Thread):
         reply = message.reply('skill.converse.response',
                               data=dict(skill_id=skill_id, error=error_msg))
         self.bus.emit(reply)
-        # Also emit the old error message to keep compatibility
-        # TODO Remove in 20.08
-        reply = message.reply('skill.converse.error',
-                              data=dict(skill_id=skill_id, error=error_msg))
-        self.bus.emit(reply)
 
     def _emit_converse_response(self, result, message, skill_loader):
         reply = message.reply(


### PR DESCRIPTION
## Description
Remove the previously deprecated `skills.converse.error` message that was emitted alongside `skills.converse.response` for compatibility. Has been marked for removal and I can't find anything still using it.


## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
