### PR TITLE
Stop location being referenced before assignment

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -139,6 +139,7 @@ class RemoteConf(LocalConf):
             api = DeviceApi()
             setting = api.get_settings()
 
+            location = None
             try:
                 location = api.get_location()
             except RequestException as e:


### PR DESCRIPTION
## Description
In cases where the location can't be determined by the device or a
config setting, the location variable wouldn't exist but it would still
be referenced.
This makes sure the variable always exists, but if not changed is equal
to None

## How to test
Run Mycroft on a device with no location set in config or accessible via GPS or anything. Notice in the voice log that location is being referenced before assignment.
Then run Mycroft with this PR and notice the error is gone.

## Contributor license agreement signed?
CLA [x]
