### PR TITLE
Issue-2812 - Allow overridden converse methods to accept messages

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -334,7 +334,7 @@ class MycroftSkill:
         """
         return None
 
-    def converse(self, utterances=None, lang=None, message=None):
+    def converse(self, message=None):
         """Handle conversation.
 
         This method gets a peek at utterances before the normal intent

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -343,7 +343,7 @@ class MycroftSkill:
         To use, override the converse() method and return True to
         indicate that the utterance has been handled.
 
-        utterances and lang are depreciated and shout NOT be used in newer skills
+        utterances and lang are depreciated
 
         Arguments:
             message:    a message object containing a message type with an

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -334,7 +334,7 @@ class MycroftSkill:
         """
         return None
 
-    def converse(self, utterances, lang=None):
+    def converse(self, utterances, lang=None, message=None):
         """Handle conversation.
 
         This method gets a peek at utterances before the normal intent
@@ -350,6 +350,8 @@ class MycroftSkill:
                                first entry is the user utt and the second
                                is normalized() version of the first utterance
             lang:       language the utterance is in, None for default
+            message:    a message object containing a message type with an
+                        optional JSON data packet
 
         Returns:
             bool: True if an utterance was handled, otherwise False

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -334,7 +334,7 @@ class MycroftSkill:
         """
         return None
 
-    def converse(self, utterances, lang=None, message=None):
+    def converse(self, utterances=None, lang=None, message=None):
         """Handle conversation.
 
         This method gets a peek at utterances before the normal intent
@@ -343,13 +343,9 @@ class MycroftSkill:
         To use, override the converse() method and return True to
         indicate that the utterance has been handled.
 
+        utterances and lang are depreciated and shout NOT be used in newer skills
+
         Arguments:
-            utterances (list): The utterances from the user.  If there are
-                               multiple utterances, consider them all to be
-                               transcription possibilities.  Commonly, the
-                               first entry is the user utt and the second
-                               is normalized() version of the first utterance
-            lang:       language the utterance is in, None for default
             message:    a message object containing a message type with an
                         optional JSON data packet
 

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -444,8 +444,6 @@ class SkillManager(Thread):
                     self._emit_converse_error(message, skill_id, error_message)
                     break
                 try:
-                    utterances = message.data['utterances']
-                    lang = message.data['lang']
                     # check the signature of a converse method to either pass a message or not
                     if len(signature(skill_loader.instance.converse).parameters) == 1:
                         result = skill_loader.instance.converse(message)

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -447,9 +447,11 @@ class SkillManager(Thread):
                     utterances = message.data['utterances']
                     lang = message.data['lang']
                     # check the signature of a converse method to either pass a message or not
-                    if len(signature(skill_loader.instance.converse).parameters) == 3:
-                        result = skill_loader.instance.converse(utterances, lang, message)
+                    if len(signature(skill_loader.instance.converse).parameters) == 1:
+                        result = skill_loader.instance.converse(message)
                     else:
+                        utterances = message.data['utterances']
+                        lang = message.data['lang']
                         result = skill_loader.instance.converse(utterances, lang)
                     self._emit_converse_response(result, message, skill_loader)
                 except Exception:

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -17,6 +17,7 @@ import os
 from glob import glob
 from threading import Thread, Event, Lock
 from time import sleep, time, monotonic
+from inspect import signature
 
 from mycroft.api import is_paired
 from mycroft.enclosure.api import EnclosureAPI
@@ -445,7 +446,11 @@ class SkillManager(Thread):
                 try:
                     utterances = message.data['utterances']
                     lang = message.data['lang']
-                    result = skill_loader.instance.converse(utterances, lang)
+                    # check the signature of a converse method to either pass a message or not
+                    if len(signature(skill_loader.instance.converse).parameters) == 3:
+                        result = skill_loader.instance.converse(utterances, lang, message)
+                    else:
+                        result = skill_loader.instance.converse(utterances, lang)
                     self._emit_converse_response(result, message, skill_loader)
                 except Exception:
                     error_message = 'exception in converse method'

--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -444,13 +444,17 @@ class SkillManager(Thread):
                     self._emit_converse_error(message, skill_id, error_message)
                     break
                 try:
-                    # check the signature of a converse method to either pass a message or not
-                    if len(signature(skill_loader.instance.converse).parameters) == 1:
-                        result = skill_loader.instance.converse(message)
+                    # check the signature of a converse method
+                    # to either pass a message or not
+                    if len(signature(
+                            skill_loader.instance.converse).parameters) == 1:
+                        result = skill_loader.instance.converse(
+                            message=message)
                     else:
                         utterances = message.data['utterances']
                         lang = message.data['lang']
-                        result = skill_loader.instance.converse(utterances, lang)
+                        result = skill_loader.instance.converse(
+                            utterances=utterances, lang=lang)
                     self._emit_converse_response(result, message, skill_loader)
                 except Exception:
                     error_message = 'exception in converse method'


### PR DESCRIPTION
## Description
Fixes #2812 
In SkillManager.handle_converse_request(), add a function signature check to pass either an overridden converse or the default one.

## How to test
This change should have no effect on existing Mycroft (or compatible) skills and should be testing on a skill that requires skill.converse to have access to messages passed into SkillManager.handle_converse_request.

## Contributor license agreement signed?
Yes
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
