### PR TITLE
Unshadow Message class in _handle_pairing_complete

### DIFF
--- a/mycroft/client/enclosure/generic/__init__.py
+++ b/mycroft/client/enclosure/generic/__init__.py
@@ -80,7 +80,7 @@ class EnclosureGeneric(Enclosure):
     def speak(self, text):
         self.bus.emit(Message("speak", {'utterance': text}))
 
-    def _handle_pairing_complete(self, Message):
+    def _handle_pairing_complete(self, _):
         """
         Handler for 'mycroft.paired', unmutes the mic after the pairing is
         complete.


### PR DESCRIPTION
## Description
Fixes issue spotted by @j1nx, the "Message" class is shadowed by the unused "Message" argument.

Pairing (previously at least) muted the mic until pairing was complete. The restoration of the mic state has been broken (it seems) since the Mark-2 work began. Which leads me to believe that the initial mute of the mic isn't working.

This will not make things work worse and the code will do what it tries to do but if the mute during pairing is something we don't want in the future we should just remove this handler.

## Contributor license agreement signed?
CLA [ Yes ]