### PR TITLE
Update for newer Porcupine engines

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -14,28 +14,26 @@
 #
 """Factory functions for loading hotword engines - both internal and plugins.
 """
-from time import time, sleep
-import os
-import platform
-import posixpath
-import struct
-import sys
-import tempfile
-import requests
 from contextlib import suppress
 from glob import glob
+import os
 from os.path import dirname, exists, join, abspath, expanduser, isfile, isdir
+import platform
+import posixpath
 from shutil import rmtree
+import struct
+import tempfile
 from threading import Timer, Thread
+from time import time, sleep
 from urllib.error import HTTPError
 
 from petact import install_package
+import requests
 
 from mycroft.configuration import Configuration, LocalConf, USER_CONFIG
-from mycroft.util.log import LOG
 from mycroft.util.monotonic_event import MonotonicEvent
+from mycroft.util.log import LOG
 from mycroft.util.plugins import load_plugin
-
 
 RECOGNIZER_DIR = join(abspath(dirname(__file__)), "recognizer")
 INIT_TIMEOUT = 10  # In seconds
@@ -357,8 +355,9 @@ class SnowboyHotWord(HotWordEngine):
 
 
 class PorcupineHotWord(HotWordEngine):
+    """Hotword engine using picovoice's Porcupine hot word engine."""
     def __init__(self, key_phrase="hey mycroft", config=None, lang="en-us"):
-        super(PorcupineHotWord, self).__init__(key_phrase, config, lang)
+        super().__init__(key_phrase, config, lang)
         keyword_file_paths = [expanduser(x.strip()) for x in self.config.get(
             "keyword_file_path", "hey_mycroft.ppn").split(',')]
         sensitivities = self.config.get("sensitivities", 0.5)
@@ -367,10 +366,10 @@ class PorcupineHotWord(HotWordEngine):
             from pvporcupine.porcupine import Porcupine
             from pvporcupine.util import (pv_library_path,
                                           pv_model_path)
-        except ImportError:
+        except ImportError as err:
             raise Exception(
                 "Python bindings for Porcupine not found. "
-                "Please run \"mycroft-pip install pvporcupine\"")
+                "Please run \"mycroft-pip install pvporcupine\"") from err
 
         library_path = pv_library_path('')
         model_file_path = pv_model_path('')
@@ -395,6 +394,11 @@ class PorcupineHotWord(HotWordEngine):
         LOG.info('Loaded Porcupine')
 
     def update(self, chunk):
+        """Update detection state from a chunk of audio data.
+
+        Arguments:
+            chunk (bytes): Audio data to parse
+        """
         pcm = struct.unpack_from("h" * (len(chunk)//2), chunk)
         self.audio_buffer += pcm
         while True:
@@ -410,12 +414,21 @@ class PorcupineHotWord(HotWordEngine):
                 return
 
     def found_wake_word(self, frame_data):
+        """Check if wakeword has been found.
+
+        Returns:
+            (bool) True if wakeword was found otherwise False.
+        """
         if self.has_found:
             self.has_found = False
             return True
         return False
 
     def stop(self):
+        """Stop the hotword engine.
+
+        Clean up Porcupine library.
+        """
         if self.porcupine is not None:
             self.porcupine.delete()
 

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -374,7 +374,6 @@ class PorcupineHotWord(HotWordEngine):
                 "Python bindings for Porcupine not found. "
                 "Please use --porcupine-path to set Porcupine base path")
 
-        system = platform.system()
         machine = platform.machine()
         library_path = join(
             porcupine_path, 'lib/linux/%s/libpv_porcupine.so' % machine)
@@ -393,8 +392,8 @@ class PorcupineHotWord(HotWordEngine):
             .format(library_path, keyword_file_paths))
         self.porcupine = Porcupine(
             library_path=library_path,
-            model_file_path=model_file_path,
-            keyword_file_paths=keyword_file_paths,
+            model_path=model_file_path,
+            keyword_paths=keyword_file_paths,
             sensitivities=sensitivities)
 
         LOG.info('Loaded Porcupine')
@@ -406,11 +405,9 @@ class PorcupineHotWord(HotWordEngine):
             if len(self.audio_buffer) >= self.porcupine.frame_length:
                 result = self.porcupine.process(
                     self.audio_buffer[0:self.porcupine.frame_length])
-                # result could be boolean (if there is one keword)
-                # or int (if more than one keyword)
-                self.has_found |= (
-                    (self.num_keywords == 1 and result) |
-                    (self.num_keywords > 1 and result >= 0))
+                # result will be the index of the found keyword or -1 if
+                # nothing has been found.
+                self.has_found |= result >= 0
                 self.audio_buffer = self.audio_buffer[
                     self.porcupine.frame_length:]
             else:

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -355,7 +355,10 @@ class SnowboyHotWord(HotWordEngine):
 
 
 class PorcupineHotWord(HotWordEngine):
-    """Hotword engine using picovoice's Porcupine hot word engine."""
+    """Hotword engine using picovoice's Porcupine hot word engine.
+
+    TODO: Remove in 21.02
+    """
     def __init__(self, key_phrase="hey mycroft", config=None, lang="en-us"):
         super().__init__(key_phrase, config, lang)
         keyword_file_paths = [expanduser(x.strip()) for x in self.config.get(
@@ -382,6 +385,10 @@ class PorcupineHotWord(HotWordEngine):
         self.has_found = False
         self.num_keywords = len(keyword_file_paths)
 
+        LOG.warning('The Porcupine wakeword engine shipped with '
+                    'Mycroft-core is deprecated and will be removed in '
+                    'mycroft-core 21.02. Use the mycroft-porcupine-plugin '
+                    'instead.')
         LOG.info(
             'Loading Porcupine using library path {} and keyword paths {}'
             .format(library_path, keyword_file_paths))

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -359,26 +359,21 @@ class SnowboyHotWord(HotWordEngine):
 class PorcupineHotWord(HotWordEngine):
     def __init__(self, key_phrase="hey mycroft", config=None, lang="en-us"):
         super(PorcupineHotWord, self).__init__(key_phrase, config, lang)
-        porcupine_path = expanduser(self.config.get(
-            "porcupine_path", join('~', '.mycroft', 'Porcupine')))
         keyword_file_paths = [expanduser(x.strip()) for x in self.config.get(
             "keyword_file_path", "hey_mycroft.ppn").split(',')]
         sensitivities = self.config.get("sensitivities", 0.5)
-        bindings_path = join(porcupine_path, 'binding/python')
-        LOG.info('Adding %s to Python path' % bindings_path)
-        sys.path.append(bindings_path)
+
         try:
-            from porcupine import Porcupine
+            from pvporcupine.porcupine import Porcupine
+            from pvporcupine.util import (pv_library_path,
+                                          pv_model_path)
         except ImportError:
             raise Exception(
                 "Python bindings for Porcupine not found. "
-                "Please use --porcupine-path to set Porcupine base path")
+                "Please run \"mycroft-pip install pvporcupine\"")
 
-        machine = platform.machine()
-        library_path = join(
-            porcupine_path, 'lib/linux/%s/libpv_porcupine.so' % machine)
-        model_file_path = join(
-            porcupine_path, 'lib/common/porcupine_params.pv')
+        library_path = pv_library_path('')
+        model_file_path = pv_model_path('')
         if isinstance(sensitivities, float):
             sensitivities = [sensitivities] * len(keyword_file_paths)
         else:
@@ -387,6 +382,7 @@ class PorcupineHotWord(HotWordEngine):
         self.audio_buffer = []
         self.has_found = False
         self.num_keywords = len(keyword_file_paths)
+
         LOG.info(
             'Loading Porcupine using library path {} and keyword paths {}'
             .format(library_path, keyword_file_paths))


### PR DESCRIPTION
## Description
This switches the module to use the [pvporcupine](https://pypi.org/project/pvporcupine/) library instead of the git clone. It updates the code to match the new signature of the Porcupine class initialization. It also switches to use the builtin module finding code which will make the hotword engine usable on Raspberry Pi units.

Should resolve #2720 

This also does some minor cleanup of the Porcupine hotword module.

## How to test
- Install pvporcupine `mycroft-pip install pvporcupine`
- Download the blueberry keyword file from [here](https://github.com/Picovoice/porcupine/tree/master/resources/keyword_files)
Create a hotword entry in your mycroft.conf and set the listener to use it.
```
...
  "listener": {
    "wake_word": "blueberry"
  },
  "hotwords": {
    "blueberry": {
      "module": "porcupine",
      "keyword_file_path": "PATH_TO_BLUEBERRY.ppn"
    }
  }
```

## Contributor license agreement signed?
CLA [ Yes ]
