### PR TITLE
Feature/gui get

### DIFF
--- a/mycroft/enclosure/gui.py
+++ b/mycroft/enclosure/gui.py
@@ -110,6 +110,10 @@ class SkillGUI:
         """Implements get part of dict-like behaviour with named keys."""
         return self.__session_data[key]
 
+    def get(self, *args, **kwargs):
+        """Implements the get method for accessing dict keys."""
+        return self.__session_data.get(*args, **kwargs)
+
     def __contains__(self, key):
         """Implements the "in" operation."""
         return self.__session_data.__contains__(key)

--- a/test/unittests/enclosure/test_gui.py
+++ b/test/unittests/enclosure/test_gui.py
@@ -150,3 +150,12 @@ class TestSkillGUI(TestCase):
         response = None
         self.mock_skill.bus.wait_for_response.return_value = response
         self.assertFalse(self.gui.connected)
+
+    def test_get(self):
+        """Ensure the get method returns expected values."""
+        self.gui["example"] = "value"
+        self.assertEqual(self.gui.get("example"), "value")
+        self.assertEqual(self.gui.get("nothing"), None)
+        self.assertEqual(self.gui.get(0), None)
+        self.gui[0] = "value"
+        self.assertEqual(self.gui.get(0), "value")

--- a/test/unittests/enclosure/test_gui.py
+++ b/test/unittests/enclosure/test_gui.py
@@ -159,3 +159,27 @@ class TestSkillGUI(TestCase):
         self.assertEqual(self.gui.get(0), None)
         self.gui[0] = "value"
         self.assertEqual(self.gui.get(0), "value")
+
+    def test_clear(self):
+        """Ensure that namespace is cleared."""
+        self.gui["example"] = "value"
+        self.assertEqual(self.gui.get("example"), "value")
+        self.gui.clear()
+        self.assertEqual(self.gui.get("example"), None)
+
+    def test_release(self):
+        """Ensure the correct method and data is sent to close a Skill."""
+        self.gui.show_page('meaning.qml')
+        self.gui.release()
+        sent_message = self.mock_skill.bus.emit.call_args_list[-1][0][0]
+        self.assertEqual(sent_message.msg_type, 'mycroft.gui.screen.close')
+        self.assertEqual(sent_message.data['skill_id'], 'fortytwo-skill')
+
+    def test_shutdown(self):
+        """Ensure the GUI is cleared and Skill ref removed on shutdown."""
+        self.gui["example"] = "value"
+        self.gui.show_page('meaning.qml')
+        self.assertEqual(self.gui.skill, self.mock_skill)
+        self.gui.shutdown()
+        self.assertEqual(self.gui.get("example"), None)
+        self.assertEqual(self.gui.skill, None)


### PR DESCRIPTION
## Description
Currently if a Skill attempts to access a value on the GUI interface that doesn't exist a KeyError will be raised. 

This implements the Pythonic behaviour of a dict.get() method to provide a safer mechanism for accessing those keys including an optional parameter for returning a default value. 

While there, I added some extra unittests for the `SkillGUI` class.

## How to test
Unit tests included. Or you can drop the following into a Skills `initialize` method
```Python
        self.gui['some'] = 'value'
        self.log.info(self.gui['some'])
        self.log.info(self.gui.get('thing', "WORKING"))
        self.log.info(self.gui['thing'])  # Raises KeyError
```

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
