### PR TITLE
Add update comment logic to Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -120,16 +120,33 @@ pipeline {
                 }
                 failure {
                     script {
+                        def comment_text = 'Voight Kampff Integration Test Failed ([Results](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + ')). ' +
+                                           '\nMycroft logs are also available: ' +
+                                           '[skills.log](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '/logs/skills.log), ' +
+                                           '[audio.log](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '/logs/audio.log), ' +
+                                           '[voice.log](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '/logs/voice.log), ' +
+                                           '[bus.log](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '/logs/bus.log), ' +
+                                           '[enclosure.log](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '/logs/enclosure.log)'
+
                         // Create comment for Pull Requests
                         if (env.CHANGE_ID) {
-                            echo 'Sending PR comment'
-                            pullRequest.comment('Voight Kampff Integration Test Failed ([Results](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + ')). ' +
-                                                '\nMycroft logs are also available: ' +
-                                                '[skills.log](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '/logs/skills.log), ' +
-                                                '[audio.log](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '/logs/audio.log), ' +
-                                                '[voice.log](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '/logs/voice.log), ' +
-                                                '[bus.log](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '/logs/bus.log), ' +
-                                                '[enclosure.log](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '/logs/enclosure.log)')
+                            def found_comment = false
+                            for (comment in pullRequest.comments) {
+                                echo "Author: ${comment.user}"
+                                if (comment.user == "devops-mycroft" &&
+                                    comment.body.contains("Voight Kampff")) {
+                                    echo "Updating comment..."
+                                    found_comment = true
+                                    pullRequest.editComment(
+                                        comment.id,
+                                        comment_text
+                                    )
+                                }
+                            } 
+                            if (!found_comment) {
+                                echo 'Sending PR comment'
+                                pullRequest.comment(comment_text)
+                            }
                         }
                     }
                     // Send failure email containing a link to the Jenkins build
@@ -184,8 +201,25 @@ pipeline {
                 success {
                     script {
                         if (env.CHANGE_ID) {
-                            echo 'Sending PR comment'
-                            pullRequest.comment('Voight Kampff Integration Test Succeeded  ([Results](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '))')
+                            def comment_text = 'Voight Kampff Integration Test Succeeded  ([Results](https://reports.mycroft.ai/core/' + env.BRANCH_ALIAS + '))'
+                            def found_comment = false
+                            for (comment in pullRequest.comments) {
+                                echo "Author: ${comment.user}"
+                                if (comment.user == "devops-mycroft" &&
+                                    comment.body.contains("Voight Kampff")) {
+                                    echo "Updating comment!"
+                                    found_comment = true
+                                    pullRequest.editComment(
+                                        comment.id,
+                                        comment_text
+                                    )
+                                    break
+                                }
+                            } 
+                            if (!found_comment) {
+                                echo 'Sending PR comment'
+                                pullRequest.comment(comment_text)
+                            }
                         }
                     }
                     // Send success email containing a link to the Jenkins build


### PR DESCRIPTION
## Description
Makes VK tests update an existing comment if present instead of always sending a new comment. Suggested by @JarbasAI on the chat.

So the logic is

No existing comment and CICD was Successful -> No comment will be made
No existing comment and CICD was *not* Successful -> Comment will be added
Existing comment and CICD was Successful -> Comment will be modified showing the success message
Existing comment and CICD was *not* Successful -> Comment will be modified to show the latest information

## Contributor license agreement signed?
CLA [ Yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
