### PR TITLE
Update to pyee 8.1.0

### DIFF
--- a/mycroft/client/speech/listener.py
+++ b/mycroft/client/speech/listener.py
@@ -16,7 +16,7 @@ import time
 from threading import Thread
 import speech_recognition as sr
 import pyaudio
-from pyee import BaseEventEmitter
+from pyee import EventEmitter
 from requests import RequestException
 from requests.exceptions import ConnectionError
 
@@ -271,7 +271,7 @@ def recognizer_conf_hash(config):
     return hash(json.dumps(c, sort_keys=True))
 
 
-class RecognizerLoop(BaseEventEmitter):
+class RecognizerLoop(EventEmitter):
     """ EventEmitter loop running speech recognition.
 
     Local wake word recognizer and remote general speech recognition.

--- a/mycroft/messagebus/service/event_handler.py
+++ b/mycroft/messagebus/service/event_handler.py
@@ -18,7 +18,7 @@ import sys
 import traceback
 
 from tornado.websocket import WebSocketHandler
-from pyee import BaseEventEmitter
+from pyee import EventEmitter
 
 from mycroft.messagebus.message import Message
 from mycroft.util.log import LOG
@@ -29,7 +29,7 @@ client_connections = []
 class MessageBusEventHandler(WebSocketHandler):
     def __init__(self, application, request, **kwargs):
         super().__init__(application, request, **kwargs)
-        self.emitter = BaseEventEmitter()
+        self.emitter = EventEmitter()
 
     def on(self, event_name, handler):
         self.emitter.on(event_name, handler)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -19,7 +19,7 @@ PyYAML==5.1.2
 lingua-franca==0.2.2
 msm==0.8.8
 msk==0.3.16
-adapt-parser==0.3.6
+adapt-parser==0.3.7
 padatious==0.4.8
 fann2==1.0.7
 padaos==0.1.9

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -2,7 +2,7 @@ six==1.13.0
 requests==2.20.0
 gTTS==2.1.1
 PyAudio==0.2.11
-pyee==7.0.1
+pyee==8.1.0
 SpeechRecognition==3.8.1
 tornado==6.0.3
 websocket-client==0.54.0

--- a/test/integrationtests/skills/skill_tester.py
+++ b/test/integrationtests/skills/skill_tester.py
@@ -39,7 +39,7 @@ import os
 import re
 import ast
 from os.path import join, isdir, basename
-from pyee import BaseEventEmitter
+from pyee import EventEmitter
 from numbers import Number
 from mycroft.messagebus.message import Message
 from mycroft.skills.core import MycroftSkill, FallbackSkill
@@ -167,7 +167,7 @@ class InterceptEmitter(object):
     """
 
     def __init__(self):
-        self.emitter = BaseEventEmitter()
+        self.emitter = EventEmitter()
         self.q = None
 
     def on(self, event, f):

--- a/test/wake_word/wake_word_test.py
+++ b/test/wake_word/wake_word_test.py
@@ -100,7 +100,7 @@ class AudioTester:
 
     def test_audio(self, file_name):
         source = FileMockMicrophone(file_name)
-        ee = pyee.BaseEventEmitter()
+        ee = pyee.EventEmitter()
 
         class SharedData:
             times_found = 0


### PR DESCRIPTION
## Description
pyee 8.1.0 adds a small change to make the once call to be more safe in
multithreaded environments.

This switches back from the now deprecated BaseEventEmitter to the
standard EventEmitter.

Before this PR can be merged [Adapt PR #117](https://github.com/MycroftAI/adapt/pull/117) also needs to be merged to sync the requirements.

The update should a tleast improve on the behaviour reported in #2695 if not fix it all together.

## How to test
Ensure that unit tests and integration tests succeeds.

## Contributor license agreement signed?
CLA [ Yes ]