### PR TITLE
Bugfix/anonymous adapt intent

### DIFF
--- a/mycroft/skills/intent_services/adapt_service.py
+++ b/mycroft/skills/intent_services/adapt_service.py
@@ -26,9 +26,11 @@ from .base import IntentMatch
 class AdaptIntent(IntentBuilder):
     """Wrapper for IntentBuilder setting a blank name.
 
-    This is mainly here for backwards compatibility, adapt now support
-    automatically named IntentBulders.
+    Arguments:
+        name (str): Optional name of intent
     """
+    def __init__(self, name=''):
+        super().__init__(name)
 
 
 def _strip_result(context_features):

--- a/test/unittests/skills/test_intent_service.py
+++ b/test/unittests/skills/test_intent_service.py
@@ -19,7 +19,7 @@ from adapt.intent import IntentBuilder
 from mycroft.configuration import Configuration
 from mycroft.messagebus import Message
 from mycroft.skills.intent_service import (ContextManager, IntentService,
-                                           _get_message_lang)
+                                           _get_message_lang, AdaptIntent)
 
 from test.util import base_config
 
@@ -327,3 +327,14 @@ class TestIntentServiceApi(TestCase):
         self.intent_service.handle_get_adapt(msg)
         reply = get_last_message(self.intent_service.bus)
         self.assertEqual(reply.data['intent'], None)
+
+
+class TestAdaptIntent(TestCase):
+    """Test the AdaptIntent wrapper."""
+    def test_named_intent(self):
+        intent = AdaptIntent("CallEaglesIntent")
+        self.assertEqual(intent.name, "CallEaglesIntent")
+
+    def test_unnamed_intent(self):
+        intent = AdaptIntent()
+        self.assertEqual(intent.name, "")


### PR DESCRIPTION
## Description
When refactoring the intent service the AdaptIntent was simplified to a name wrapper. This was wrong, Adapt doesn't seem to have implemented handling IntentBuilder objects without name as I thought.

This also adds a simple testcase for this issue.

## How to test
Ensure unittests pass.

## Contributor license agreement signed?
CLA [ Yes ]