### PR TITLE
remove deprecated startListening signal

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -494,8 +494,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
 
         For example when we are in a dialog with the user.
         """
-        # TODO: remove startListening signal check in 20.02
-        if check_for_signal('startListening') or self._listen_triggered:
+        if self._listen_triggered:
             return True
 
         # Pressing the Mark 1 button can start recording (unless


### PR DESCRIPTION
## Description
Removes a previously deprecated signal that was used to trigger the device listening. This is now handled by toggling a boolean.

## How to test
Trigger a get_response such as "set a timer". Ensure you are prompted for a duration and that the listener is activated without need for the wake word.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
