### PR TITLE
docs: fix simple typo, retruns -> returns

### DIFF
--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -29,7 +29,7 @@ def read_vocab_file(path):
     """ Read voc file.
 
         This reads a .voc file, stripping out empty lines comments and expand
-        parentheses. It retruns each line as a list of all expanded
+        parentheses. It returns each line as a list of all expanded
         alternatives.
 
         Arguments:


### PR DESCRIPTION
There is a small typo in mycroft/skills/skill_data.py.

Should read `returns` rather than `retruns`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md