### PR TITLE
Clarify that gui.clear does not close a Skill

### DIFF
--- a/mycroft/enclosure/gui.py
+++ b/mycroft/enclosure/gui.py
@@ -115,7 +115,11 @@ class SkillGUI:
         return self.__session_data.__contains__(key)
 
     def clear(self):
-        """Reset the value dictionary, and remove namespace from GUI."""
+        """Reset the value dictionary, and remove namespace from GUI.
+
+        This method does not close the GUI for a Skill. For this purpose see
+        the `release` method.
+        """
         self.__session_data = {}
         self.page = None
         self.skill.bus.emit(Message("gui.clear.namespace",


### PR DESCRIPTION
## Description
Clarify docstring for `gui.clear` method. This method does not close a Skill / release the GUI from it. Tweaks / amendments / suggestions most welcome!

A new `release` method is being added in PR #2766 for this purpose

## How to test
Documentation update only.

## Contributor license agreement signed?
- [x] CLA  (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
