### PR TITLE
Fix Audioservice startup

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -17,11 +17,12 @@ import sys
 import time
 from os import listdir
 from os.path import abspath, dirname, basename, isdir, join
-from threading import Lock, Event
+from threading import Lock
 
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
+from mycroft.util.monotonic_event import MonotonicEvent
 
 from .services import RemoteAudioBackend
 
@@ -152,7 +153,7 @@ class AudioService:
         self.play_start_time = 0
         self.volume_is_low = False
 
-        self._loaded = Event()
+        self._loaded = MonotonicEvent()
         bus.once('open', self.load_services_callback)
 
     def load_services_callback(self):
@@ -161,7 +162,6 @@ class AudioService:
             service and default and registers the event handlers for the
             subsystem.
         """
-
         services = load_services(self.config, self.bus)
         # Sort services so local services are checked first
         local = [s for s in services if not isinstance(s, RemoteAudioBackend)]

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -24,13 +24,14 @@ from contextlib import suppress
 from glob import glob
 from os.path import dirname, exists, join, abspath, expanduser, isfile, isdir
 from shutil import rmtree
-from threading import Timer, Event, Thread
+from threading import Timer, Thread
 from urllib.error import HTTPError
 
 from petact import install_package
 
 from mycroft.configuration import Configuration, LocalConf, USER_CONFIG
 from mycroft.util.log import LOG
+from mycroft.util.monotonic_event import MonotonicEvent
 
 RECOGNIZER_DIR = join(abspath(dirname(__file__)), "recognizer")
 INIT_TIMEOUT = 10  # In seconds
@@ -402,7 +403,7 @@ class HotWordFactory:
     def load_module(module, hotword, config, lang, loop):
         LOG.info('Loading "{}" wake word via {}'.format(hotword, module))
         instance = None
-        complete = Event()
+        complete = MonotonicEvent()
 
         def initialize():
             nonlocal instance, complete

--- a/mycroft/util/monotonic_event.py
+++ b/mycroft/util/monotonic_event.py
@@ -1,0 +1,63 @@
+# Copyright 2017 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Events with respect for montonic time.
+
+The MontonicEvent class defined here wraps the normal class ensuring that
+changes in system time are handled.
+"""
+from threading import Event
+from time import sleep, monotonic
+
+from mycroft.util.log import LOG
+
+
+class MonotonicEvent(Event):
+    """Event class with monotonic timeout.
+
+    Normal Event doesn't do wait timeout in a monotonic manner and may be
+    affected by changes in system time. This class wraps the Event class
+    wait() method with logic guards ensuring monotonic operation.
+    """
+    def wait_timeout(self, timeout):
+        """Handle timeouts in a monotonic way.
+
+        Repeatingly wait as long the event hasn't been set and the
+        monotonic time doesn't indicate a timeout.
+
+        Arguments:
+            timeout: timeout of wait in seconds
+
+        Returns:
+            True if Event has been set, False if timeout expired
+        """
+        result = False
+        end_time = monotonic() + timeout
+
+        while not result and (monotonic() < end_time):
+            # Wait however many seconds are left until the timeout has passed
+            sleep(0.1)  # Mainly a precaution to not busy wait
+            remaining_time = end_time - monotonic()
+            LOG.debug('Will wait for {} sec for Event'.format(remaining_time))
+            result = super().wait(remaining_time)
+
+        return result
+
+    def wait(self, timeout=None):
+        if timeout is None:
+            ret = super().wait()
+        else:
+            ret = self.wait_timeout(timeout)
+        return ret

--- a/test/unittests/util/test_monotonic_event.py
+++ b/test/unittests/util/test_monotonic_event.py
@@ -1,0 +1,32 @@
+from threading import Thread
+from time import sleep
+from unittest import TestCase, mock
+
+from mycroft.util.monotonic_event import MonotonicEvent
+
+
+class MonotonicEventTest(TestCase):
+    def test_wait_set(self):
+        event = MonotonicEvent()
+        event.set()
+        self.assertTrue(event.wait())
+
+    def test_wait_timeout(self):
+        event = MonotonicEvent()
+        self.assertFalse(event.wait(0.1))
+
+    def test_wait_set_with_timeout(self):
+        wait_result = False
+        event = MonotonicEvent()
+
+        def wait_event():
+            nonlocal wait_result
+            wait_result = event.wait(30)
+
+        wait_thread = Thread(target=wait_event)
+        wait_thread.start()
+
+        sleep(0.1)
+        event.set()
+        wait_thread.join()
+        self.assertTrue(wait_result)


### PR DESCRIPTION
## Description
Handle ntp sync in audioservice ready wait. Events (and [python threading in general](https://bugs.python.org/issue41710)) don't use monotonic time and can be affected by an ntp sync.

The log from @krisgesling shows the following

```
2020-04-01 17:24:12.190 | INFO     |   467 | __main__:main:50 | Starting Audio Services
2020-04-01 17:24:12.198 | INFO     |   467 | mycroft.messagebus.client.client:on_open:114 | Connected
2020-04-01 17:24:12.204 | INFO     |   467 | mycroft.audio.audioservice:get_services:61 | Loading services from /home/mycroft/mycroft-core/mycroft/audio/services/
2020-04-01 17:24:12.215 | INFO     |   467 | mycroft.audio.audioservice:load_services:105 | Loading chromecast
2020-09-02 02:02:49.463 | ERROR    |   467 | __main__:on_error:34 | Audio service failed to launch ('No audio services loaded').
```

Notice the timestamp difference on the two last entries. Between these the time jumped ~5 months which is longer than the 3 minute timeout on the wait. **Likely** (possibly/maybe) network connection was established during this time adjusting the time and thus ending the Event wait.

This adds logic to repeat the wait if the monotonic time don't agree with the event timeout.

## How to test
It's sort of tricky to test in a good way. Firstly make sure the audioservice starts in normal circumstances (run the service, add a delay in loading services and make sure the result of the wait is as expected).

Secondly try to repeat the actual issue using the `date` command:
- inject a long sleep (`time.sleep(300)` on L204
- launch the audio service
- run `sudo date +%T -s "HH:MM:SS"` with a suitable clock time in the future

Make sure the service doesn't exit directly, but waits the expected 3 minutes before shutting down.
## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
