### PR TITLE
Send correct conf to mimic when used as fallback

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install compilers
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -y gcc-4.8 g++-4.8
+        sudo apt-get install -y gcc g++
     - name: Install Python packages for testing
       run: pip install -r requirements/tests.txt
     - name: Setup mycroft core
@@ -51,7 +51,6 @@ jobs:
         if [[ ${{ matrix.python-version }} == 3.9 ]]; then ./dev_setup.sh; fi
         if [[ ${{ matrix.python-version }} != 3.9 ]]; then ./dev_setup.sh -sm; fi
       env:
-        CC: gcc-4.8
         CI: true
     - name: Linting and code style
       run: |

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -571,10 +571,10 @@ class TTSFactory:
                 LOG.exception('The selected TTS backend couldn\'t be loaded. '
                               'Falling back to Mimic')
                 clazz = TTSFactory.CLASSES.get('mimic')
+                tts_config = config.get('tts', {}).get('mimic', {})
                 tts = clazz(tts_lang, tts_config)
                 tts.validator.validate()
             else:
                 LOG.exception('The TTS could not be loaded.')
                 raise
-
         return tts

--- a/test/unittests/tts/test_tts.py
+++ b/test/unittests/tts/test_tts.py
@@ -190,7 +190,8 @@ class TestTTSFactory(unittest.TestCase):
     def test_create(self, mock_config):
         config = {
             'tts': {
-                'module': 'mock'
+                'module': 'mock',
+                'mimic': {'mock': True}
             }
         }
 
@@ -217,6 +218,10 @@ class TestTTSFactory(unittest.TestCase):
         mock_tts_class.side_effect = side_effect
         tts_instance = mycroft.tts.TTSFactory.create()
         self.assertEqual(tts_instance, mock_mimic_instance)
+
+        # Check that mimic get's the proper config
+        mimic_conf = mock_mimic.call_args[0][1]
+        self.assertEqual(mimic_conf, config['tts']['mimic'])
 
         # Make sure exception is raised when mimic fails
         mock_mimic.side_effect = side_effect


### PR DESCRIPTION
## Description
When testing PR #2828 I noticed mimic could fail to load properly as fallback. Basically it sent the config for the failed tts instead of the fallback.

- Mimic is now sent the correct config when used as a fallback
- Tests updated to ensure this

## How to test
Ensure unittests pass

## Contributor license agreement signed?
CLA [ Yes ]