### PR TITLE
Feature/Skill-Settings-In-GUI Revised API

### DIFF
--- a/mycroft/enclosure/gui.py
+++ b/mycroft/enclosure/gui.py
@@ -371,25 +371,20 @@ class SkillGUI:
         if isfile(settingmeta_path):
             self.settings_gui_generator.populate(skill_id,
                                                  settingmeta_path,
-                                                 self.skill.settings,
-                                                 "json")
-        else:
-            settingmeta_path = join(self.skill.root_dir,
-                                    "settingsmeta.yaml")
-            self.settings_gui_generator.populate(skill_id,
-                                                 settingmeta_path,
-                                                 self.skill.settings,
-                                                 "yaml")
+                                                 self.skill.settings)
+            apply_handler = skill_id + ".settings.set"
+            update_handler = skill_id + ".settings.update"
+            remove_pagehandler = skill_id + ".settings.remove_page"
+            self.register_handler(apply_handler,
+                                  self._apply_settings)
+            self.register_handler(update_handler,
+                                  self._update_settings)
+            self.register_handler(remove_pagehandler,
+                                  self._remove_settings_display)
 
-        apply_handler = skill_id + ".settings.set"
-        update_handler = skill_id + ".settings.update"
-        remove_pagehandler = skill_id + ".settings.remove_page"
-        self.register_handler(apply_handler,
-                              self._apply_settings)
-        self.register_handler(update_handler,
-                              self._update_settings)
-        self.register_handler(remove_pagehandler,
-                              self._remove_settings_display)
+        else:
+            raise FileNotFoundError("Unable to find setting file for: {}".
+                                    format(skill_id))
 
     def show_settings(self, override_idle=True,
                       override_animations=False):

--- a/mycroft/enclosure/gui.py
+++ b/mycroft/enclosure/gui.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 """ Interface for interacting with the Mycroft gui qml viewer. """
-from os.path import join
+from os.path import join, isfile
 
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
@@ -365,11 +365,22 @@ class SkillGUI:
         updated via Web interface.
         """
         skill_id = self.skill.skill_id
+
         settingmeta_path = join(self.skill.root_dir,
                                 "settingsmeta.json")
-        self.settings_gui_generator.populate(skill_id,
-                                             settingmeta_path,
-                                             self.skill.settings)
+        if isfile(settingmeta_path):
+            self.settings_gui_generator.populate(skill_id,
+                                                 settingmeta_path,
+                                                 self.skill.settings,
+                                                 "json")
+        else:
+            settingmeta_path = join(self.skill.root_dir,
+                                    "settingsmeta.yaml")
+            self.settings_gui_generator.populate(skill_id,
+                                                 settingmeta_path,
+                                                 self.skill.settings,
+                                                 "yaml")
+
         apply_handler = skill_id + ".settings.set"
         update_handler = skill_id + ".settings.update"
         remove_pagehandler = skill_id + ".settings.remove_page"

--- a/mycroft/res/ui/SYSTEM_SkillSettings.qml
+++ b/mycroft/res/ui/SYSTEM_SkillSettings.qml
@@ -256,7 +256,8 @@ Mycroft.Delegate {
         MouseArea {
             anchors.fill: parent
             onClicked: {
-                triggerGuiEvent("mycroft.device.settings", {})
+                var skillevent = skill_id + ".settings.remove_page"
+                triggerGuiEvent(skillevent, {})
             }
         }
     }

--- a/mycroft/res/ui/SYSTEM_SkillSettings.qml
+++ b/mycroft/res/ui/SYSTEM_SkillSettings.qml
@@ -35,7 +35,6 @@ Mycroft.Delegate {
     
     function generate_settings_ui(mData, comp) {
         if (mData.type == "select") {
-            console.log("Got Type Select")
             var newObject = Qt.createComponent("settings_ui/settingButton.qml")
             var available_values = sanitize_values(mData.options.split(";"))
             for (var i = 0; i < available_values.length; i++) {
@@ -44,8 +43,6 @@ Mycroft.Delegate {
             }
         }
         if (mData.type == "checkbox") {
-            console.log("check value = " + mData.value)
-            console.log("I got a new value I am supposed to change here")
             var newObject = Qt.createComponent("settings_ui/settingCheckBox.qml")
             var rbutton = newObject.createObject(comp, {checked: mData.value.toString() == "true" ? 1 : 0, text: mData.value == "true" ? "Disable" : "Enable", "key": mData.name, "value": mData.value});
             rbutton.clicked.connect(selectSettingUpdated)
@@ -67,8 +64,6 @@ Mycroft.Delegate {
     }
     
     function sanitize_values(mValues) {
-        console.log("mVals")
-        console.log(mValues)
         var val_listing = []
         for (var i = 0; i < mValues.length; i++) {
             if (mValues[i].includes('|')) {
@@ -78,7 +73,6 @@ Mycroft.Delegate {
                 val_listing.push(mValues[i])
             }
         }
-        console.log("currentVals")
         console.log(val_listing)
         return val_listing
     }
@@ -87,7 +81,6 @@ Mycroft.Delegate {
         skillConfigView.update()
         console.log(JSON.stringify(skillsConfig))
         if(skillsConfig !== null){
-            console.log("I am not null anymore")
             skillConfigView.model = skillsConfig.sections
             skillSettingsView.skill_id = skillsConfig.skill_id
             var skillname = skill_id.split(".")[0]
@@ -221,101 +214,6 @@ Mycroft.Delegate {
             }
         }
     }
-    
-    //Item {
-        //anchors.top: topArea.bottom
-        //anchors.topMargin: Kirigami.Units.largeSpacing
-        //anchors.left: parent.left
-        //anchors.right: parent.right
-        //anchors.bottom: areaSep.top
-        //anchors.bottomMargin: Kirigami.Units.smallSpacing
-        //clip: true
-        
-        //ColumnLayout {
-            //anchors.fill: parent
-            //spacing: Kirigami.Units.smallSpacing
-            
-            //ListView {
-                //id: skillConfigView
-                //clip: true
-                //Layout.fillWidth: true
-                //Layout.fillHeight: true
-                //boundsBehavior: Flickable.StopAtBounds
-                //spacing: Kirigami.Units.largeSpacing
-                //delegate: Control {
-                    
-                    //background: Rectangle {
-                        //color: "#1d1d1d"
-                        //radius: 10
-                    //}
-                    
-                    //contentItem: Item {
-                    //implicitWidth: skillConfigView.width;
-                    //implicitHeight: delegateLayout.implicitHeight + Kirigami.Units.largeSpacing;
-            
-                        //ColumnLayout {
-                            //id: delegateLayout
-                            //anchors.fill: parent
-                            //anchors.margins: Kirigami.Units.largeSpacing
-                            //spacing: Kirigami.Units.largeSpacing
-                            
-                            //Rectangle {
-                                //color: Kirigami.Theme.linkColor
-                                //Layout.fillWidth: true
-                                //Layout.preferredHeight: skillName.contentHeight + Kirigami.Units.smallSpacing
-                                //radius: 3
-                                
-                                //Kirigami.Heading {
-                                    //id: skillName
-                                    //elide: Text.ElideRight
-                                    //font.weight: Font.DemiBold
-                                    //text: modelData.name
-                                    //width: parent.width
-                                    //verticalAlignment: Text.AlignVCenter
-                                    //horizontalAlignment: Text.AlignHCenter
-                                    //level: 2
-                                //}
-                            //}
-                            
-                            //Repeater {
-                                //model: modelData.fields
-                                //delegate: RowLayout {
-                                    //Layout.alignment: Qt.AlignHCenter
-                                    //spacing: Math.round(Kirigami.Units.gridUnit / 2)
-                                                                    
-                                    //Kirigami.Heading {
-                                        //id: skillSettingName
-                                        //Layout.alignment: Qt.AlignLeft
-                                        //elide: Text.ElideRight
-                                        //text: modelData.name
-                                        //font.capitalization: Font.Capitalize
-                                        //textFormat: Text.AutoText
-                                        //level: 3
-                                    //}
-                                    
-                                    //GridLayout {
-                                        //id: skillSettingType
-                                        //Layout.preferredWidth: Kirigami.Units.gridUnit * 3
-                                        //Layout.alignment: Qt.AlignRight
-                                        //Layout.fillHeight: true
-                                        //columns: 3
-                                                                            
-                                        //ButtonGroup {
-                                            //id: settingGroup
-                                        //}
-                                        
-                                        //Component.onCompleted: {
-                                            //generate_settings_ui(modelData, skillSettingType)
-                                        //}
-                                    //}
-                                //}
-                            //}
-                        //}
-                    //}
-                //}
-            //}
-        //}
-    //}
 
     Kirigami.Separator {
         id: areaSep

--- a/mycroft/res/ui/SYSTEM_SkillSettings.qml
+++ b/mycroft/res/ui/SYSTEM_SkillSettings.qml
@@ -1,0 +1,365 @@
+/*
+ * Copyright 2018 Aditya Mehra <aix.m@outlook.com>
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import QtQuick.Layouts 1.4
+import QtQuick 2.9
+import QtQuick.Controls 2.3
+import org.kde.kirigami 2.11 as Kirigami
+import Mycroft 1.0 as Mycroft
+
+Mycroft.Delegate {
+    id: skillSettingsView
+    anchors.fill: parent
+    property var skillsConfig: sessionData.skillsConfig
+    property var skill_id
+    fillWidth: true
+    
+    function selectSettingUpdated(key, value){
+        var skillevent = skill_id + ".settings.set"
+        triggerGuiEvent(skillevent, {"setting_key": key, "setting_value": value})
+    }
+    
+    function generate_settings_ui(mData, comp) {
+        if (mData.type == "select") {
+            console.log("Got Type Select")
+            var newObject = Qt.createComponent("settings_ui/settingButton.qml")
+            var available_values = sanitize_values(mData.options.split(";"))
+            for (var i = 0; i < available_values.length; i++) {
+                var rbutton = newObject.createObject(comp, {checked: mData.value.toString() == available_values[i] ? 1 : 0 , text: available_values[i], "key": mData.name, "value": available_values[i]});
+                rbutton.clicked.connect(selectSettingUpdated)
+            }
+        }
+        if (mData.type == "checkbox") {
+            console.log("check value = " + mData.value)
+            console.log("I got a new value I am supposed to change here")
+            var newObject = Qt.createComponent("settings_ui/settingCheckBox.qml")
+            var rbutton = newObject.createObject(comp, {checked: mData.value.toString() == "true" ? 1 : 0, text: mData.value == "true" ? "Disable" : "Enable", "key": mData.name, "value": mData.value});
+            rbutton.clicked.connect(selectSettingUpdated)
+        }
+        if (mData.type == "text") {
+            var newObject = Qt.createComponent("settings_ui/settingTextBox.qml")
+            var rbutton = newObject.createObject(comp, {text: mData.value, "key": mData.name, "value": mData.value});
+            rbutton.clicked.connect(selectSettingUpdated)
+        }
+        if (mData.type == "password") {
+            var newObject = Qt.createComponent("settings_ui/settingPasswordBox.qml")
+            var rbutton = newObject.createObject(comp, {text: mData.value, "key": mData.name, "value": mData.value});
+            rbutton.clicked.connect(selectSettingUpdated)
+        }
+        if (mData.type == "label") {
+            var newObject = Qt.createComponent("settings_ui/settingLabelBox.qml")
+            var rbutton = newObject.createObject(comp, {text: mData.label});
+        }
+    }
+    
+    function sanitize_values(mValues) {
+        console.log("mVals")
+        console.log(mValues)
+        var val_listing = []
+        for (var i = 0; i < mValues.length; i++) {
+            if (mValues[i].includes('|')) {
+                var splitVals = mValues[i].split("|")[1]
+                val_listing.push(splitVals.toLowerCase())
+            } else {
+                val_listing.push(mValues[i])
+            }
+        }
+        console.log("currentVals")
+        console.log(val_listing)
+        return val_listing
+    }
+    
+    onSkillsConfigChanged: {
+        skillConfigView.update()
+        console.log(JSON.stringify(skillsConfig))
+        if(skillsConfig !== null){
+            console.log("I am not null anymore")
+            skillConfigView.model = skillsConfig.sections
+            skillSettingsView.skill_id = skillsConfig.skill_id
+            var skillname = skill_id.split(".")[0]
+            configPageHeading.text = skillname.replace("-", " ") + " Configuration"
+        }
+    }
+    
+    Connections {
+        target: Mycroft.MycroftController
+        onIntentRecevied: {
+            console.log(type)
+            if(type == "mycroft.skills.settings.changed"){
+                var skillevent = skill_id + ".settings.update"
+                triggerGuiEvent(skillevent, {})
+            }
+        }
+    }
+    
+    Item {
+        id: topArea
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        height: Kirigami.Units.gridUnit * 2
+        
+        Kirigami.Heading {
+            id: configPageHeading
+            level: 1
+            wrapMode: Text.WordWrap
+            anchors.centerIn: parent
+            font.capitalization: Font.Capitalize
+            font.bold: true
+            color: Kirigami.Theme.linkColor
+        }
+    }
+
+    Flickable {
+        anchors.top: topArea.bottom
+        anchors.topMargin: Kirigami.Units.largeSpacing
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: areaSep.top
+        anchors.bottomMargin: Kirigami.Units.smallSpacing
+        contentHeight: scvGrid.implicitHeight
+        clip: true
+        
+        GridLayout {
+            id: scvGrid
+            width: parent.width
+            height: parent.height
+            columns: scvGrid.width > 600 ? 2 : 1
+            rowSpacing: Kirigami.Units.smallSpacing
+            
+            Repeater {
+                id: skillConfigView
+                clip: true
+
+                delegate: Control {
+                    Layout.alignment: Qt.AlignTop
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    
+                    background: Rectangle {
+                        color: "#1d1d1d"
+                        radius: 10
+                    }
+                    
+                    contentItem: Item {
+                    implicitWidth: scvGrid.width > 600 ? scvGrid.width / 2 : scvGrid.width
+                    implicitHeight: delegateLayout.implicitHeight + Kirigami.Units.largeSpacing;
+            
+                        ColumnLayout {
+                            id: delegateLayout
+                            anchors.fill: parent
+                            anchors.margins: Kirigami.Units.largeSpacing
+                            spacing: Kirigami.Units.largeSpacing
+                            
+                            Rectangle {
+                                color: Kirigami.Theme.linkColor
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: skillName.contentHeight + Kirigami.Units.smallSpacing
+                                radius: 3
+                                
+                                Kirigami.Heading {
+                                    id: skillName
+                                    elide: Text.ElideRight
+                                    font.weight: Font.DemiBold
+                                    text: modelData.name
+                                    width: parent.width
+                                    verticalAlignment: Text.AlignVCenter
+                                    horizontalAlignment: Text.AlignHCenter
+                                    level: 2
+                                }
+                            }
+                            
+                            Repeater {
+                                model: modelData.fields
+                                delegate: RowLayout {
+                                    spacing: Math.round(Kirigami.Units.gridUnit / 2)
+                                                                    
+                                    Kirigami.Heading {
+                                        id: skillSettingName
+                                        Layout.alignment: Qt.AlignLeft
+                                        elide: Text.ElideRight
+                                        text: modelData.name
+                                        font.capitalization: Font.Capitalize
+                                        textFormat: Text.AutoText
+                                        level: 3
+                                    }
+                                    
+                                    GridLayout {
+                                        id: skillSettingType
+                                        Layout.preferredWidth: Kirigami.Units.gridUnit * 3
+                                        Layout.alignment: Qt.AlignRight
+                                        Layout.fillHeight: true
+                                        columns: 3
+                                                                            
+                                        ButtonGroup {
+                                            id: settingGroup
+                                        }
+                                        
+                                        Component.onCompleted: {
+                                            generate_settings_ui(modelData, skillSettingType)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    //Item {
+        //anchors.top: topArea.bottom
+        //anchors.topMargin: Kirigami.Units.largeSpacing
+        //anchors.left: parent.left
+        //anchors.right: parent.right
+        //anchors.bottom: areaSep.top
+        //anchors.bottomMargin: Kirigami.Units.smallSpacing
+        //clip: true
+        
+        //ColumnLayout {
+            //anchors.fill: parent
+            //spacing: Kirigami.Units.smallSpacing
+            
+            //ListView {
+                //id: skillConfigView
+                //clip: true
+                //Layout.fillWidth: true
+                //Layout.fillHeight: true
+                //boundsBehavior: Flickable.StopAtBounds
+                //spacing: Kirigami.Units.largeSpacing
+                //delegate: Control {
+                    
+                    //background: Rectangle {
+                        //color: "#1d1d1d"
+                        //radius: 10
+                    //}
+                    
+                    //contentItem: Item {
+                    //implicitWidth: skillConfigView.width;
+                    //implicitHeight: delegateLayout.implicitHeight + Kirigami.Units.largeSpacing;
+            
+                        //ColumnLayout {
+                            //id: delegateLayout
+                            //anchors.fill: parent
+                            //anchors.margins: Kirigami.Units.largeSpacing
+                            //spacing: Kirigami.Units.largeSpacing
+                            
+                            //Rectangle {
+                                //color: Kirigami.Theme.linkColor
+                                //Layout.fillWidth: true
+                                //Layout.preferredHeight: skillName.contentHeight + Kirigami.Units.smallSpacing
+                                //radius: 3
+                                
+                                //Kirigami.Heading {
+                                    //id: skillName
+                                    //elide: Text.ElideRight
+                                    //font.weight: Font.DemiBold
+                                    //text: modelData.name
+                                    //width: parent.width
+                                    //verticalAlignment: Text.AlignVCenter
+                                    //horizontalAlignment: Text.AlignHCenter
+                                    //level: 2
+                                //}
+                            //}
+                            
+                            //Repeater {
+                                //model: modelData.fields
+                                //delegate: RowLayout {
+                                    //Layout.alignment: Qt.AlignHCenter
+                                    //spacing: Math.round(Kirigami.Units.gridUnit / 2)
+                                                                    
+                                    //Kirigami.Heading {
+                                        //id: skillSettingName
+                                        //Layout.alignment: Qt.AlignLeft
+                                        //elide: Text.ElideRight
+                                        //text: modelData.name
+                                        //font.capitalization: Font.Capitalize
+                                        //textFormat: Text.AutoText
+                                        //level: 3
+                                    //}
+                                    
+                                    //GridLayout {
+                                        //id: skillSettingType
+                                        //Layout.preferredWidth: Kirigami.Units.gridUnit * 3
+                                        //Layout.alignment: Qt.AlignRight
+                                        //Layout.fillHeight: true
+                                        //columns: 3
+                                                                            
+                                        //ButtonGroup {
+                                            //id: settingGroup
+                                        //}
+                                        
+                                        //Component.onCompleted: {
+                                            //generate_settings_ui(modelData, skillSettingType)
+                                        //}
+                                    //}
+                                //}
+                            //}
+                        //}
+                    //}
+                //}
+            //}
+        //}
+    //}
+
+    Kirigami.Separator {
+        id: areaSep
+        anchors.bottom: bottomArea.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        height: 1
+    }
+    
+    Item {
+        id: bottomArea
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: Kirigami.Units.largeSpacing * 1.15
+        height: backIcon.implicitHeight + Kirigami.Units.largeSpacing * 1.15
+
+        RowLayout {
+            anchors.fill: parent
+            
+            Kirigami.Icon {
+                id: backIcon
+                source: "go-previous"
+                Layout.preferredHeight: Kirigami.Units.iconSizes.medium
+                Layout.preferredWidth: Kirigami.Units.iconSizes.medium
+            }
+            
+            Kirigami.Heading {
+                level: 2
+                wrapMode: Text.WordWrap
+                Layout.alignment: Qt.AlignVCenter
+                verticalAlignment: Text.AlignVCenter
+                font.bold: true
+                text: "Back"
+                Layout.fillWidth: true
+                Layout.preferredHeight: Kirigami.Units.gridUnit * 2
+            }
+        }
+        
+        MouseArea {
+            anchors.fill: parent
+            onClicked: {
+                triggerGuiEvent("mycroft.device.settings", {})
+            }
+        }
+    }
+}

--- a/mycroft/res/ui/settings_ui/settingButton.qml
+++ b/mycroft/res/ui/settings_ui/settingButton.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+
+RadioButton {
+    property string buttonId;
+    property var key;
+    property var value;
+    signal clicked(string key, string value);
+    
+    onCheckedChanged: {
+        if(checked){
+            clicked(key, value)
+        }
+    }
+} 

--- a/mycroft/res/ui/settings_ui/settingCheckBox.qml
+++ b/mycroft/res/ui/settings_ui/settingCheckBox.qml
@@ -1,5 +1,6 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.3
+import QtQuick.Layouts 1.4
 
 CheckBox {
     property string buttonId;

--- a/mycroft/res/ui/settings_ui/settingCheckBox.qml
+++ b/mycroft/res/ui/settings_ui/settingCheckBox.qml
@@ -1,0 +1,17 @@
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+
+CheckBox {
+    property string buttonId;
+    property var key;
+    property var value;
+    signal clicked(string key, string value);
+    
+    onCheckedChanged: {
+        if(checked){
+            clicked(key, "true")
+        } else {
+            clicked(key, "false")
+        }
+    }
+}

--- a/mycroft/res/ui/settings_ui/settingLabelBox.qml
+++ b/mycroft/res/ui/settings_ui/settingLabelBox.qml
@@ -1,0 +1,10 @@
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.4
+
+Label {
+    property string buttonId;
+    Layout.fillWidth: true;
+    wrapMode: Text.WordWrap; 
+}
+ 

--- a/mycroft/res/ui/settings_ui/settingLabelBox.qml
+++ b/mycroft/res/ui/settings_ui/settingLabelBox.qml
@@ -1,10 +1,10 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.4
 
 Label {
     property string buttonId;
     Layout.fillWidth: true;
-    wrapMode: Text.WordWrap; 
+    wrapMode: Text.WordWrap;
 }
  

--- a/mycroft/res/ui/settings_ui/settingNumberBox.qml
+++ b/mycroft/res/ui/settings_ui/settingNumberBox.qml
@@ -1,18 +1,18 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.4
+import org.kde.kirigami 2.11 as Kirigami
 
-RadioButton {
+TextField {
     property string buttonId;
     property var key;
     property var value;
     signal clicked(string key, string value);
-    Layout.alignment: Qt.AlignLeft
     Layout.fillWidth: true
+    Layout.minimumHeight: Kirigami.Units.gridUnit * 2
+    inputMethodHints: Qt.ImhFormattedNumbersOnly
     
-    onCheckedChanged: {
-        if(checked){
-            clicked(key, value)
-        }
+    onTextChanged: {
+        clicked(key, text)
     }
-} 
+}

--- a/mycroft/res/ui/settings_ui/settingPasswordBox.qml
+++ b/mycroft/res/ui/settings_ui/settingPasswordBox.qml
@@ -1,0 +1,16 @@
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.4
+
+TextField {
+    property string buttonId;
+    property var key;
+    property var value;
+    signal clicked(string key, string value);
+    echoMode: TextInput.PasswordEchoOnEdit
+    Layout.fillWidth: true
+    
+    onTextChanged: {
+            clicked(key, text)
+    }
+}

--- a/mycroft/res/ui/settings_ui/settingPasswordBox.qml
+++ b/mycroft/res/ui/settings_ui/settingPasswordBox.qml
@@ -1,6 +1,7 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.4
+import org.kde.kirigami 2.11 as Kirigami
 
 TextField {
     property string buttonId;
@@ -9,8 +10,9 @@ TextField {
     signal clicked(string key, string value);
     echoMode: TextInput.PasswordEchoOnEdit
     Layout.fillWidth: true
-    
+    Layout.minimumHeight: Kirigami.Units.gridUnit * 2
+        
     onTextChanged: {
-            clicked(key, text)
+        clicked(key, text)
     }
 }

--- a/mycroft/res/ui/settings_ui/settingTextBox.qml
+++ b/mycroft/res/ui/settings_ui/settingTextBox.qml
@@ -1,0 +1,15 @@
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.4
+
+TextField {
+    property string buttonId;
+    property var key;
+    property var value;
+    signal clicked(string key, string value);
+    Layout.fillWidth: true
+    
+    onTextChanged: {
+            clicked(key, text)
+    }
+}

--- a/mycroft/res/ui/settings_ui/settingTextBox.qml
+++ b/mycroft/res/ui/settings_ui/settingTextBox.qml
@@ -1,6 +1,7 @@
-import QtQuick 2.4
-import QtQuick.Controls 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.4
+import org.kde.kirigami 2.11 as Kirigami
 
 TextField {
     property string buttonId;
@@ -8,8 +9,9 @@ TextField {
     property var value;
     signal clicked(string key, string value);
     Layout.fillWidth: true
+    Layout.minimumHeight: Kirigami.Units.gridUnit * 2
     
     onTextChanged: {
-            clicked(key, text)
+        clicked(key, text)
     }
 }

--- a/mycroft/util/settings_gui_generator.py
+++ b/mycroft/util/settings_gui_generator.py
@@ -16,6 +16,7 @@ import json
 import yaml
 import pathlib
 
+
 class SettingsGuiGenerator:
     """Skill Settings Generator For GUI. """
 

--- a/mycroft/util/settings_gui_generator.py
+++ b/mycroft/util/settings_gui_generator.py
@@ -14,7 +14,7 @@
 #
 import json
 import yaml
-
+import pathlib
 
 class SettingsGuiGenerator:
     """Skill Settings Generator For GUI. """
@@ -23,7 +23,7 @@ class SettingsGuiGenerator:
         """ Create a SettingList Object """
         self.settings_list = []
 
-    def populate(self, skill_id, settings_file, settings_dict, file_type):
+    def populate(self, skill_id, settings_file, settings_dict):
         """
         Populates settings list for current skill.
 
@@ -32,8 +32,9 @@ class SettingsGuiGenerator:
             settings_file: Settings meta file from skill folder.
             settings_dict: Dictionary of current settings.json file.
         """
+        file_type = pathlib.Path(settings_file).suffix
 
-        if file_type == "json":
+        if file_type == ".json":
             with open(settings_file, 'r') as f:
                 settingsmeta_dict = json.load(f)
 
@@ -41,7 +42,7 @@ class SettingsGuiGenerator:
                 for section in __skillMetaData.get('sections'):
                     self.settings_list.append(section)
 
-        if file_type == "yaml":
+        if file_type == ".yaml":
             with open(settings_file, 'r') as f:
                 settingsmeta_dict = yaml.safe_load(f)
 

--- a/mycroft/util/settings_gui_generator.py
+++ b/mycroft/util/settings_gui_generator.py
@@ -1,0 +1,78 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import json
+
+
+class SettingsGuiGenerator:
+    """Skill Settings Generator For GUI. """
+
+    def __init__(self):
+        """ Create a SettingList Object """
+        self.settings_list = []
+
+    def populate(self, skill_id, settings_file, settings_dict):
+        """
+        Populates settings list for current skill.
+
+        Arguments:
+            skill_id: ID of target skill.
+            settings_file: Settings meta file from skill folder.
+            settings_dict: Dictionary of current settings.json file.
+        """
+        with open(settings_file, 'r') as f:
+            settingsmeta_dict = json.load(f)
+
+            __skillMetaData = settingsmeta_dict.get('skillMetadata')
+            for section in __skillMetaData.get('sections'):
+                self.settings_list.append(section)
+
+        if settings_dict is not None:
+            __updated_list = []
+            for sections in self.settings_list:
+                for fields in sections['fields']:
+                    if "name" in fields:
+                        if fields["name"] in settings_dict.keys():
+                            fields["value"] = settings_dict[fields["name"]]
+
+                __updated_list.append(sections)
+
+            self.clear()
+            self.settings_list = __updated_list
+
+    def fetch(self):
+        """Return Settings List """
+        return self.settings_list
+
+    def clear(self):
+        """Clear Settings List """
+        self.settings_list.clear()
+
+    def update(self, settings_dict):
+        """Getting Changed Settings & Update List.
+
+        Arguments:
+        settings_dict: Dictionary of current settings.json file.
+        """
+        __updated_list = []
+        for sections in self.settings_list:
+            for fields in sections['fields']:
+                if "name" in fields:
+                    if fields["name"] in settings_dict.keys():
+                        fields["value"] = settings_dict[fields["name"]]
+
+            __updated_list.append(sections)
+
+        self.clear()
+        self.settings_list = __updated_list

--- a/mycroft/util/settings_gui_generator.py
+++ b/mycroft/util/settings_gui_generator.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import json
+import yaml
 
 
 class SettingsGuiGenerator:
@@ -22,7 +23,7 @@ class SettingsGuiGenerator:
         """ Create a SettingList Object """
         self.settings_list = []
 
-    def populate(self, skill_id, settings_file, settings_dict):
+    def populate(self, skill_id, settings_file, settings_dict, file_type):
         """
         Populates settings list for current skill.
 
@@ -31,12 +32,22 @@ class SettingsGuiGenerator:
             settings_file: Settings meta file from skill folder.
             settings_dict: Dictionary of current settings.json file.
         """
-        with open(settings_file, 'r') as f:
-            settingsmeta_dict = json.load(f)
 
-            __skillMetaData = settingsmeta_dict.get('skillMetadata')
-            for section in __skillMetaData.get('sections'):
-                self.settings_list.append(section)
+        if file_type == "json":
+            with open(settings_file, 'r') as f:
+                settingsmeta_dict = json.load(f)
+
+                __skillMetaData = settingsmeta_dict.get('skillMetadata')
+                for section in __skillMetaData.get('sections'):
+                    self.settings_list.append(section)
+
+        if file_type == "yaml":
+            with open(settings_file, 'r') as f:
+                settingsmeta_dict = yaml.safe_load(f)
+
+                __skillMetaData = settingsmeta_dict.get('skillMetadata')
+                for section in __skillMetaData.get('sections'):
+                    self.settings_list.append(section)
 
         if settings_dict is not None:
             __updated_list = []


### PR DESCRIPTION
## Description
**Adds the ability for a skill display its skill configuration parsed from Settings Meta JSON in skill GUI.**
This Feature is a complete refactor over the previous implementation https://github.com/MycroftAI/mycroft-core/pull/2175, and works independently of any enclosure / platform skill.

It provides a cleaner and simpler interface for displaying Active Skills settings in GUI.

Adds two methods for skill authors:
- self.gui.register_settings(): Allows skills authors to register their skill configuration in GUI, Adds additional GUI handler events on registration to handle syncing and applying skill settings in the GUI UI interface.
- self.gui.display_settings(): Generates UI interface with settings as per the sections and fields on the fly as defined in the Settings Meta JSON with sync from settings.json and Displays the active skill settings in GUI.

The helper util class used internally is responsible for performing the following actions:
- Populate: Reads the Settings Meta JSON and skills own Settings dictionary to create a data model with synced values for GUI to parse.
- Fetch: Returns the populated data model.
- Update: Performs a sync on the new and updated values from Settings.JSON when settings are updated on the web interface and updates the data model parsed in GUI. 
- Clear: Clears the previous data model.

## How to test
```
def initialize(self):
    self.gui.register_settings()

def display_settings(self): 
    # Example function to call display settings 
    # Can be registered with a voice intent, or connected to any button click event in GUI.
    self.gui.show_settings()
```

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
