### PR TITLE
Bugfix/duration stretch update

### DIFF
--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -136,7 +136,7 @@ class Mimic(TTS):
 
         args = [mimic_bin, '-voice', voice, '-psdur', '-ssml']
 
-        stretch = config.get('duration_stretch', None)
+        stretch = self.config.get('duration_stretch', None)
         if stretch:
             args += ['--setf', 'duration_stretch=' + stretch]
         return args

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -29,10 +29,10 @@ from mycroft.util.log import LOG
 
 from .tts import TTS, TTSValidator
 
-config = Configuration.get().get("tts").get("mimic")
-data_dir = expanduser(Configuration.get()['data_dir'])
+CONFIG = Configuration.get().get("tts").get("mimic")
+DATA_DIR = expanduser(Configuration.get()['data_dir'])
 
-BIN = config.get("path",
+BIN = CONFIG.get("path",
                  os.path.join(MYCROFT_ROOT_PATH, 'mimic', 'bin', 'mimic'))
 
 if not os.path.isfile(BIN):
@@ -41,7 +41,7 @@ if not os.path.isfile(BIN):
 
     BIN = distutils.spawn.find_executable("mimic")
 
-SUBSCRIBER_VOICES = {'trinity': join(data_dir, 'voices/mimic_tn')}
+SUBSCRIBER_VOICES = {'trinity': join(DATA_DIR, 'voices/mimic_tn')}
 
 
 def download_subscriber_voices(selected_voice):

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -138,7 +138,7 @@ class Mimic(TTS):
 
         stretch = self.config.get('duration_stretch', None)
         if stretch:
-            args += ['--setf', 'duration_stretch=' + stretch]
+            args += ['--setf', 'duration_stretch={}'.format(stretch)]
         return args
 
     def get_tts(self, sentence, wav_file):


### PR DESCRIPTION
## Description
Chat user *hniazi* discovered that the `duration_stretch` setting wasn't updated as expected when configuration was updated. It turned out the method looked a global scoped config and not the object specific config. This fixes that issue.

It also changes the global variable names to uppercase to make this kind of issue harder happen again.


## How to test

Add a tts section to your user's config file

```
"tts": {
  "module": "mimic",
  "mimic": {"duration_stretch": "1.3"}
}
```
then trigger a config reload
`python -m mycroft.messagebus.send "configuration.updated"`
Make mycroft talk to hear the slower speech

Change the value to something like "0.5" trigger an update again and make sure mycroft now talks really fast.

## Contributor license agreement signed?
CLA [ Yes ]