### PR TITLE
Add Mozilla TTS connection validation

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -309,8 +309,7 @@
       "voice": "m1"
     },
     "mozilla": {
-      "lang": "de",
-      "url": "http://0.0.0.0:5002/api/tts"
+      "url": "http://0.0.0.0:5002"
     }
   },
 

--- a/mycroft/tts/mozilla_tts.py
+++ b/mycroft/tts/mozilla_tts.py
@@ -27,7 +27,7 @@ class MozillaTTS(TTS):
             self.config = config
         super(MozillaTTS, self).__init__(lang, self.config,
                                          MozillaTTSValidator(self))
-        self.url = self.config['url']
+        self.url = self.config['url'] + "/api/tts"
         self.type = 'wav'
 
     def get_tts(self, sentence, wav_file):
@@ -49,8 +49,10 @@ class MozillaTTSValidator(TTSValidator):
         pass
 
     def validate_connection(self):
-        # TODO
-        pass
+        url = self.tts.config['url']
+        response = requests.get(url)
+        if not response.status_code == 200:
+            raise ConnectionRefusedError
 
     def get_tts_class(self):
         return MozillaTTS


### PR DESCRIPTION
Replication of PR #2719
Original code from @JarbasAl

## Description
Validates the ability to connect to the defined Mozilla TTS instance.

## How to test
Run Mozilla TTS and configure Mycroft to use it.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
