### PR TITLE
Add support for `doas`

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -127,6 +127,8 @@ function found_exe() {
 
 if found_exe sudo ; then
     SUDO=sudo
+elif found_exe doas ; then
+    SUDO=doas
 elif [[ $opt_allowroot != true ]]; then
     echo 'This script requires "sudo" to install system packages. Please install it, then re-run this script.'
     exit 1


### PR DESCRIPTION
This adds support for `doas`, an alternative to `sudo`.

## How to test
Run `bash dev_setup.sh` on a system with `doas` installed and in PATH, and with sudo either not installed, or not in the PATH.

## Contributor license agreement signed?

Not yet; I've filed the form, and am waiting for the email.
