### PR TITLE
allow variants of arch (archarm, ...) to fetch dependencies (dev_setup.sh)

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -398,14 +398,14 @@ function install_deps() {
         # Fedora
         echo "$GREEN Installing packages for Fedora...$RESET"
         fedora_install
-    elif found_exe pacman && os_is arch ; then
+    elif found_exe pacman && (os_is arch || os_is_like arch); then
         # Arch Linux
         echo "$GREEN Installing packages for Arch...$RESET"
         arch_install
     elif found_exe emerge && os_is gentoo; then
         # Gentoo Linux
         echo "$GREEN Installing packages for Gentoo Linux ...$RESET"
-        gentoo_install	
+        gentoo_install
     elif found_exe apk && os_is alpine; then
         # Alpine Linux
         echo "$GREEN Installing packages for Alpine Linux...$RESET"


### PR DESCRIPTION
Problem: Arch Linux Arm doesn't fetch dependencies in the installation process

Just added `&& ( ... || os_is_like arch)` to let variants like archarm pass the filter

since os-release (archarm)

```
ID=archarm
ID_LIKE=arch
```

Alternatively this could be handled with `os_is archarm` , yet i've seen many (core) arch variants which could run into the same problem. This should also pass Manjaro, i guess.

