### PR TITLE
Fix/add missing skill_id parameter for page interaction and focus events

### DIFF
--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -530,7 +530,8 @@ class GUIWebsocketHandler(WebSocketHandler):
             # System event, a page was changed
             msg_type = 'gui.page_interaction'
             msg_data = {'namespace': msg['namespace'],
-                        'page_number': msg['parameters'].get('number')}
+                        'page_number': msg['parameters'].get('number'),
+                        'skill_id': msg['parameters'].get('skillId')}
         elif msg.get('type') == "mycroft.events.triggered":
             # A normal event was triggered
             msg_type = '{}.{}'.format(msg['namespace'], msg['event_name'])


### PR DESCRIPTION
## Description
Adds missing skill_id parameter for page interaction events and page focus events

## How to test
gui.page_interaction bus event should have skill_id available in data

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
