### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,4 +16,4 @@ formats: all
 python:
   version: 3.7
   install:
-    - requirements: docs/requirements.txt
+    - requirements: doc/requirements.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,13 +45,19 @@ extensions = [
 req_path = os.path.join(os.path.dirname(os.path.dirname(
     os.path.realpath(__file__))), 'requirements', 'requirements.txt')
 
+# To easily run sphinx without additional installation autodoc_mock_imports
+# sets modules to mock.
+
+# Step 1: Pull module names to mock from requirements
 # Assuming package name is the same as the module name
 with open(req_path) as f:
     autodoc_mock_imports = map(str.strip, re.findall(r'^\s*[a-zA-Z_]*',
                                f.read().lower().replace('-', '_'),
                                flags=re.MULTILINE))
 
-# Dependencies with different module names
+# Step 2: Add custom names
+# Not all module names match the package name (as stated in requirements.txt)
+# this adds the modules whose names don't match the package name.
 autodoc_mock_imports = list(autodoc_mock_imports) + [
     'adapt',
     'alsaaudio',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -59,7 +59,8 @@ autodoc_mock_imports = list(autodoc_mock_imports) + [
     'past',
     'serial',
     'websocket',
-    'speech_recognition'
+    'speech_recognition',
+    'xdg'
 ]
 
 templates_path = ['_templates']

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,7 +60,8 @@ autodoc_mock_imports = list(autodoc_mock_imports) + [
     'serial',
     'websocket',
     'speech_recognition',
-    'xdg'
+    'xdg',
+    'yaml'
 ]
 
 templates_path = ['_templates']

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -61,6 +61,8 @@ import re
 from pathlib import Path
 from threading import Timer
 
+import yaml
+
 from mycroft.api import DeviceApi, is_paired
 from mycroft.configuration import Configuration
 from mycroft.messagebus.message import Message
@@ -249,8 +251,6 @@ class SettingsMetaUploader:
 
     def _load_settings_meta_file(self):
         """Read the contents of the settingsmeta file into memory."""
-        # Imported here do handle issue with readthedocs build
-        import yaml
         _, ext = os.path.splitext(str(self.settings_meta_path))
         is_json_file = self.settings_meta_path.suffix == ".json"
         try:


### PR DESCRIPTION
## Description
After readthedocs was fixed enough to update again a couple of issues were observed, the most obvious one that the docs for MycroftSkill derived classes are missing. See [here](https://mycroft-core.readthedocs.io/en/latest/source/mycroft.html#mycroftskill-class-base-class-for-all-mycroft-skills)

This was due to `xdg` not being mocked when generating the docs, and thus erroring out when sphinx imported those modules. This adds `xdg` as a `autodoc_mocked_import`.

Finding this out I realized the same isse ẃas causing the previous issue with `yaml` so that has been cleaned up as well.

I also noticed that the `.readthedocs` file was not named correctly and wasn't actually used. This renames it and fixes an incorrect path making it usable.

## How to test
I generated readthedocs from this branch [here](https://mycroft-core.readthedocs.io/en/bugfix-readthedocs/) Make sure the MycroftSkills module and related modules are generated properly.

## Contributor license agreement signed?
CLA [ Yes ]