### PR TITLE
{start,stop}-mycroft.sh: allow system-wide setups

### DIFF
--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright 2017 Mycroft AI Inc.
 #
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SOURCE="${BASH_SOURCE[0]}"
+# This script is never sourced but always directly executed, so this is safe to do
+SOURCE="$0"
 
 script=${0}
 script=${script##*/}
@@ -22,7 +23,7 @@ cd -P "$( dirname "$SOURCE" )" || exit
 DIR="$( pwd )"
 VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${DIR}/.venv"}
 
-function help() {
+help() {
     echo "${script}:  Mycroft command/service launcher"
     echo "usage: ${script} [COMMAND] [restart] [params]"
     echo
@@ -60,7 +61,7 @@ function help() {
 }
 
 _module=""
-function name-to-script-path() {
+name_to_script_path() {
     case ${1} in
         "bus")               _module="mycroft.messagebus.service" ;;
         "skills")            _module="mycroft.skills" ;;
@@ -77,48 +78,50 @@ function name-to-script-path() {
     esac
 }
 
-function source-venv() {
-    # Enter Python virtual environment, unless under Docker
-    if [ ! -f "/.dockerenv" ] ; then
+source_venv() {
+    # Enter Python virtual environment, unless under Docker or when a virtualenv is already active
+    virtualenv=$(python3 -c 'import sys; sys.stdout.write("1") if (hasattr(sys, "real_prefix") or (hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix)) else sys.stdout.write("0")')
+
+    if [ ! -f "/.dockerenv" ] && [ "$virtualenv" -eq 0 ] ; then
         # shellcheck source=/dev/null
-        source "${VIRTUALENV_ROOT}"/bin/activate
+        . "${VIRTUALENV_ROOT}"/bin/activate
     fi
 }
 
 first_time=true
-function init-once() {
+init_once() {
     if ($first_time) ; then
         echo "Initializing..."
         "${DIR}/scripts/prepare-msm.sh"
-        source-venv
+        source_venv
         first_time=false
     fi
 }
 
-function launch-process() {
-    init-once
+launch_process() {
+    init_once
 
-    name-to-script-path "${1}"
+    name_to_script_path "${1}"
 
     # Launch process in foreground
     echo "Starting $1"
     python3 -m ${_module} "$_params"
 }
 
-function require-process() {
+require_process() {
     # Launch process if not found
-    name-to-script-path "${1}"
+    name_to_script_path "${1}"
     if ! pgrep -f "python3 (.*)-m ${_module}" > /dev/null ; then
         # Start required process
-        launch-background "${1}"
+        launch_background "${1}"
     fi
 }
 
-function launch-background() {
-    init-once
+launch_background() {
+    init_once
 
     # Check if given module is running and start (or restart if running)
-    name-to-script-path "${1}"
+    name_to_script_path "${1}"
     if pgrep -f "python3 (.*)-m ${_module}" > /dev/null ; then
         if ($_force_restart) ; then
             echo "Restarting: ${1}"
@@ -132,7 +135,7 @@ function launch-background() {
     fi
 
     # Security warning/reminder for the user
-    if [[ "${1}" == "bus" ]] ; then
+    if [ "${1}" = "bus" ] ; then
         echo "CAUTION: The Mycroft bus is an open websocket with no built-in security"
         echo "         measures.  You are responsible for protecting the local port"
         echo "         8181 with a firewall as appropriate."
@@ -142,29 +145,29 @@ function launch-background() {
     python3 -m ${_module} "$_params" >> /var/log/mycroft/"${1}".log 2>&1 &
 }
 
-function launch-all() {
+launch_all() {
     echo "Starting all mycroft-core services"
-    launch-background bus
-    launch-background skills
-    launch-background audio
-    launch-background voice
-    launch-background enclosure
+    launch_background bus
+    launch_background skills
+    launch_background audio
+    launch_background voice
+    launch_background enclosure
 }
 
-function check-dependencies() {
+check_dependencies() {
     if [ -f .dev_opts.json ] ; then
         auto_update=$( jq -r ".auto_update" < .dev_opts.json 2> /dev/null)
     else
         auto_update="false"
     fi
-    if [ "$auto_update" == "true" ] ; then
+    if [ "$auto_update" = "true" ] ; then
         # Check github repo for updates (e.g. a new release)
         git pull
     fi
 
-    if [ ! -f .installed ] || ! md5sum -c &> /dev/null < .installed ; then
+    if [ ! -f .installed ] || ! md5sum -c 2>&1 > /dev/null < .installed ; then
         # Critical files have changed, dev_setup.sh should be run again
-        if [ "$auto_update" == "true" ] ; then
+        if [ "$auto_update" = "true" ] ; then
             echo "Updating dependencies..."
             bash dev_setup.sh
         else
@@ -181,9 +184,9 @@ function check-dependencies() {
 _opt=$1
 _force_restart=false
 shift
-if [[ "${1}" == "restart" ]] || [[ "${_opt}" == "restart" ]] ; then
+if [ "${1}" = "restart" ] || [ "${_opt}" = "restart" ] ; then
     _force_restart=true
-    if [[ "${_opt}" == "restart" ]] ; then
+    if [ "${_opt}" = "restart" ] ; then
         # Support "start-mycroft.sh restart all" as well as "start-mycroft.sh all restart"
         _opt=$1
     fi
@@ -191,70 +194,70 @@ if [[ "${1}" == "restart" ]] || [[ "${_opt}" == "restart" ]] ; then
 fi
 _params=$*
 
-check-dependencies
+check_dependencies
 
 case ${_opt} in
     "all")
-        launch-all
+        launch_all
         ;;
 
     "bus")
-        launch-background "${_opt}"
+        launch_background "${_opt}"
         ;;
     "audio")
-        launch-background "${_opt}"
+        launch_background "${_opt}"
         ;;
     "skills")
-        launch-background "${_opt}"
+        launch_background "${_opt}"
         ;;
     "voice")
-        launch-background "${_opt}"
+        launch_background "${_opt}"
         ;;
 
     "debug")
-        launch-all
-        launch-process cli
+        launch_all
+        launch_process cli
         ;;
 
     "cli")
-        require-process bus
-        require-process skills
-        launch-process "${_opt}"
+        require_process bus
+        require_process skills
+        launch_process "${_opt}"
         ;;
 
     # TODO: Restore support for Wifi Setup on a Picroft, etc.
     # "wifi")
-    #    launch-background ${_opt}
+    #    launch_background ${_opt}
     #    ;;
     "unittest")
-        source-venv
+        source_venv
         pytest test/unittests/ --cov=mycroft "$@"
         ;;
     "singleunittest")
-        source-venv
+        source_venv
         pytest "$@"
         ;;
     "skillstest")
-        source-venv
+        source_venv
         pytest test/integrationtests/skills/discover_tests.py "$@"
         ;;
     "vktest")
-        source "$DIR/bin/mycroft-skill-testrunner" vktest "$@"
+        bash "$DIR/bin/mycroft-skill-testrunner" vktest "$@"
         ;;
     "audiotest")
-        launch-process "${_opt}"
+        launch_process "${_opt}"
         ;;
     "wakewordtest")
-        launch-process "${_opt}"
+        launch_process "${_opt}"
         ;;
     "sdkdoc")
-        source-venv
+        source_venv
         cd doc || exit
         make "${_params}"
         cd ..
         ;;
     "enclosure")
-        launch-background "${_opt}"
+        launch_background "${_opt}"
         ;;
 
     *)

--- a/stop-mycroft.sh
+++ b/stop-mycroft.sh
@@ -18,7 +18,7 @@ SOURCE="${BASH_SOURCE[0]}"
 
 script=${0}
 script=${script##*/}
-cd -P "$( dirname "$SOURCE" )"
+cd -P "$( dirname "$SOURCE" )" || exit
 
 function help() {
     echo "${script}:  Mycroft service stopper"
@@ -49,16 +49,16 @@ function process-running() {
 }
 
 function end-process() {
-    if process-running $1 ; then
+    if process-running "$1" ; then
         # Find the process by name, only returning the oldest if it has children
         pid=$( pgrep -o -f "python3 (.*)-m mycroft.*${1}" )
         echo -n "Stopping $1 (${pid})..."
-        kill -SIGINT ${pid}
+        kill -SIGINT "${pid}"
 
         # Wait up to 5 seconds (50 * 0.1) for process to stop
         c=1
         while [ $c -le 50 ] ; do
-            if process-running $1 ; then
+            if process-running "$1" ; then
                 sleep 0.1
                 (( c++ ))
             else
@@ -66,11 +66,11 @@ function end-process() {
             fi
         done
 
-        if process-running $1 ; then
+        if process-running "$1" ; then
             echo "failed to stop."
             pid=$( pgrep -o -f "python3 (.*)-m mycroft.*${1}" )            
             echo -n "  Killing $1 (${pid})..."
-            kill -9 ${pid}
+            kill -9 "${pid}"
             echo "killed."
             result=120
         else

--- a/stop-mycroft.sh
+++ b/stop-mycroft.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 # Copyright 2017 Mycroft AI Inc.
 #
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SOURCE="${BASH_SOURCE[0]}"
+# This script is never sourced but always directly executed, so this is safe to do
+SOURCE="$0"
 
 script=${0}
 script=${script##*/}
 cd -P "$( dirname "$SOURCE" )" || exit
 
-function help() {
+help() {
     echo "${script}:  Mycroft service stopper"
     echo "usage: ${script} [service]"
     echo
@@ -40,36 +41,36 @@ function help() {
     exit 0
 }
 
-function process-running() {
-    if [[ $( pgrep -f "python3 (.*)-m mycroft.*${1}" ) ]] ; then
+process_running() {
+    if [ "$( pgrep -f "python3 (.*)-m mycroft.*${1}" )" ] ; then
         return 0
     else
         return 1
     fi
 }
 
-function end-process() {
-    if process-running "$1" ; then
+end_process() {
+    if process_running "$1" ; then
         # Find the process by name, only returning the oldest if it has children
         pid=$( pgrep -o -f "python3 (.*)-m mycroft.*${1}" )
-        echo -n "Stopping $1 (${pid})..."
+        printf "Stopping %s (%s)..." "$1" "${pid}"
         kill -SIGINT "${pid}"
 
         # Wait up to 5 seconds (50 * 0.1) for process to stop
         c=1
         while [ $c -le 50 ] ; do
-            if process-running "$1" ; then
+            if process_running "$1" ; then
                 sleep 0.1
-                (( c++ ))
+		c=$((c + 1))
             else
                 c=999   # end loop
             fi
         done
 
-        if process-running "$1" ; then
+        if process_running "$1" ; then
             echo "failed to stop."
             pid=$( pgrep -o -f "python3 (.*)-m mycroft.*${1}" )            
-            echo -n "  Killing $1 (${pid})..."
+            printf "  Killing %s (%s)..." "$1" "${pid}"
             kill -9 "${pid}"
             echo "killed."
             result=120
@@ -90,30 +91,28 @@ OPT=$1
 shift
 
 case ${OPT} in
-    "all")
-        ;&
-    "")
+    ""|"all")
         echo "Stopping all mycroft-core services"
-        end-process skills
-        end-process audio
-        end-process speech
-        end-process enclosure
-        end-process messagebus.service
+        end_process skills
+        end_process audio
+        end_process speech
+        end_process enclosure
+        end_process messagebus.service
         ;;
     "bus")
-        end-process messagebus.service
+        end_process messagebus.service
         ;;
     "audio")
-        end-process audio
+        end_process audio
         ;;
     "skills")
-        end-process skills
+        end_process skills
         ;;
     "voice")
-        end-process speech
+        end_process speech
         ;;
     "enclosure")
-        end-process enclosure
+        end_process enclosure
         ;;
 
     *)

--- a/stop-mycroft.sh
+++ b/stop-mycroft.sh
@@ -19,7 +19,19 @@ SOURCE="$0"
 
 script=${0}
 script=${script##*/}
-cd -P "$( dirname "$SOURCE" )" || exit
+
+# If we're running systemwide it means MyCroft has been installed from distribution packaging
+# In this case, some things like sourcing the virtual environment shouldn't happen
+# Check if we're running systemwide by testing if the script is called start-mycroft.sh
+# (which would be an in-source installation) or start-mycroft (which would be distro packaging)
+systemwide=false
+if [ "${script#*.sh}" = "$script" ]; then
+	systemwide=true
+fi
+
+if [ $systemwide = false ]; then
+    cd -P "$( dirname "$SOURCE" )" || exit
+fi
 
 help() {
     echo "${script}:  Mycroft service stopper"


### PR DESCRIPTION
## Description
This allows `start-mycroft.sh` and `stop-mycroft.sh` to start and stop MyCroft when it's installed system-wide, assuming the files are installed as `start-mycroft` and `stop-mycroft` (so without the `.sh` extension). This is especially useful for distribution packaging which won't have a git checkout with the source and a virtualenv available and can probably be used for Pip as well.

Note that this PR depends on #2686 and shouldn't be merged without it. I'll rebase this PR on the latest `dev` when #2686 is merged.

## How to test
Install MyCroft system wide (e.g. `python3 setup.py install --prefix=/usr --root=/`, make sure you have all the deps installed system-wide!), copy/rename `start-mycroft.sh` to `start-mycroft` and optionally put it in `/usr/bin`. Then just run `start-mycroft all`. Do the same for `stop-mycroft.sh`.

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)


Fixes #2191