### PR TITLE
revert a temporary bugfix from PR #2626

### DIFF
--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -90,12 +90,6 @@ def before_all(context):
         else:
             sleep(1)
 
-    # Temporary bugfix - First test to run sometimes fails
-    # Sleeping to see if something isn't finished setting up when tests start
-    # More info in Jira Ticket MYC-370
-    # TODO - remove and fix properly dependant on if failures continue
-    sleep(10)
-
     context.bus = bus
     context.step_timeout = 10  # Reset the step_timeout to 10 seconds
     context.matched_message = None


### PR DESCRIPTION
## Description
Reverts changes from PR #2626 removing the 10 second sleep after Skills have loaded. 

## How to test
See if previous VK failures start to re-appear.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
