### PR TITLE
Only build mimic once during travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,9 @@ install:
  - rm -rf ${TMPDIR}
  - mkdir ${TMPDIR}
  - echo ${TMPDIR}
- - VIRTUALENV_ROOT=${VIRTUAL_ENV} ./dev_setup.sh
+ - if [[ $TRAVIS_PYTHON_VERSION == 3.9 ]]; then VIRTUALENV_ROOT=${VIRTUAL_ENV} ./dev_setup.sh; fi
+# Skip mimic build for other versions
+ - if [[ $TRAVIS_PYTHON_VERSION != 3.9 ]]; then VIRTUALENV_ROOT=${VIRTUAL_ENV} ./dev_setup.sh -sm; fi
 # command to run tests
 script:
  - pycodestyle mycroft test

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
  - mkdir ${TMPDIR}
  - echo ${TMPDIR}
  - if [[ $TRAVIS_PYTHON_VERSION == 3.9 ]]; then VIRTUALENV_ROOT=${VIRTUAL_ENV} ./dev_setup.sh; fi
-# Skip mimic build for other versions
+# Skip mimic build for other versions because they should not differ
  - if [[ $TRAVIS_PYTHON_VERSION != 3.9 ]]; then VIRTUALENV_ROOT=${VIRTUAL_ENV} ./dev_setup.sh -sm; fi
 # command to run tests
 script:


### PR DESCRIPTION
## Description
Save some CPU cycles by only building mimic once. The build shouldn't
differ vastly (or at all) between runs.

## How to test
Check that only Python 3.9 builds mimic as part of the Travis tests.

## Contributor license agreement signed?
CLA [ Yes ]