### PR TITLE
Fix vlc audioservice loading

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -40,7 +40,7 @@ def create_service_spec(service_folder):
         Returns:
             Dict with import information
     """
-    module_name = basename(service_folder)
+    module_name = 'audioservice_' + basename(service_folder)
     path = join(service_folder, MAINMODULE + '.py')
     spec = importlib.util.spec_from_file_location(module_name, path)
     mod = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Description
Set a more specific module name for audioservices

The basic name caused collisions between the "vlc" audioservice and the
vlc module. This prepends an "audioservice_" to the service folder name. vlc would not load with the error message

```
2020-08-31 17:22:02.653 | INFO     | 22637 | mycroft.audio.audioservice:load_services:105 | Loading vlc
2020-08-31 17:22:02.655 | ERROR    | 22637 | mycroft.audio.audioservice:load_services:129 | Failed to load service. AttributeError("module 'vlc' has no attribute 'Instance'",)
```
## How to test
Check that the vlc audioservice is properly loaded.

## Contributor license agreement signed?
CLA [ Yes ]