### PR TITLE
Don't run default update if autoupdate is disabled

### DIFF
--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -226,7 +226,8 @@ class SkillManager(Thread):
         """Load skills and update periodically from disk and internet."""
         self._remove_git_locks()
         self._connected_event.wait()
-        if not self.skill_updater.defaults_installed():
+        if (not self.skill_updater.defaults_installed() and
+                self.skills_config["auto_update"]):
             LOG.info('Not all default skills are installed, '
                      'performing skill update...')
             self.skill_updater.update_skills()


### PR DESCRIPTION
## Description
The default skills check bypassed the autoupdate flag. This makes it respect it.

## How to test
Disable skill autoupdate and remove a default skill, ensure that it's not installed at startup.

## Contributor license agreement signed?
CLA [ Yes ]