### PR TITLE
Read skills from XDG Base directory specification locations

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -26,6 +26,8 @@ ROOT_DIRNAME=$(dirname "$0")
 cd "$ROOT_DIRNAME"
 TOP=$(pwd -L)
 
+datadir=${XDG_DATA_HOME:-$HOME/.local/share}/mycroft
+
 function clean_mycroft_files() {
     echo '
 This will completely remove any files installed by mycroft (including pairing
@@ -39,6 +41,9 @@ Do you wish to continue? (y/n)'
         read -rN1 -s key
         case $key in
         [Yy])
+	    rm -r "$datadir"
+
+	    # Legacy locations
             sudo rm -rf /var/log/mycroft
             rm -f /var/tmp/mycroft_web_cache.json
             rm -rf "${TMPDIR:-/tmp}/mycroft"
@@ -108,7 +113,7 @@ fi
 
 for var in "$@" ; do
     # Check if parameter should be read
-    if [[ $param == 'python' ]] ; then
+	if [[ $param == 'python' ]] ; then
         opt_python=$var
         param=""
         continue
@@ -304,20 +309,10 @@ fi" > ~/.profile_mycroft
     # Create a link to the 'skills' folder.
     sleep 0.5
     echo
-    echo 'The standard location for Mycroft skills is under /opt/mycroft/skills.'
-    if [[ ! -d /opt/mycroft/skills ]] ; then
-        echo 'This script will create that folder for you.  This requires sudo'
-        echo 'permission and might ask you for a password...'
-        setup_user=$USER
-        setup_group=$(id -gn "$USER")
-        $SUDO mkdir -p /opt/mycroft/skills
-        $SUDO chown -R "${setup_user}":"${setup_group}" /opt/mycroft
-        echo 'Created!'
-    fi
     if [[ ! -d skills ]] ; then
-        ln -s /opt/mycroft/skills skills
+        ln -s "$datadir"/skills skills
         echo "For convenience, a soft link has been created called 'skills' which leads"
-        echo 'to /opt/mycroft/skills.'
+        echo "to $datadir/skills."
     fi
 
     # Add PEP8 pre-commit hook

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -106,13 +106,11 @@
       }
     },
     "upload_skill_manifest": true,
-    // Directory to look for user skills
-    "directory": "~/.local/share/mycroft/skills",
     // Enable auto update by msm
     "auto_update": true,
     // blacklisted skills to not load
     // NB: This is the basename() of the directory where the skill lives, so if
-    // the skill you want to blacklist is in /opt/mycroft/skills/mycroft-alarm.mycroftai/
+    // the skill you want to blacklist is in $XDG_DATA_DIR/mycroft/skills/mycroft-alarm.mycroftai/
     // then you should write `["mycroft-alarm.mycroftai"]` below.
     "blacklisted_skills": [],
     // priority skills to be loaded first

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -22,6 +22,7 @@ frequently.  To improve performance, the MSM instance is cached.
 from collections import namedtuple
 from functools import lru_cache
 from os import path, makedirs
+import xdg.BaseDirectory
 
 from msm import MycroftSkillsManager, SkillRepo
 
@@ -34,9 +35,8 @@ MsmConfig = namedtuple(
     [
         'platform',
         'repo_branch',
-        'repo_cache',
         'repo_url',
-        'skills_dir',
+        'old_skills_dir',
         'versioned'
     ]
 )
@@ -71,9 +71,8 @@ def build_msm_config(device_config: dict) -> MsmConfig:
     return MsmConfig(
         platform=enclosure_config.get('platform', 'default'),
         repo_branch=msm_repo_config['branch'],
-        repo_cache=path.join(data_dir, msm_repo_config['cache']),
         repo_url=msm_repo_config['url'],
-        skills_dir=path.join(data_dir, msm_config['directory']),
+        old_skills_dir=path.join(data_dir, msm_config['directory']),
         versioned=msm_config['versioned']
     )
 
@@ -95,17 +94,15 @@ def create_msm(msm_config: MsmConfig) -> MycroftSkillsManager:
     msm_lock = _init_msm_lock()
     LOG.info('Acquiring lock to instantiate MSM')
     with msm_lock:
-        if not path.exists(msm_config.skills_dir):
-            makedirs(msm_config.skills_dir)
+        xdg.BaseDirectory.save_data_path('mycroft/skills')
 
         msm_skill_repo = SkillRepo(
-            msm_config.repo_cache,
             msm_config.repo_url,
             msm_config.repo_branch
         )
         msm_instance = MycroftSkillsManager(
             platform=msm_config.platform,
-            skills_dir=msm_config.skills_dir,
+            old_skills_dir=msm_config.old_skills_dir,
             repo=msm_skill_repo,
             versioned=msm_config.versioned
         )

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -124,7 +124,7 @@ class MycroftSkill:
 
         # Get directory of skill
         #: Member variable containing the absolute path of the skill's root
-        #: directory. E.g. /opt/mycroft/skills/my-skill.me/
+        #: directory. E.g. $XDG_DATA_HOME/mycroft/skills/my-skill.me/
         self.root_dir = dirname(abspath(sys.modules[self.__module__].__file__))
 
         self.gui = SkillGUI(self)

--- a/mycroft/skills/settings.py
+++ b/mycroft/skills/settings.py
@@ -99,7 +99,7 @@ def save_settings(skill_dir, skill_settings):
     """Save skill settings to file."""
     settings_path = Path(skill_dir).joinpath('settings.json')
 
-    # Either the file already exists in /opt, or we are writing
+    # Either the file already exists or we are writing
     # to XDG_CONFIG_DIR and always have the permission to make
     # sure the file always exists
     if not Path(settings_path).exists():

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -18,6 +18,7 @@ from glob import glob
 from threading import Thread, Event, Lock
 from time import sleep, time, monotonic
 from inspect import signature
+import xdg.BaseDirectory
 
 from mycroft.api import is_paired
 from mycroft.enclosure.api import EnclosureAPI
@@ -264,7 +265,9 @@ class SkillManager(Thread):
 
     def _remove_git_locks(self):
         """If git gets killed from an abrupt shutdown it leaves lock files."""
-        for i in glob(os.path.join(self.msm.skills_dir, '*/.git/index.lock')):
+        for i in glob(os.path.join(
+            xdg.BaseDirectory.save_data_path('mycroft/skills'),
+                '*/.git/index.lock')):
             LOG.warning('Found and removed git lock file: ' + i)
             os.remove(i)
 
@@ -310,7 +313,8 @@ class SkillManager(Thread):
         return skill_loader if load_status else None
 
     def _get_skill_directories(self):
-        skill_glob = glob(os.path.join(self.msm.skills_dir, '*/'))
+        skill_glob = glob(os.path.join(
+            xdg.BaseDirectory.save_data_path('mycroft/skills'), '*/'))
 
         skill_directories = []
         for skill_dir in skill_glob:

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -55,7 +55,8 @@ class SkillUpdater:
         self.config = Configuration.get()
         update_interval = self.config['skills']['update_interval']
         self.update_interval = int(update_interval) * ONE_HOUR
-        self.dot_msm_path = os.path.join(self.msm.skills_dir, '.msm')
+        self.dot_msm_path = os.path.join(
+                xdg.BaseDirectory.save_data_path('mycroft/skills'), '.msm')
         self.next_download = self._determine_next_download_time()
         self._log_next_download_time()
         self.installed_skills = set()

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 testpaths = test
 norecursedirs = wake_word
+env =
+    XDG_DATA_HOME=/tmp/mycroft-test

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -15,7 +15,7 @@ fasteners==0.14.1
 PyYAML~=5.4
 
 lingua-franca==0.4.2
-msm==0.8.9
+msm==0.9.0
 msk==0.3.16
 mycroft-messagebus-client==0.9.4
 adapt-parser==0.5.1

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -2,6 +2,7 @@ coveralls==1.8.2
 flake8==3.7.9
 pytest==5.2.4
 pytest-cov==2.8.1
+pytest-env==0.6.2
 cov-core==1.15.0
 sphinx==2.2.1
 sphinx-rtd-theme==0.4.3

--- a/test/integrationtests/voight_kampff/test_setup.py
+++ b/test/integrationtests/voight_kampff/test_setup.py
@@ -204,7 +204,10 @@ def create_skills_manager(platform, skills_dir, url, branch):
         MycroftSkillsManager
     """
     repo = SkillRepo(url=url, branch=branch)
-    return MycroftSkillsManager(platform, skills_dir, repo)
+    return MycroftSkillsManager(
+            platform=platform,
+            skills_dir=skills_dir,
+            repo=repo)
 
 
 def main(args):

--- a/test/unittests/base.py
+++ b/test/unittests/base.py
@@ -18,6 +18,8 @@ from shutil import rmtree
 from unittest import TestCase
 from unittest.mock import patch
 
+import xdg.BaseDirectory
+
 from .mocks import mock_msm, mock_config, MessageBusMock
 
 
@@ -54,3 +56,4 @@ class MycroftUnitTestBase(TestCase):
 
     def tearDown(self):
         rmtree(str(self.temp_dir))
+        rmtree(xdg.BaseDirectory.save_data_path('mycroft'))

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 from os import path
+from pathlib import Path
+import xdg.BaseDirectory
 from unittest import TestCase
 from unittest.mock import Mock, patch
 
@@ -95,7 +97,10 @@ class TestSkillManager(MycroftUnitTestBase):
         self.skill_updater_mock = skill_updater_patch.start()
 
     def _mock_skill_loader_instance(self):
-        self.skill_dir = self.temp_dir.joinpath('test_skill')
+        self.skill_dir = (
+            Path(xdg.BaseDirectory.save_data_path('mycroft/skills'))
+            .joinpath('test_skill')
+        )
         self.skill_loader_mock = Mock(spec=SkillLoader)
         self.skill_loader_mock.instance = Mock()
         self.skill_loader_mock.instance.default_shutdown = Mock()
@@ -128,8 +133,9 @@ class TestSkillManager(MycroftUnitTestBase):
         )
 
     def test_remove_git_locks(self):
-        git_dir = self.temp_dir.joinpath('foo/.git')
-        git_dir.mkdir(parents=True)
+        git_dir = Path(
+                xdg.BaseDirectory.save_data_path('mycroft/skills/foo/.git')
+            )
         git_lock_file_path = str(git_dir.joinpath('index.lock'))
         with open(git_lock_file_path, 'w') as git_lock_file:
             git_lock_file.write('foo')

--- a/test/unittests/skills/test_skill_updater.py
+++ b/test/unittests/skills/test_skill_updater.py
@@ -247,10 +247,11 @@ class TestSkillUpdater(MycroftUnitTestBase):
 
     def test_update_download_time(self):
         """Test updating the next time a download will occur."""
-        dot_msm_path = self.temp_dir.joinpath('.msm')
-        dot_msm_path.touch()
-        dot_msm_mtime_before = dot_msm_path.stat().st_mtime
+        skill_updater = SkillUpdater(self.message_bus_mock)
+        skill_updater.dot_msm_path = self.temp_dir.joinpath('.msm')
+        skill_updater.dot_msm_path.touch()
+        dot_msm_mtime_before = skill_updater.dot_msm_path.stat().st_mtime
         sleep(0.5)
-        SkillUpdater(self.message_bus_mock)._update_download_time()
-        dot_msm_mtime_after = dot_msm_path.stat().st_mtime
+        skill_updater._update_download_time()
+        dot_msm_mtime_after = skill_updater.dot_msm_path.stat().st_mtime
         self.assertLess(dot_msm_mtime_before, dot_msm_mtime_after)


### PR DESCRIPTION
## Description
~This makes mycroft-core read skills from all locations as specified by the XDG Base Directory specification, so in `/usr/share/mycroft/skills`, `/usr/local/share/mycroft/skills`, and `$XDG_DATA_HOME/.local/share/mycroft/skills` if it exists and otherwise `~/.local/share/mycroft/skills`.~

This makes mycroft-core read skills from the XDG Base Directory location in the user's home folder, so `$XDG_DATA_HOME/.local/share/mycroft/skills` if it exists and otherwise `~/.local/share/mycroft/skills`.

This requires https://github.com/MycroftAI/mycroft-skills-manager/pull/90 for the installation of skills part.

## How to test
1. Apply https://github.com/MycroftAI/mycroft-skills-manager/pull/90 to msm
2. Install some skills
3. Start Mycroft and check if skills in the required directories are being loaded properly

## Contributor license agreement signed?
CLA [x]
