### PR TITLE
remove deprecated DialogLoader class

### DIFF
--- a/mycroft/dialog/__init__.py
+++ b/mycroft/dialog/__init__.py
@@ -14,5 +14,4 @@
 #
 """Provides utilities for rendering dialogs and populating with custom data."""
 
-from .dialog import (MustacheDialogRenderer, DialogLoader,
-                     load_dialogs, get)
+from .dialog import (MustacheDialogRenderer, load_dialogs, get)

--- a/mycroft/dialog/dialog.py
+++ b/mycroft/dialog/dialog.py
@@ -120,28 +120,6 @@ class MustacheDialogRenderer:
         return line
 
 
-class DialogLoader:
-    """Loads a collection of dialog files into a renderer implementation.
-
-    TODO: Remove in 20.02
-    """
-
-    def __init__(self, renderer_factory=MustacheDialogRenderer):
-        LOG.warning('Deprecated, use load_dialogs() instead.')
-        self.__renderer = renderer_factory()
-
-    def load(self, dialog_dir):
-        """Load all dialog files within the specified directory.
-
-        Args:
-            dialog_dir (str): directory that contains dialog files
-
-        Returns:
-            a loaded instance of a dialog renderer
-        """
-        return load_dialogs(dialog_dir, self.__renderer)
-
-
 def load_dialogs(dialog_dir, renderer=None):
     """Load all dialog files within the specified directory.
 

--- a/test/unittests/dialog/test_dialog.py
+++ b/test/unittests/dialog/test_dialog.py
@@ -17,7 +17,7 @@ import unittest
 import pathlib
 import json
 
-from mycroft.dialog import MustacheDialogRenderer, DialogLoader, get
+from mycroft.dialog import MustacheDialogRenderer, load_dialogs, get
 from mycroft.util import resolve_resource_file
 
 
@@ -90,15 +90,13 @@ class DialogTest(unittest.TestCase):
 
     def test_dialog_loader(self):
         template_path = self.topdir.joinpath('./multiple_dialogs')
-        loader = DialogLoader()
-        renderer = loader.load(template_path)
+        renderer = load_dialogs(template_path)
         self.assertEqual(renderer.render('one'), 'ONE')
         self.assertEqual(renderer.render('two'), 'TWO')
 
     def test_dialog_loader_missing(self):
         template_path = self.topdir.joinpath('./missing_dialogs')
-        loader = DialogLoader()
-        renderer = loader.load(template_path)
+        renderer = load_dialogs(template_path)
         self.assertEqual(renderer.render('test'), 'test')
 
     def test_get(self):


### PR DESCRIPTION
## Description
Remove deprecated `DialogLoader` class in favor of new `load_dialogs` function. Unit tests also updated.

## How to test
Unit and integration tests pass

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
