### PR TITLE
Refactor/stop speaking

### DIFF
--- a/mycroft/audio/utils.py
+++ b/mycroft/audio/utils.py
@@ -39,11 +39,7 @@ def wait_while_speaking():
 
 
 def stop_speaking():
-    # TODO: Less hacky approach to this once Audio Manager is implemented
-    # Skills should only be able to stop speech they've initiated
-    from mycroft.messagebus.send import send
-    send('mycroft.audio.speech.stop')
+    """Stop mycroft speech.
 
-    # Block until stopped
-    while check_for_signal("isSpeaking", -1):
-        time.sleep(0.25)
+    TODO: Skills should only be able to stop speech they've initiated
+    """

--- a/mycroft/audio/utils.py
+++ b/mycroft/audio/utils.py
@@ -14,7 +14,7 @@
 #
 import time
 
-from mycroft.util.signal import check_for_signal, create_signal
+from mycroft.util.signal import check_for_signal
 
 
 def is_speaking():
@@ -42,12 +42,8 @@ def stop_speaking():
     # TODO: Less hacky approach to this once Audio Manager is implemented
     # Skills should only be able to stop speech they've initiated
     from mycroft.messagebus.send import send
-    create_signal('stoppingTTS')
     send('mycroft.audio.speech.stop')
 
     # Block until stopped
     while check_for_signal("isSpeaking", -1):
         time.sleep(0.25)
-
-    # This consumes the signal
-    check_for_signal('stoppingTTS')

--- a/mycroft/audio/utils.py
+++ b/mycroft/audio/utils.py
@@ -43,3 +43,10 @@ def stop_speaking():
 
     TODO: Skills should only be able to stop speech they've initiated
     """
+    if is_speaking():
+        from mycroft.messagebus.send import send
+        send('mycroft.audio.speech.stop')
+
+        # Block until stopped
+        while check_for_signal("isSpeaking", -1):
+            time.sleep(0.25)

--- a/test/unittests/audio/test_utils.py
+++ b/test/unittests/audio/test_utils.py
@@ -58,10 +58,21 @@ class TestInterface(unittest.TestCase):
         sleep(2)
         self.assertTrue(done_waiting)
 
+    @mock.patch('mycroft.audio.utils.is_speaking')
     @mock.patch('mycroft.messagebus.send_func.send')
-    def test_stop_speaking(self, mock_send):
+    def test_stop_speaking(self, mock_send, mock_is_speaking):
+        """Test that stop speak message is sent."""
+        mock_is_speaking.return_value = True
         mycroft.audio.stop_speaking()
         mock_send.assert_called_with('mycroft.audio.speech.stop')
+
+    @mock.patch('mycroft.audio.utils.is_speaking')
+    @mock.patch('mycroft.messagebus.send_func.send')
+    def test_stop_speaking_when_not(self, mock_send, mock_is_speaking):
+        """Check that the stop speaking msg isn't sent when not speaking."""
+        mock_is_speaking.return_value = False
+        mycroft.audio.stop_speaking()
+        mock_send.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Minor update of `stop_speaking` removing the filesystem signal that is no longer used. In addition:

- Fixed the missing doc string
- It also include a common check to only send the stop message if Mycroft is actually speaking

Also improved a failing unrelated unittest regarding the simple audioservice backend
## How to test
Ensure that the unit tests pass

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
