### PR TITLE
skill settings sync flag

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -126,7 +126,8 @@
     "url": "https://api.mycroft.ai",
     "version": "v1",
     "update": true,
-    "metrics": false
+    "metrics": false,
+    "sync_skill_settings": true
   },
 
   // The mycroft-core messagebus websocket

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -137,6 +137,12 @@ class SettingsMetaUploader:
         self.settings_meta = {}
         self.api = None
         self.upload_timer = None
+        self.sync_enabled = self.config["server"].get("sync_skill_settings",
+                                                      False)
+        if not self.sync_enabled:
+            LOG.info("Skill settings sync is disabled, settingsmeta will "
+                     "not be uploaded")
+
         self._stopped = None
 
         # Property placeholders
@@ -216,6 +222,8 @@ class SettingsMetaUploader:
         The settingsmeta file does not change often, if at all.  Only perform
         the upload if a change in the file is detected.
         """
+        if not self.sync_enabled:
+            return
         synced = False
         if is_paired():
             self.api = DeviceApi()
@@ -315,6 +323,11 @@ class SkillSettingsDownloader:
         self.remote_settings = None
         self.api = DeviceApi()
         self.download_timer = None
+        self.sync_enabled = Configuration.get()["server"]\
+            .get("sync_skill_settings", False)
+        if not self.sync_enabled:
+            LOG.info("Skill settings sync is disabled, backend settings will "
+                     "not be downloaded")
 
     def stop_downloading(self):
         """Stop synchronizing backend and core."""
@@ -328,6 +341,8 @@ class SkillSettingsDownloader:
 
         When used as a messagebus handler a message is passed but not used.
         """
+        if not self.sync_enabled:
+            return
         if is_paired():
             remote_settings = self._get_remote_settings()
             if remote_settings:

--- a/test/unittests/mocks.py
+++ b/test/unittests/mocks.py
@@ -12,10 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from copy import deepcopy
 from unittest.mock import Mock
 
 from msm import MycroftSkillsManager
 from msm.skill_repo import SkillRepo
+
+from mycroft.configuration.config import LocalConf, DEFAULT_CONFIG
+
+__CONFIG = LocalConf(DEFAULT_CONFIG)
+
+
+def base_config():
+    """Base config used when mocking.
+
+    Preload to skip hitting the disk each creation time but make a copy
+    so modifications don't mutate it.
+
+    Returns:
+        (dict) Mycroft default configuration
+    """
+    return deepcopy(__CONFIG)
 
 
 def mock_msm(temp_dir):
@@ -50,27 +67,13 @@ def mock_msm(temp_dir):
 def mock_config(temp_dir):
     """Supply a reliable return value for the Configuration.get() method."""
     get_config_mock = Mock()
-    get_config_mock.return_value = dict(
-        skills=dict(
-            msm=dict(
-                directory='skills',
-                versioned=True,
-                repo=dict(
-                    cache='.skills-repo',
-                    url='https://github.com/MycroftAI/mycroft-skills',
-                    branch='19.02'
-                )
-            ),
-            update_interval=1.0,
-            auto_update=True,
-            blacklisted_skills=[],
-            priority_skills=['foobar'],
-            upload_skill_manifest=True
-        ),
-        data_dir=str(temp_dir),
-        enclosure=dict()
-    )
+    config = base_config()
+    config['skills']['priority_skills'] = ['foobar']
+    config['data_dir'] = str(temp_dir)
+    config['server']['metrics'] = False
+    config['enclosure'] = {}
 
+    get_config_mock.return_value = config
     return get_config_mock
 
 

--- a/test/unittests/mycroft.conf
+++ b/test/unittests/mycroft.conf
@@ -1,5 +1,0 @@
-{
-  "server": {
-    "metrics": false
-  }
-}

--- a/test/util.py
+++ b/test/util.py
@@ -1,12 +1,4 @@
-from mycroft.configuration.config import LocalConf, DEFAULT_CONFIG
-from copy import deepcopy
-
-__config = LocalConf(DEFAULT_CONFIG)
-
-
-# Base config to use when mocking
-def base_config():
-    return deepcopy(__config)
+from test.unittests.mocks import base_config  # For backwards compatibility
 
 
 class Anything:


### PR DESCRIPTION
adds a flag to .conf that allows disabling skill settings sync

some users just dont want/like it
why do i dislike skill settings?

- the websettings overwrite my local changes (breaks a few of my most important skills) related #2707 and #2698
- sync to all devices, messes up stuff like my Voip skill since i cant set up different accounts per device
- privacy reasons, once the 2way sync is reimplemented stuff like creds (changed on device) might get uploaded to you, in this case creds shouldnt even be in settingsmeta, but we dont control what others dev do and forking should not be a requirement for privacy

while this stuff isnt fixed/implemented i essentially stopped using websettings at all. not an issue for me, but i would like other people to be able to use my skills.....

this was proposed before and further discussed in https://github.com/MycroftAI/mycroft-core/issues/2633 


default flag is set to True for compatibility reasons, but IMHO it should be false by default since this is a privacy feature, i made the code default to False but the .conf defaults to True. My reasoning here is that disabled is the sane default and enabling it is up to the enclosure and not core