### PR TITLE
Enable utf-8 encoding during dev-setup.sh

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -16,7 +16,7 @@
 ##########################################################################
 
 # Set a default locale to handle output from commands reliably
-export LANG=C
+export LANG=C.UTF-8
 
 # exit on any error
 set -Ee


### PR DESCRIPTION
## Description
Adapt fails to install due to an encoding issue, this was originally reported [here](
https://github.com/MycroftAI/docker-mycroft/issues/71).

This enables utf-8 in the dev_setup.sh script to fix this issue.

## How to test

Ensure dev_setup.sh manages to complete successfully. I removed adapt and added the `--no-cache` flag to the pip command on L514 to ensure that the error would occur.

## Contributor license agreement signed?
CLA [ Yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
