### PR TITLE
Issue-2567 - Fixing not initialized dialog_render

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1134,9 +1134,17 @@ class MycroftSkill:
             wait (bool):            set to True to block while the text
                                     is being spoken.
         """
-        data = data or {}
-        self.speak(self.dialog_renderer.render(key, data),
-                   expect_response, wait, meta={'dialog': key, 'data': data})
+        if self.dialog_renderer:
+            data = data or {}
+            self.speak(
+                self.dialog_renderer.render(key, data),
+                expect_response, wait, meta={'dialog': key, 'data': data}
+            )
+        else:
+            self.log.warning(
+                'dialog_render is None, does the locale/dialog folder exists?'
+            )
+            self.speak(key, expect_response, wait, {})
 
     def acknowledge(self):
         """Acknowledge a successful request.

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1142,7 +1142,7 @@ class MycroftSkill:
             )
         else:
             self.log.warning(
-                'dialog_render is None, does the locale/dialog folder exists?'
+                'dialog_render is None, does the locale/dialog folder exist?'
             )
             self.speak(key, expect_response, wait, {})
 

--- a/test/unittests/skills/test_common_query_skill.py
+++ b/test/unittests/skills/test_common_query_skill.py
@@ -48,14 +48,6 @@ class TestCommonQuerySkill(TestCase):
         self.skill.CQS_action.assert_called_once_with(
             'What\'s the meaning of life', None)
 
-    def test_speak_dialog_render_not_intialized(self):
-        """Test that non-initialzed dialog_renderer won't raise an error."""
-        skill = CQSTest()
-        bus = mock.Mock(name='bus')
-        skill.bind(bus)
-        skill.dialog_renderer = None
-        skill.speak_dialog(key='key')
-
 
 class TestCommonQueryMatching(TestCase):
     """Tests for CQS_match_query_phrase."""

--- a/test/unittests/skills/test_common_query_skill.py
+++ b/test/unittests/skills/test_common_query_skill.py
@@ -48,6 +48,14 @@ class TestCommonQuerySkill(TestCase):
         self.skill.CQS_action.assert_called_once_with(
             'What\'s the meaning of life', None)
 
+    def test_speak_dialog_render_not_intialized(self):
+        """Test that non-initialzed dialog_renderer won't raise an error."""
+        skill = CQSTest()
+        bus = mock.Mock(name='bus')
+        skill.bind(bus)
+        skill.dialog_renderer = None
+        skill.speak_dialog(key='key')
+
 
 class TestCommonQueryMatching(TestCase):
     """Tests for CQS_match_query_phrase."""

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -602,6 +602,13 @@ class TestMycroftSkill(unittest.TestCase):
         # Restore lang to en-us
         s.config_core['lang'] = 'en-us'
 
+    def test_speak_dialog_render_not_intialized(self):
+        """Test that non-initialzed dialog_renderer won't raise an error."""
+        s = SimpleSkill1()
+        s.bind(self.emitter)
+        s.dialog_renderer = None
+        s.speak_dialog(key='key')
+
 
 class _TestSkill(MycroftSkill):
     def __init__(self):

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -603,7 +603,7 @@ class TestMycroftSkill(unittest.TestCase):
         s.config_core['lang'] = 'en-us'
 
     def test_speak_dialog_render_not_initialized(self):
-        """Test that non-initialzed dialog_renderer won't raise an error."""
+        """Test that non-initialized dialog_renderer won't raise an error."""
         s = SimpleSkill1()
         s.bind(self.emitter)
         s.dialog_renderer = None

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -602,7 +602,7 @@ class TestMycroftSkill(unittest.TestCase):
         # Restore lang to en-us
         s.config_core['lang'] = 'en-us'
 
-    def test_speak_dialog_render_not_intialized(self):
+    def test_speak_dialog_render_not_initialized(self):
         """Test that non-initialzed dialog_renderer won't raise an error."""
         s = SimpleSkill1()
         s.bind(self.emitter)


### PR DESCRIPTION
## Description
Fix for issue #2567 

## How to test
Run `test/unittests/skills/test_mycroft_skill.py` to ensure that `test_speak_dialog_render_not_intialized` won't fail

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
