### PR TITLE
Point sphinxdocs to new requirements.txt location

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -42,10 +42,11 @@ extensions = [
     'sphinx.ext.githubpages',
     'sphinx.ext.napoleon'
 ]
+req_path = os.path.join(os.path.dirname(os.path.dirname(
+    os.path.realpath(__file__))), 'requirements', 'requirements.txt')
 
 # Assuming package name is the same as the module name
-with open(os.path.join(os.path.dirname(os.path.dirname(
-        os.path.realpath(__file__))), 'requirements.txt')) as f:
+with open(req_path) as f:
     autodoc_mock_imports = map(str.strip, re.findall(r'^\s*[a-zA-Z_]*',
                                f.read().lower().replace('-', '_'),
                                flags=re.MULTILINE))


### PR DESCRIPTION
## Description
Sphinx docs currently fails to build the api documentation due to requirements.txt being moved. This fixes the location making the docs buildable again

## How to test
Generate API docs

```
cd docs
make html
```

Check that _build/html contains updated docs.

## Contributor license agreement signed?
CLA [ Yes ]