### PR TITLE
Bug Fix - Don't clear namespace on every system page call

### DIFF
--- a/mycroft/enclosure/gui.py
+++ b/mycroft/enclosure/gui.py
@@ -259,7 +259,6 @@ class SkillGUI:
                 True: Disables showing all platform skill animations.
                 False: 'Default' always show animations.
         """
-        self.clear()
         self["text"] = text
         self["title"] = title
         self.show_page("SYSTEM_TextFrame.qml", override_idle,
@@ -284,7 +283,6 @@ class SkillGUI:
                 True: Disables showing all platform skill animations.
                 False: 'Default' always show animations.
         """
-        self.clear()
         self["image"] = url
         self["title"] = title
         self["caption"] = caption
@@ -311,7 +309,6 @@ class SkillGUI:
                 True: Disables showing all platform skill animations.
                 False: 'Default' always show animations.
         """
-        self.clear()
         self["image"] = url
         self["title"] = title
         self["caption"] = caption
@@ -334,7 +331,6 @@ class SkillGUI:
                 True: Disables showing all platform skill animations.
                 False: 'Default' always show animations.
         """
-        self.clear()
         self["html"] = html
         self["resourceLocation"] = resource_url
         self.show_page("SYSTEM_HtmlFrame.qml", override_idle,
@@ -354,7 +350,6 @@ class SkillGUI:
                 True: Disables showing all platform skill animations.
                 False: 'Default' always show animations.
         """
-        self.clear()
         self["url"] = url
         self.show_page("SYSTEM_UrlFrame.qml", override_idle,
                        override_animations)


### PR DESCRIPTION
## Description
Calling self.clear() on every show some system page event causes mycroft to remove the namespace from active index and reinsert it constantly with a flood of messages, skills showing a page of text self.gui.show_text() for example should only emit the data changes and not try reinserting and removing skill namespace constantly. If an skill author wants to clear the data they can manually call the self.gui.clear() method before calling self.gui.show_text() 

## How to test
Use self.gui.show_text("some text..") in a while loop and make sure it does not keep removing and re inserting the skill namespace from active skill index only sends the set data message with the changed data values

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
