### PR TITLE
Fix UnboundLocalError in AudioProducer

### DIFF
--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -621,6 +621,7 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
         ww_frames = deque(maxlen=7)
 
         said_wake_word = False
+        audio_data = None
         while (not said_wake_word and not self._stop_signaled and
                not self._skip_wake_word()):
             chunk = self.record_sound_chunk(source)


### PR DESCRIPTION
==== Fixed Issues ====
#2779 

====  Tech Notes ====
The variable should be declared outside the loop.

## Description
fixes an UnboundLocalError exception

## How to test
Basic use of mycroft. Nothing broken, then good to go.

## Contributor license agreement signed?
CLA [X]
