### PR TITLE
Update gtts

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 six==1.13.0
 requests==2.20.0
-gTTS==2.0.4
+gTTS==2.1.1
 PyAudio==0.2.11
 pyee==7.0.1
 SpeechRecognition==3.8.1


### PR DESCRIPTION
## Description
An upstream bug already fixed in gTTS: https://github.com/pndurette/gTTS/issues/197

Everytime I asked Mycroft with a response sentence with the character `m.` in the text, it'd substitute it for 'monsieur'. e.g.: "bedroom.", "a.m."

## How to test
Using google tts with mycroft use the cli "say a.m.", result is "a monsieur".

## Contributor license agreement signed?
CLA [Not yet, I signed up on the link]
(Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
