### PR TITLE
Vk error stability

### DIFF
--- a/test/integrationtests/voight_kampff/tools.py
+++ b/test/integrationtests/voight_kampff/tools.py
@@ -84,7 +84,7 @@ def mycroft_responses(context):
         responses = 'Mycroft responded with:\n'
         for m in messages:
             responses += 'Mycroft: '
-            if 'dialog' in m.data['meta']:
+            if 'meta' in m.data and 'dialog' in m.data['meta']:
                 responses += '{}.dialog'.format(m.data['meta']['dialog'])
             responses += '({})\n'.format(m.data['meta'].get('skill'))
             responses += '"{}"\n'.format(m.data['utterance'])


### PR DESCRIPTION
## Description
While testing #2578 we ran into a couple of issues in VK not handling some error cases in Mycroft core.

This PR ensures that
- Missing speak meta field is handled appropriately
- Waiting for config update times out eventually (10 seconds)

## How to test
Make sure Voight Kampff tests still pass. To check the timeout comment out lines 77 and 79 of `test/integrationtests/voight_kampff/features/steps/configuration.py` and run the tests for the fallback-query skill.

## Contributor license agreement signed?
CLA [ Yes ]