### PR TITLE
self.gui.release()

### DIFF
--- a/mycroft/enclosure/gui.py
+++ b/mycroft/enclosure/gui.py
@@ -349,6 +349,15 @@ class SkillGUI:
         self.show_page("SYSTEM_UrlFrame.qml", override_idle,
                        override_animations)
 
+    def release(self):
+        """Signal that this skill is no longer using the GUI,
+        allow different platforms to properly handle this event.
+        Also calls self.clear() to reset the state variables
+        Platforms can close the window or go back to previous page"""
+        self.clear()
+        self.skill.bus.emit(Message("mycroft.gui.screen.close",
+                                    {"skill_id": self.skill.skill_id}))
+
     def shutdown(self):
         """Shutdown gui interface.
 


### PR DESCRIPTION
Signal that this skill is no longer using the GUI, allow different platforms to properly handle this event.
     
Also calls self.clear() to reset the state variables

Currently self.gui.clear() has been wrongly used for this purpose, for example in my [evil-laugh-skill](https://github.com/JarbasSkills/skill-laugh/blob/master/__init__.py#L86) this worked ok if mark2 skill was installed (due to a different bug related to idle screen) which makes it seem like its working, but in bigscreen it causes a black screen to linger around

Platforms can close the window or go back to previous page, clearing the page data is not enough

more recently in https://github.com/MycroftAI/mycroft-timer/pull/82 self.gui.clear() is also being wrongly used for this purpose

![image](https://user-images.githubusercontent.com/33701864/99884016-e35d8800-2c22-11eb-83a9-a0a094efd700.png)



