### PR TITLE
Fix Voight kampff reset of patched config

### DIFF
--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -100,7 +100,6 @@ def before_all(context):
     context.step_timeout = 10  # Reset the step_timeout to 10 seconds
     context.matched_message = None
     context.log = log
-    context.original_config = {}
     context.config = Configuration.get()
     Configuration.set_config_update_handlers(bus)
 
@@ -121,18 +120,6 @@ def after_feature(context, feature):
     sleep(1)
 
 
-def reset_config(context):
-    """Reset configuration with changes stored in original_config of context.
-    """
-    context.log.info('Resetting patched configuration...')
-
-    context.bus.emit(Message('configuration.patch.clear'))
-    key = list(context.original_config)[0]
-    while context.config[key] != context.original_config[key]:
-        sleep(0.5)
-    context.original_config = {}
-
-
 def after_scenario(context, scenario):
     """Wait for mycroft completion and reset any changed state."""
     # TODO wait for skill handler complete
@@ -141,7 +128,3 @@ def after_scenario(context, scenario):
     context.bus.clear_messages()
     context.matched_message = None
     context.step_timeout = 10  # Reset the step_timeout to 10 seconds
-
-    if context.original_config:
-        # something has changed, reset changes by done in the context
-        reset_config(context)

--- a/test/integrationtests/voight_kampff/features/steps/configuration.py
+++ b/test/integrationtests/voight_kampff/features/steps/configuration.py
@@ -41,9 +41,11 @@ def patch_config(context, patch):
         context: Behave context for test
         patch: patch to apply
     """
+    context.log.info('Patching config with {}'.format(patch))
     # If this is first patch in scenario
     if not hasattr(context, 'original_config'):
         context.original_config = {}
+
     # store originals in context
     for key in patch:
         # If this patch is redefining an already changed key don't update

--- a/test/integrationtests/voight_kampff/features/steps/configuration.py
+++ b/test/integrationtests/voight_kampff/features/steps/configuration.py
@@ -21,6 +21,19 @@ from mycroft.messagebus import Message
 from mycroft.util import resolve_resource_file
 
 
+def reset_config(context):
+    """Cleanup callback to reset patched configuration
+
+    Arguments:
+        context (Context): Behave context of current scenario
+    """
+    context.log.info('Resetting patched configuration...')
+    context.bus.emit(Message('configuration.patch.clear'))
+    key = list(context.original_config)[0]
+    while context.config[key] != context.original_config[key]:
+        time.sleep(0.5)
+
+
 def patch_config(context, patch):
     """Apply patch to config and wait for it to take effect.
 
@@ -28,6 +41,9 @@ def patch_config(context, patch):
         context: Behave context for test
         patch: patch to apply
     """
+    # If this is first patch in scenario
+    if not hasattr(context, 'original_config'):
+        context.original_config = {}
     # store originals in context
     for key in patch:
         # If this patch is redefining an already changed key don't update
@@ -37,6 +53,8 @@ def patch_config(context, patch):
     # Patch config
     patch_config_msg = Message('configuration.patch', {'config': patch})
     context.bus.emit(patch_config_msg)
+
+    context.add_cleanup(reset_config, context)
 
     # Wait until one of the keys has been updated
     key = list(patch.keys())[0]


### PR DESCRIPTION
## Description
This resets a configuration patch by adding a custom cleanup function. This moves the entire config patching and resetting into the steps/configuration.py file keeping it all together in one place.

This also fixes issue with test cases following a case setting the system units would reset the config despite not needing to. This resulted in quite cluttered see [here](https://hudson.mycroft.team/blue/organizations/jenkins/mycroft-core/detail/PR-2736/3/pipeline) for example

## How to test
Make sure VK test passes and reset message is only shown on test cases that patches the config.

## Contributor license agreement signed?
CLA [ Yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
