### PR TITLE
initialize status members before bus handlers

### DIFF
--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -131,13 +131,14 @@ class SkillManager(Thread):
         self.initial_load_complete = False
         self.num_install_retries = 0
         self.settings_downloader = SkillSettingsDownloader(self.bus)
-        self._define_message_bus_events()
-        self.skill_updater = SkillUpdater()
-        self.daemon = True
 
         # Statuses
         self._alive_status = False  # True after priority skills has loaded
         self._loaded_status = False  # True after all skills has loaded
+
+        self.skill_updater = SkillUpdater()
+        self._define_message_bus_events()
+        self.daemon = True
 
     def _define_message_bus_events(self):
         """Define message bus events with handlers defined in this class."""


### PR DESCRIPTION
## Description
self._loaded_status was accessed from a message handler, if a message is
§received at the precisely wrong time an exception may occur. This fixes
the init order.

This was reported by @j1nx with the following stack trace:

```
2020-02-07 15:51:09.257 | ERROR    |   337 | concurrent.futures | exception calling callback for <Future at 0x7f96356d00 state=finished raised AttributeError>
Traceback (most recent call last):
  File "/usr/lib/python3.8/concurrent/futures/_base.py", line 408, in add_done_callback
    fn(self)
  File "/usr/lib/python3.8/site-packages/pyee/_executor.py", line 60, in _callback
    self.emit('error', exc)
  File "/usr/lib/python3.8/site-packages/pyee/_base.py", line 111, in emit
    self._emit_handle_potential_error(event, args[0] if args else None)
  File "/usr/lib/python3.8/site-packages/pyee/_base.py", line 83, in _emit_handle_potential_error
    raise error
  File "/usr/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/lib/python3.8/site-packages/mycroft/skills/skill_manager.py", line 361, in is_all_loaded
    status = {'status': self._loaded_status}
AttributeError: 'SkillManager' object has no attribute '_loaded_status'
```

In this case it was likely a message from mycroft gui that arrived at precisely the wrong time.

The issue is likely resolved in #2648, but if that PR isn't included this is a quick fix for the issue.

## Contributor license agreement signed?
CLA [ Yes ]