### PR TITLE
Fix missing remove page implementation, show idle if all pages removed

### DIFF
--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -240,10 +240,9 @@ class Enclosure:
                    })
         # Remove the page from the local reprensentation as well.
         self.loaded[0].pages.pop(pos)
-        # Add a check to return to idle from position 0
-        if (pos == 0 and self.config.get("platform") == "mycroft_mark_2"
-                and len(self.loaded[0].pages) == 0):
-            self.bus.emit(Message("mycroft.mark2.reset_idle"))
+        # Add a check to return any display to idle from position 0
+        if (pos == 0 and len(self.loaded[0].pages) == 0):
+            self.bus.emit(Message("mycroft.display.reset_idle"))
 
     def __insert_new_namespace(self, namespace, pages):
         """ Insert new namespace and pages.

--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -240,6 +240,10 @@ class Enclosure:
                    })
         # Remove the page from the local reprensentation as well.
         self.loaded[0].pages.pop(pos)
+        # Add a check to return to idle from position 0
+        if pos == 0 and self.config.get("platform") == "mycroft_mark_2" and
+        len(self.loaded[0].pages) == 0:
+            self.bus.emit(Message("mycroft.mark2.reset_idle"))
 
     def __insert_new_namespace(self, namespace, pages):
         """ Insert new namespace and pages.

--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -242,7 +242,7 @@ class Enclosure:
         self.loaded[0].pages.pop(pos)
         # Add a check to return any display to idle from position 0
         if (pos == 0 and len(self.loaded[0].pages) == 0):
-            self.bus.emit(Message("mycroft.display.reset_idle"))
+            self.bus.emit(Message("mycroft.device.show.idle"))
 
     def __insert_new_namespace(self, namespace, pages):
         """ Insert new namespace and pages.

--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -241,8 +241,8 @@ class Enclosure:
         # Remove the page from the local reprensentation as well.
         self.loaded[0].pages.pop(pos)
         # Add a check to return to idle from position 0
-        if pos == 0 and self.config.get("platform") == "mycroft_mark_2" and
-        len(self.loaded[0].pages) == 0:
+        if (pos == 0 and self.config.get("platform") == "mycroft_mark_2"
+                and len(self.loaded[0].pages) == 0):
             self.bus.emit(Message("mycroft.mark2.reset_idle"))
 
     def __insert_new_namespace(self, namespace, pages):

--- a/mycroft/enclosure/gui.py
+++ b/mycroft/enclosure/gui.py
@@ -228,9 +228,15 @@ class SkillGUI:
         # Convert pages to full reference
         page_urls = []
         for name in page_names:
-            page = self.skill.find_resource(name, 'ui')
+            if name.startswith("SYSTEM"):
+                page = resolve_resource_file(join('ui', name))
+            else:
+                page = self.skill.find_resource(name, 'ui')
             if page:
-                page_urls.append("file://" + page)
+                if self.config.get('remote'):
+                    page_urls.append(self.remote_url + "/" + page)
+                else:
+                    page_urls.append("file://" + page)
             else:
                 raise FileNotFoundError("Unable to find page: {}".format(name))
 


### PR DESCRIPTION
## Description
- Added missing check for "remote" and "system" page urls in remove pages GUI API
- Added check and emit show idle screen if current page position is 0 and no other pages are left in the namespace, ensures the idle screen is activated for the mark-2 enclosure when all pages are removed from the skill

## How to test
 ```
# Add a page in some function
self.gui.show_page("somepage.qml")
self.gui.show_page("somepage2.qml")
self.gui,remove_page("somepage2.qml")
self.gui.remove_page("somepage.qml")

# if all pages are removed it should go back to idle screen for platform mycroft_mark_2
```

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
