### PR TITLE
[sst-requirements] Add boto3 library

### DIFF
--- a/requirements/extra-stt.txt
+++ b/requirements/extra-stt.txt
@@ -1,1 +1,2 @@
 google-api-python-client==1.6.4
+boto3==1.16.44


### PR DESCRIPTION
## Description
When using Amazon Polly Text-To-Speech service, the `boto3` library is a requirement to make it works.

## How to test
Setup TTS within Mycroft using `polly` module.

## Contributor license agreement signed?
CLA [X]
