### PR TITLE
Ensure messagebus is connected before reporting that the service is ready

### DIFF
--- a/mycroft/client/enclosure/__main__.py
+++ b/mycroft/client/enclosure/__main__.py
@@ -19,8 +19,7 @@ control over the Mark-1 Faceplate.
 """
 from mycroft.configuration import LocalConf, SYSTEM_CONFIG
 from mycroft.util.log import LOG
-from mycroft.util import (create_daemon, wait_for_exit_signal,
-                          reset_sigint_handler)
+from mycroft.util import wait_for_exit_signal, reset_sigint_handler
 
 
 def on_ready():
@@ -32,7 +31,7 @@ def on_stopping():
 
 
 def on_error(e='Unknown'):
-    LOG.error('Enclosure failed to start. ({})'.format(repr(e)))
+    LOG.error('Enclosure failed: {}'.format(repr(e)))
 
 
 def create_enclosure(platform):
@@ -64,7 +63,6 @@ def create_enclosure(platform):
 
 
 def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
-    # Read the system configuration
     """Launch one of the available enclosure implementations.
 
     This depends on the configured platform and can currently either be
@@ -77,15 +75,16 @@ def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping):
 
     enclosure = create_enclosure(platform)
     if enclosure:
+        LOG.debug("Enclosure created")
         try:
-            LOG.debug("Enclosure started!")
             reset_sigint_handler()
-            create_daemon(enclosure.run)
+            enclosure.run()
             ready_hook()
             wait_for_exit_signal()
+            enclosure.stop()
             stopping_hook()
         except Exception as e:
-            print(e)
+            error_hook(e)
     else:
         LOG.info("No enclosure available for this hardware, running headless")
 

--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -19,6 +19,7 @@ from threading import Lock
 
 from mycroft.configuration import Configuration
 from mycroft.messagebus.client import MessageBusClient
+from mycroft.services import start_message_bus_client
 from mycroft.util import create_daemon
 from mycroft.util.log import LOG
 
@@ -61,15 +62,14 @@ def _get_page_data(message):
 
 class Enclosure:
     def __init__(self):
-        # Establish Enclosure's websocket connection to the messagebus
-        self.bus = MessageBusClient()
         # Load full config
-        Configuration.set_config_update_handlers(self.bus)
         config = Configuration.get()
-
         self.lang = config['lang']
         self.config = config.get("enclosure")
         self.global_config = config
+
+        # Create Message Bus Client
+        self.bus = MessageBusClient()
 
         self.gui = create_gui_service(self, config['gui_websocket'])
         # This datastore holds the data associated with the GUI provider. Data
@@ -107,11 +107,14 @@ class Enclosure:
         self.bus.on("gui.status.request", self.handle_gui_status_request)
 
     def run(self):
-        try:
-            self.bus.run_forever()
-        except Exception as e:
-            LOG.error("Error: {0}".format(e))
-            self.stop()
+        """Start the Enclosure after it has been constructed."""
+        # Allow exceptions to be raised to the Enclosure Service
+        # if they may cause the Service to fail.
+        start_message_bus_client("ENCLOSURE", self.bus)
+
+    def stop(self):
+        """Perform any enclosure shutdown processes."""
+        pass
 
     ######################################################################
     # GUI client API
@@ -128,7 +131,6 @@ class Enclosure:
 
     def send(self, msg_dict):
         """ Send to all registered GUIs. """
-        LOG.info('SENDING...')
         for connection in GUIWebsocketHandler.clients:
             try:
                 connection.send(msg_dict)

--- a/mycroft/services/__init__.py
+++ b/mycroft/services/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mycroft.services.util import start_message_bus_client

--- a/mycroft/services/util.py
+++ b/mycroft/services/util.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Mycroft AI Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from threading import Event
+from mycroft.messagebus.client import MessageBusClient
+from mycroft.configuration import Configuration
+from mycroft.util import create_daemon, create_echo_function
+from mycroft.util.log import LOG
+
+
+def start_message_bus_client(service, bus=None):
+    """Start the bus client daemon and wait for connection.
+
+    Arguments:
+        service (str): name of the service starting the connection
+        bus (MessageBusClient): an instance of the Mycroft MessageBusClient
+    Returns:
+        A connected instance of the MessageBusClient
+    """
+    # Create a client if one was not provided
+    if bus is None:
+        bus = MessageBusClient()
+    # Configuration.set_config_update_handlers(bus)
+    bus_connected = Event()
+    bus.on('message', create_echo_function(service))
+    # Set the bus connected event when connection is established
+    bus.once('open', bus_connected.set)
+    create_daemon(bus.run_forever)
+
+    # Wait for connection
+    bus_connected.wait()
+    LOG.info('Connected to messagebus')
+
+    return bus


### PR DESCRIPTION
## Description
- Add standard method for starting the bus client as a daemon
- Ensure messagebus is connected before reporting that the service is ready
- Ensure exceptions during `.run()` are raised to the Enclosure service
- Add missing `.stop()` method to base Enclosure Class and shift the call of it to after exit signal
- Remove info level log presumably left over from development

To add:
- Ensure GUI messagebus is connected before reporting ready.

## How to test
Start Mycroft and check that the bus is connected before the service reports ready.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
