### PR TITLE
Remove DSS English-only error

### DIFF
--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -316,8 +316,6 @@ class DeepSpeechServerSTT(STT):
 
     def execute(self, audio, language=None):
         language = language or self.lang
-        if not language.startswith("en"):
-            raise ValueError("Deepspeech is currently english only")
         response = post(self.config.get("uri"), data=audio.get_wav_data())
         return response.text
 


### PR DESCRIPTION
## Description
As deepspeech now supports other languages, the error raised for English-only is not correct.

## How to test
Try using a non-english DSS instance to handle STT services.

## Contributor license agreement signed?
CLA [x] 
