### PR TITLE
Do not download Precise if executable already exists

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -232,6 +232,8 @@ class PreciseHotword(HotWordEngine):
     def update_precise(self, precise_config):
         """Continously try to download precise until successful"""
         precise_exe = None
+        if exists(self.install_destination):
+            precise_exe = self.install_destination
         while not precise_exe:
             try:
                 precise_exe = self.install_exe(precise_config['dist_url'])
@@ -240,11 +242,8 @@ class PreciseHotword(HotWordEngine):
             except Exception as e:
                 LOG.error(
                     'Precise could not be downloaded({})'.format(repr(e)))
-                if exists(self.install_destination):
-                    precise_exe = self.install_destination
-                else:
-                    # Wait one minute before retrying
-                    sleep(60)
+                # Wait one minute before retrying
+                sleep(60)
         return precise_exe
 
     @property


### PR DESCRIPTION
This is partially a conversation starter unless it really turns out to be this simple.

Currently we repeatedly download Precise on first boot unless both the Precise engine tarball and extracted contents are present. IMO Precise should be preloaded with any distribution of Mycroft. If Precise is not present or fails, it can still fall back PocketSphinx but then clearly something has gone very wrong.

If the Precise engine is going to be updated, then this should be provided in an update of the Mycroft distribution.

I am however assuming that there are edge cases or side effects that I'm not considering. So very interested in why this PR is a bad idea?

## How to test
- Delete the Precise tarball at `~/.mycroft/precise/precise-engine_*.tar.gz`
- With the Precise engine executable in place, mycroft-core should not attempt to download Precise.
- Remove `~/.mycroft/precise/precise-engine/precise-engine`

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
