### PR TITLE
Make consistence over all steps

### DIFF
--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -215,7 +215,7 @@ def then_exactly(context, skill, text):
 
 
 @then('"{skill}" reply should contain "{text}"')
-@then('mycroft reply should contain "{text}"'
+@then('mycroft reply should contain "{text}"') 
 def then_contains(context, text):
     def check_contains(message):
         utt = message.data['utterance'].lower()

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -215,6 +215,7 @@ def then_exactly(context, skill, text):
 
 
 @then('"{skill}" reply should contain "{text}"')
+@then('mycroft reply should contain "{text}"'
 def then_contains(context, text):
     def check_contains(message):
         utt = message.data['utterance'].lower()

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -215,7 +215,7 @@ def then_exactly(context, skill, text):
 
 
 @then('"{skill}" reply should contain "{text}"')
-@then('mycroft reply should contain "{text}"') 
+@then('mycroft reply should contain "{text}"')
 def then_contains(context, text):
     def check_contains(message):
         utt = message.data['utterance'].lower()

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -214,7 +214,7 @@ def then_exactly(context, skill, text):
     assert passed, assert_msg
 
 
-@then('mycroft reply should contain "{text}"')
+@then('"{skill}" reply should contain "{text}"')
 def then_contains(context, text):
     def check_contains(message):
         utt = message.data['utterance'].lower()


### PR DESCRIPTION
The step contains is the only step where is necessary write "mycroft" and not "{skill"}.
So for all the step is necessary write something like
'Then "myskill" should reply with...' 
except for the should contains step were is necessary write: 'Then mycroft reply should contains... " and not 
'Then" myskill" reply should contains...' .

## Description
(Description of what the PR does, such as fixes # {issue number})

## How to test
(Description of how to validate or test this PR)

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
