### PR TITLE
Remove six from dependencies

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,3 @@
-six==1.13.0
 requests==2.20.0
 gTTS==2.2.0
 PyAudio==0.2.11


### PR DESCRIPTION
## Description
Although some of the dependencies of MyCroft still use it, MyCroft
itself seems to have no uses of this anywhere, so let's get rid of it
(dependencies will pull it in on their own)

## How to test
Run the tests, validate normal functionality as before, run a `grep -r six`.

## Contributor license agreement signed?
CLA [X]
