### PR TITLE
Reorder operations to ensure removed Skills are first unloaded.

### DIFF
--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -240,9 +240,9 @@ class SkillManager(Thread):
         # unload the existing version from memory and reload from the disk.
         while not self._stop_event.is_set():
             try:
+                self._unload_removed_skills()
                 self._reload_modified_skills()
                 self._load_new_skills()
-                self._unload_removed_skills()
                 self._update_skills()
                 if (is_paired() and self.upload_queue.started and
                         len(self.upload_queue) > 0):


### PR DESCRIPTION
Prevents SkillManager from attempting to reload a Skill that has just been removed from the system which results in a `FileNotFoundError`

Fixes #2822

## How to test
Run Skills unit tests and ensure nothing has broken. 

## Contributor license agreement signed?
- [x] CLA
