### PR TITLE
Add VK method to wait for audio service

### DIFF
--- a/test/integrationtests/voight_kampff/__init__.py
+++ b/test/integrationtests/voight_kampff/__init__.py
@@ -15,4 +15,4 @@
 
 from .tools import (emit_utterance, wait_for_dialog, then_wait,
                     then_wait_fail, mycroft_responses,
-                    print_mycroft_responses)
+                    print_mycroft_responses, wait_for_audio_service)

--- a/test/integrationtests/voight_kampff/tools.py
+++ b/test/integrationtests/voight_kampff/tools.py
@@ -133,3 +133,30 @@ def wait_for_dialog(bus, dialogs, context=None, timeout=None):
                 return
         bus.new_message_available.wait(0.5)
     bus.clear_messages()
+
+
+def wait_for_audio_service(context, message_type):
+    """Wait for audio.service message that matches type provided.
+
+    May be play, stop, or pause messages
+
+    Arguments:
+        context (behave Context): optional context providing scenario timeout
+        message_type (string): final component of bus message in form
+                               `mycroft.audio.service.{type}
+    """
+    msg_type = 'mycroft.audio.service.{}'.format(message_type)
+
+    def check_for_msg(message):
+        return (message.msg_type == msg_type, '')
+
+    passed, debug = then_wait(msg_type, check_for_msg, context)
+
+    if not passed:
+        debug += mycroft_responses(context)
+    if not debug:
+        if message_type == 'play':
+            message_type = 'start'
+        debug = "Mycroft didn't {} playback".format(message_type)
+
+    assert passed, debug


### PR DESCRIPTION
## Description
Adds a method for VK tests to wait for the Audio Service to play, pause or stop. 

This was originally used in the News Skill and was called `wait_for_service_message`. However given it is specifically about the audio service, this seems like a more descriptive term.

This is also being added to the Singing Skill (https://github.com/MycroftAI/skill-singing/pull/35)

## How to test
Import into the Singing Skill VK tests.
