### PR TITLE
Bugfix/audioservice issues

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -356,19 +356,13 @@ class AudioService:
             self.current.lower_volume()
             self.volume_is_low = True
 
-    def _restore_volume(self, message=None):
-        """
-            Is triggered when mycroft is done speaking and restores the volume
-
-            Args:
-                message: message bus message, not used but required
-        """
-        if self.current:
+    def _restore_volume(self, _=None):
+        """Triggered when mycroft is done speaking and restores the volume."""
+        current = self.current
+        if current:
             LOG.debug('restoring volume')
             self.volume_is_low = False
-            time.sleep(2)
-            if not self.volume_is_low:
-                self.current.restore_volume()
+            current.restore_volume()
 
     def _restore_volume_after_record(self, message=None):
         """

--- a/mycroft/tts/dummy_tts.py
+++ b/mycroft/tts/dummy_tts.py
@@ -27,6 +27,7 @@ class DummyTTS(TTS):
     def execute(self, sentence, ident=None, listen=False):
         """Don't do anything, return nothing."""
         LOG.info('Mycroft: {}'.format(sentence))
+        self.end_audio(listen)
         return None
 
 


### PR DESCRIPTION
## Description
This is an attempt to make the audioservice behave better in the VK test. In particular it tries to handle exceptions seen in the audio.log after a failing VK run such as:

```
Traceback (most recent call last):
  File "/usr/lib/python3.6/concurrent/futures/_base.py", line 324, in _invoke_callbacks
    callback(self)
  File "/opt/mycroft/mycroft-core/.venv/lib/python3.6/site-packages/pyee/_executor.py", line 56, in _callback
    self.emit('error', exc)
  File "/opt/mycroft/mycroft-core/.venv/lib/python3.6/site-packages/pyee/_base.py", line 116, in emit
    self._emit_handle_potential_error(event, args[0] if args else None)
  File "/opt/mycroft/mycroft-core/.venv/lib/python3.6/site-packages/pyee/_base.py", line 86, in _emit_handle_potential_error
    raise error
  File "/usr/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/opt/mycroft/mycroft-core/mycroft/audio/services/simple/__init__.py", line 90, in _play
    if isinstance(self.tracks[self.index], list):
IndexError: list index out of range
```

This PR adds a lock and a check that the track in question still exists before starting playback.

It also handles an issue where the playback isn't restored as it should after speaking when using the dummy tts module 

## How to test
(Description of how to validate or test this PR)

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
