### PR TITLE
Add missing watchdog argument

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -203,7 +203,7 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,
     _wait_for_internet_connection()
 
     if skill_manager is None:
-        skill_manager = _initialize_skill_manager(bus)
+        skill_manager = _initialize_skill_manager(bus, watchdog)
 
     device_primer = DevicePrimer(bus, config)
     device_primer.prepare_device()


### PR DESCRIPTION
## Description
Fix retry call to _initialize_skill_manager() when Msm cache doesn't exist locally. This fixes part of #2676. This affects blank systems where Msm hasn't been run ever and there is no internet connection at startup.


## Contributor license agreement signed?
CLA [ Yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
