### PR TITLE
Fix #1943 - do not attempt update when only launching CLI

### DIFF
--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -190,7 +190,7 @@ if [[ "${1}" == "restart" ]] || [[ "${_opt}" == "restart" ]] ; then
 fi
 _params=$@
 
-if ! grep -i cli <<< ${_params} ; then 
+if ! grep -i cli <<< "${_params}" ; then 
     check-dependencies
 fi
 

--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -190,7 +190,7 @@ if [[ "${1}" == "restart" ]] || [[ "${_opt}" == "restart" ]] ; then
 fi
 _params=$@
 
-if ! grep -i cli <<< "${_params}" ; then 
+if [[ ! "${_opt}" == "cli" ]] ; then
     check-dependencies
 fi
 

--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -190,7 +190,9 @@ if [[ "${1}" == "restart" ]] || [[ "${_opt}" == "restart" ]] ; then
 fi
 _params=$@
 
-check-dependencies
+if ! grep -i cli <<< ${_params} ; then 
+    check-dependencies
+fi
 
 case ${_opt} in
     "all")


### PR DESCRIPTION
## Description
Fix for issue #1943, check dependencies is run just by trying to run the cli.  While this fix bypasses the check if cli is one of the parameters, seems like that's an easy trade-off vs. having it run every time you try and start the cli for no good reason.  

## How to test
run start-mycroft.sh with the "cli" parameter, should skip dependencies check.  Without cli in the options, check_dependencies would be run.  

## Contributor license agreement signed?
CLA [X]
