### PR TITLE
Remove unnecessary string utils

### DIFF
--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -22,7 +22,7 @@ import os
 
 import mycroft.audio
 from mycroft.util.format import nice_number
-from .string_utils import get_http, remove_last_slash, camel_case_split
+from .string_utils import remove_last_slash, camel_case_split
 from .audio_utils import (play_audio_file, play_wav, play_ogg, play_mp3,
                           record, find_input_device)
 from .file_utils import (resolve_resource_file, read_stripped_lines, read_dict,

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -22,7 +22,7 @@ import os
 
 import mycroft.audio
 from mycroft.util.format import nice_number
-from .string_utils import remove_last_slash, camel_case_split
+from .string_utils import camel_case_split
 from .audio_utils import (play_audio_file, play_wav, play_ogg, play_mp3,
                           record, find_input_device)
 from .file_utils import (resolve_resource_file, read_stripped_lines, read_dict,

--- a/mycroft/util/audio_utils.py
+++ b/mycroft/util/audio_utils.py
@@ -22,7 +22,6 @@ import re
 import subprocess
 
 import mycroft.configuration
-from .string_utils import get_http
 from .log import LOG
 
 
@@ -86,7 +85,7 @@ def _play_cmd(cmd, uri, config, environment):
     """
     environment = environment or _get_pulse_environment(config)
     cmd_elements = str(cmd).split(" ")
-    cmdline = [e if e != '%1' else get_http(uri) for e in cmd_elements]
+    cmdline = [e if e != '%1' else uri for e in cmd_elements]
     return subprocess.Popen(cmdline, env=environment)
 
 

--- a/mycroft/util/string_utils.py
+++ b/mycroft/util/string_utils.py
@@ -17,18 +17,6 @@
 import re
 
 
-def get_http(uri):
-    """Change an uri from https:// to http://.
-    TODO: Remove as part of 20.08
-
-    Arguments:
-        uri: uri to convert
-
-    Returns: (string) uri where https:// has been replaced with http://
-    """
-    return uri.replace("https://", "http://")
-
-
 def remove_last_slash(url):
     """Remove the last slash from the given url.
     TODO: Remove as part of 20.08

--- a/mycroft/util/string_utils.py
+++ b/mycroft/util/string_utils.py
@@ -17,21 +17,6 @@
 import re
 
 
-def remove_last_slash(url):
-    """Remove the last slash from the given url.
-    TODO: Remove as part of 20.08
-
-    Arguments:
-        url (str): url to trim
-
-    Returns:
-        (str) url without ending slash
-    """
-    if url and url.endswith('/'):
-        url = url[:-1]
-    return url
-
-
 def camel_case_split(identifier: str) -> str:
     """Split camel case string."""
     regex = '.+?(?:(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])|$)'

--- a/test/unittests/util/test_string_utils.py
+++ b/test/unittests/util/test_string_utils.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mycroft.util import camel_case_split, remove_last_slash
+from mycroft.util import camel_case_split
 
 
 class TestStringFunctions(TestCase):
@@ -7,12 +7,3 @@ class TestStringFunctions(TestCase):
         """Check that camel case string is split properly."""
         self.assertEqual(camel_case_split('MyCoolSkill'), 'My Cool Skill')
         self.assertEqual(camel_case_split('MyCOOLSkill'), 'My COOL Skill')
-
-    def test_remove_last_slash(self):
-        """Check that the last slash in an url is correctly removed."""
-        self.assertEqual(remove_last_slash('https://github.com/'),
-                         'https://github.com')
-        self.assertEqual(remove_last_slash('https://github.com/hello'),
-                         'https://github.com/hello')
-        self.assertEqual(remove_last_slash('https://github.com/hello/'),
-                         'https://github.com/hello')

--- a/test/unittests/util/test_string_utils.py
+++ b/test/unittests/util/test_string_utils.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-from mycroft.util import camel_case_split, get_http, remove_last_slash
+from mycroft.util import camel_case_split, remove_last_slash
 
 
 class TestStringFunctions(TestCase):
@@ -7,14 +7,6 @@ class TestStringFunctions(TestCase):
         """Check that camel case string is split properly."""
         self.assertEqual(camel_case_split('MyCoolSkill'), 'My Cool Skill')
         self.assertEqual(camel_case_split('MyCOOLSkill'), 'My COOL Skill')
-
-    def test_get_http(self):
-        """Check that https-url is correctly transformed to a http-url."""
-        self.assertEqual(get_http('https://github.com/'), 'http://github.com/')
-        self.assertEqual(get_http('http://github.com/'), 'http://github.com/')
-        self.assertEqual(get_http('https://github.com/https'),
-                         'http://github.com/https')
-        self.assertEqual(get_http('http://https.com/'), 'http://https.com/')
 
     def test_remove_last_slash(self):
         """Check that the last slash in an url is correctly removed."""


### PR DESCRIPTION
## Description
Removes the get_http and remove_last_slash functions from string utils. These were previously used to massage uri's but should no longer be required.

## How to test
Play news stations using https

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
