### PR TITLE
Refactor/remove imp

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import imp
+import importlib
 import sys
 import time
 from os import listdir
@@ -31,7 +31,7 @@ MAINMODULE = '__init__'
 sys.path.append(abspath(dirname(__file__)))
 
 
-def create_service_descriptor(service_folder):
+def create_service_spec(service_folder):
     """Prepares a descriptor that can be used together with imp.
 
         Args:
@@ -40,7 +40,11 @@ def create_service_descriptor(service_folder):
         Returns:
             Dict with import information
     """
-    info = imp.find_module(MAINMODULE, [service_folder])
+    module_name = basename(service_folder)
+    path = join(service_folder, MAINMODULE + '.py')
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    info = {'spec': spec, 'mod': mod, 'module_name': module_name}
     return {"name": basename(service_folder), "info": info}
 
 
@@ -67,7 +71,7 @@ def get_services(services_folder):
                         not MAINMODULE + ".py" in listdir(name)):
                     continue
                 try:
-                    services.append(create_service_descriptor(name))
+                    services.append(create_service_spec(name))
                 except Exception:
                     LOG.error('Failed to create service from ' + name,
                               exc_info=True)
@@ -75,7 +79,7 @@ def get_services(services_folder):
                 not MAINMODULE + ".py" in listdir(location)):
             continue
         try:
-            services.append(create_service_descriptor(location))
+            services.append(create_service_spec(location))
         except Exception:
             LOG.error('Failed to create service from ' + location,
                       exc_info=True)
@@ -100,8 +104,11 @@ def load_services(config, bus, path=None):
     for descriptor in service_directories:
         LOG.info('Loading ' + descriptor['name'])
         try:
-            service_module = imp.load_module(descriptor["name"] + MAINMODULE,
-                                             *descriptor["info"])
+            service_module = descriptor['info']['mod']
+            spec = descriptor['info']['spec']
+            module_name = descriptor['info']['module_name']
+            sys.modules[module_name] = service_module
+            spec.loader.exec_module(service_module)
         except Exception as e:
             LOG.error('Failed to import module ' + descriptor['name'] + '\n' +
                       repr(e))

--- a/test/integrationtests/skills/discover_tests.py
+++ b/test/integrationtests/skills/discover_tests.py
@@ -16,12 +16,13 @@ import pytest
 
 import glob
 import os
-from os.path import exists, join, expanduser, abspath
-import imp
+from os.path import join, expanduser, abspath
 
 from mycroft.configuration import Configuration
 from test.integrationtests.skills.skill_tester import MockSkillsLoader
 from test.integrationtests.skills.skill_tester import SkillTest
+
+from .runner import load_test_environment
 
 
 def discover_tests(skills_dir):
@@ -43,16 +44,7 @@ def discover_tests(skills_dir):
 
     for skill in skills:
         # Load test environment file
-        test_env = None
-        if exists(os.path.join(skill, 'test/__init__.py')):
-            module = imp.load_source(skill + '.test_env',
-                                     os.path.join(skill, 'test/__init__.py'))
-            if (hasattr(module, 'test_runner') and
-                    callable(module.test_runner) or
-                    hasattr(module, 'test_setup') and
-                    callable(module.test_setup)):
-                test_env = module
-
+        test_env = load_test_environment(skill)
         # Find all intent test files
         test_intent_files = [
             (f, test_env) for f

--- a/test/integrationtests/skills/runner.py
+++ b/test/integrationtests/skills/runner.py
@@ -27,7 +27,7 @@ import unittest
 import os
 from os.path import exists
 import sys
-import imp
+import importlib
 import argparse
 from test.integrationtests.skills.skill_tester import MockSkillsLoader
 from test.integrationtests.skills.skill_tester import SkillTest
@@ -45,6 +45,31 @@ parser.add_argument("skill_path", nargs='?', default=os.getcwd(),
 args = parser.parse_args()
 HOME_DIR = os.path.dirname(args.skill_path + '/')
 sys.argv = sys.argv[:1]
+
+
+def load_test_environment(skill):
+    """Load skill's test environment if present
+
+    Arguments:
+        skill (str): path to skill root folder
+
+    Returns:
+        Module if a valid test environment module was found else None
+    """
+    test_env = None
+    test_env_path = os.path.join(skill, 'test/__init__.py')
+    if exists(test_env_path):
+        skill_env = skill + '.test_env'
+        spec = importlib.util.spec_from_file_location(skill_env, test_env_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[skill_env] = module
+        spec.loader.exec_module(module)
+        if (hasattr(module, 'test_runner') and
+                callable(module.test_runner) or
+                hasattr(module, 'test_setup') and
+                callable(module.test_setup)):
+            test_env = module
+    return test_env
 
 
 def discover_tests():
@@ -74,15 +99,7 @@ def discover_tests():
             tests[skill] = test_intent_files
 
         # Load test environment script
-        test_env = None
-        if exists(os.path.join(skill, 'test/__init__.py')):
-            module = imp.load_source(skill + '.test_env',
-                                     os.path.join(skill, 'test/__init__.py'))
-            if (hasattr(module, 'test_runner') and
-                    callable(module.test_runner) or
-                    hasattr(module, 'test_setup') and
-                    callable(module.test_setup)):
-                test_env = module
+        test_env = load_test_environment(skill)
         test_envs[skill] = test_env
 
     return tests, test_envs


### PR DESCRIPTION
## Description
Remove the remaining uses of the old `imp module`

- Audio service loading
- Loading test environment setup code in the old skills integration tests

## How to test
Check that audio services load and that the test runner can run for example the spotify skill (which uses a test environment)

## Contributor license agreement signed?
CLA [ Yes ]
