### PR TITLE
Issue-2700 - Allow for different Polly engines in config

### DIFF
--- a/mycroft/tts/polly_tts.py
+++ b/mycroft/tts/polly_tts.py
@@ -34,6 +34,7 @@ class PollyTTS(TTS):
         self.key_id = self.config.get("access_key_id", '')
         self.key = self.config.get("secret_access_key", '')
         self.region = self.config.get("region", 'us-east-1')
+        self.engine = self.config.get("engine", "standard")
         self.polly = boto3.Session(aws_access_key_id=self.key_id,
                                    aws_secret_access_key=self.key,
                                    region_name=self.region).client('polly')
@@ -49,7 +50,8 @@ class PollyTTS(TTS):
             OutputFormat=self.audio_ext,
             Text=sentence,
             TextType=text_type,
-            VoiceId=self.voice)
+            VoiceId=self.voice,
+            Engine=self.engine)
 
         with open(wav_file, 'wb') as f:
             f.write(response['AudioStream'].read())


### PR DESCRIPTION
## Description
Partially fixes #2700. Allows specifying an engine in Polly TTS configuration to be passed to boto3 when synthesising speech. 

## How to test
Add a value under key `tts.polly.engine` in user config. This can be done using `mycroft-config edit user`. The values should either be `standard` or `neural`.

### Example `user` config
```
"tts": {
    "module": "polly",
    "polly": {
      "voice": "Amy",
      "region": "eu-west-2",
      "access_key_id": "placeholder",
      "secret_access_key": "placeholder",
      "engine": "neural"
    }
  }
```

## Caveats
This doesn't add support for conversational speech as specified in #2700, my understanding of SSML is currently too limited for me to do so.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
