### PR TITLE
Bug Fix - Use the correct delegate, fix layouts, autofit text for System TextFrame

### DIFF
--- a/mycroft/res/ui/SYSTEM_TextFrame.qml
+++ b/mycroft/res/ui/SYSTEM_TextFrame.qml
@@ -5,7 +5,7 @@ import org.kde.kirigami 2.4 as Kirigami
 
 import Mycroft 1.0 as Mycroft
 
-Mycroft.ProportionalDelegate {
+Mycroft.Delegate {
     id: systemTextFrame
     skillBackgroundColorOverlay: "#000000"
     property bool hasTitle: sessionData.title.length > 0 ? true : false
@@ -13,27 +13,30 @@ Mycroft.ProportionalDelegate {
     Component.onCompleted: {
         console.log(hasTitle)
     }
-    
-    Mycroft.AutoFitLabel {
-        id: systemTextFrameTitle
-        Layout.fillWidth: true
-        Layout.preferredHeight: proportionalGridUnit * 20
-        wrapMode: Text.Wrap
-        visible: hasTitle
-        enabled: hasTitle
-        font.family: "Noto Sans"
-        font.weight: Font.Bold
-        text: sessionData.title        
-    }
-    
-    Mycroft.AutoFitLabel {
-        id: systemTextFrameMainBody
-        Layout.fillWidth: true
-        Layout.preferredHeight: proportionalGridUnit * 30
-        wrapMode: Text.Wrap
-        font.family: "Noto Sans"
-        font.weight: Font.Bold
-        text: sessionData.text
+
+    contentItem: ColumnLayout {
+        Label {
+            id: systemTextFrameTitle
+            Layout.fillWidth: true
+            font.pixelSize: Math.min(systemTextFrame.height/4, Math.max(systemTextFrame.height/10, systemTextFrameMainBody.fontInfo.pixelSize * 1.4))
+            wrapMode: Text.Wrap
+            horizontalAlignment: Text.AlignHCenter
+            visible: hasTitle
+            enabled: hasTitle
+            font.family: "Noto Sans"
+            font.weight: Font.Bold
+            text: sessionData.title
+        }
+        
+        Mycroft.AutoFitLabel {
+            id: systemTextFrameMainBody
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            wrapMode: Text.Wrap
+            font.family: "Noto Sans"
+            font.weight: Font.Bold
+            text: sessionData.text
+        }
     }
 }
  


### PR DESCRIPTION
## Description
Switch the text frame to use the correct delegate, fixes layout and autofit text should scale properly with word wrapping

## How to test
self.gui.show_text("some very long text / paragraph") and the text should be scaling properly

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
