### PR TITLE
mozilla TTS validation

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -308,7 +308,6 @@
       "voice": "m1"
     },
     "mozilla": {
-      "lang": "de",
       "url": "http://0.0.0.0:5002/api/tts"
     }
   },

--- a/mycroft/tts/mozilla_tts.py
+++ b/mycroft/tts/mozilla_tts.py
@@ -49,7 +49,7 @@ class MozillaTTSValidator(TTSValidator):
         pass
 
     def validate_connection(self):
-        url = self.tts.config['url']
+        url = self.tts.config['url'].replace("/api/tts", "")
         response = requests.get(url)
         if not response.status_code == 200:
             raise ConnectionRefusedError

--- a/mycroft/tts/mozilla_tts.py
+++ b/mycroft/tts/mozilla_tts.py
@@ -49,8 +49,10 @@ class MozillaTTSValidator(TTSValidator):
         pass
 
     def validate_connection(self):
-        # TODO
-        pass
+        url = self.tts.config['url']
+        response = requests.get(url)
+        if not response.status_code == 200:
+            raise ConnectionRefusedError
 
     def get_tts_class(self):
         return MozillaTTS


### PR DESCRIPTION
adds validation to mozilla TTS, if a wrong url is entered this will now be handled and fallback to default TTS engine, instead of the user simply having no TTS output 

removed unused lang param set to "de"

i messed up in posting my review of #2713 , changes have been tested at [HelloChatterbox/text2speech](https://github.com/HelloChatterbox/text2speech/blob/master/text2speech/modules/mozilla_tts.py)