### PR TITLE
ensure load_status is initialized on load failure

### DIFF
--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -301,6 +301,7 @@ class SkillManager(Thread):
             load_status = skill_loader.load()
         except Exception:
             LOG.exception('Load of skill {} failed!'.format(skill_directory))
+            load_status = False
         finally:
             self.skill_loaders[skill_directory] = skill_loader
 


### PR DESCRIPTION
## Description
Issue reported by Jarbas on Chat:
```
Exception in thread Thread-4:
Traceback (most recent call last):
  File "/usr/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/mycroft/mycroft-core/mycroft/skills/skill_manager.py", line 234, in run
    self._load_on_startup()
  File "/home/mycroft/mycroft-core/mycroft/skills/skill_manager.py", line 271, in _load_on_startup
    self._load_new_skills()
  File "/home/mycroft/mycroft-core/mycroft/skills/skill_manager.py", line 293, in _load_new_skills
    loader = self._load_skill(skill_dir)
  File "/home/mycroft/mycroft-core/mycroft/skills/skill_manager.py", line 306, in _load_skill
    return skill_loader if load_status else None
UnboundLocalError: local variable 'load_status' referenced before assignment
```

If the load fails, we catch the exception but don't initialize the `load_status` variable that we then use in a conditional to determine the return value. This sets `load_status` to `False` if loading fails which will cause the function to `return None`.

## How to test
Somehow cause a load failure?

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
