### PR TITLE
bump version numbers for 20.08

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -102,7 +102,7 @@
         // Relative to "data_dir"
         "cache": ".skills-repo",
         "url": "https://github.com/MycroftAI/mycroft-skills",
-        "branch": "20.02"
+        "branch": "20.08"
       }
     },
     "upload_skill_manifest": true,

--- a/mycroft/version/__init__.py
+++ b/mycroft/version/__init__.py
@@ -24,8 +24,8 @@ from mycroft.util.log import LOG
 # The following lines are replaced during the release process.
 # START_VERSION_BLOCK
 CORE_VERSION_MAJOR = 20
-CORE_VERSION_MINOR = 2
-CORE_VERSION_BUILD = 5
+CORE_VERSION_MINOR = 8
+CORE_VERSION_BUILD = -1
 # END_VERSION_BLOCK
 
 CORE_VERSION_TUPLE = (CORE_VERSION_MAJOR,

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -17,7 +17,7 @@ fasteners==0.14.1
 PyYAML==5.1.2
 
 lingua-franca==0.2.2
-msm==0.8.7
+msm==0.8.8
 msk==0.3.15
 adapt-parser==0.3.6
 padatious==0.4.8


### PR DESCRIPTION
## Description
Increments version numbers for the 20.08 release of Mycroft core.

Requires MSM version to be released before merging: 
https://github.com/MycroftAI/mycroft-skills-manager/pull/77

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
