### PR TITLE
Travis unittests: Only build mimic once during travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ install:
  - rm -rf ${TMPDIR}
  - mkdir ${TMPDIR}
  - echo ${TMPDIR}
- - VIRTUALENV_ROOT=${VIRTUAL_ENV} ./dev_setup.sh
+ - VIRTUALENV_ROOT=${VIRTUAL_ENV} if [[ $TRAVIS_PYTHON_VERSION == 3.9 ]]; then ./dev_setup.sh; fi
+# Skip mimic build for other versions
+ - VIRTUALENV_ROOT=${VIRTUAL_ENV} if [[ $TRAVIS_PYTHON_VERSION != 3.9 ]]; then ./dev_setup.sh -sm; fi 
 # command to run tests
 script:
  - pycodestyle mycroft test


### PR DESCRIPTION
## Description
Save some CPU cycles by only building mimic once. The build shouldn't
differ vastly (or at all) between runs.

## How to test
Make sure python 3.5-3.8 runs much faster than the usual ~6 minutes. Ensure that mimic is built on the Python 3.9 run.

## Contributor license agreement signed?
CLA [ Yes ]