### PR TITLE
Handle Mimic missing properly

### DIFF
--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -185,10 +185,14 @@ class MimicValidator(TTSValidator):
     def validate_connection(self):
         try:
             subprocess.call([BIN, '--version'])
-        except Exception:
-            LOG.info("Failed to find mimic at: " + BIN)
+        except Exception as err:
+            if BIN:
+                LOG.error('Failed to find mimic at: {}'.format(BIN))
+            else:
+                LOG.error('Mimic executable not found')
             raise Exception(
-                'Mimic was not found. Run install-mimic.sh to install it.')
+                'Mimic was not found. Run install-mimic.sh to install it.') \
+                from err
 
     def get_tts_class(self):
         return Mimic


### PR DESCRIPTION
## Description
I got an error report on chat with the following error:

```
Traceback (most recent call last):
  File "/home/roy/mycroft-core/mycroft/tts/tts.py", line 519, in create
    tts.validator.validate()
  File "/home/roy/mycroft-core/mycroft/tts/tts.py", line 435, in validate
    self.validate_connection()
  File "/home/roy/mycroft-core/mycroft/tts/mimic_tts.py", line 189, in validate_connection
    LOG.info("Failed to find mimic at: " + BIN)
TypeError: can only concatenate str (not "NoneType") to str
2020-10-08 16:49:47.127 | ERROR    | 51541 | __main__:on_error:34 | Audio service failed to launch (TypeError('can only concatenate str (not "NoneType") to str')).
```

So the error message in the exception handler throws an exception making the real exception not show.

I also went through the module with pylint and fixed the issues that could be fixed without breaking backwards compatibility.

## How to test
Make sure Mimic still works and unittests works. You can also set `BIN` to `None` and check that the correct exception is shown.

## Contributor license agreement signed?
CLA [ Yes ]