### PR TITLE
Use os default gcc in github workflow

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install compilers
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -y gcc-4.8 g++-4.8
+        sudo apt-get install -y gcc g++
     - name: Install Python packages for testing
       run: pip install -r requirements/tests.txt
     - name: Setup mycroft core
@@ -51,7 +51,6 @@ jobs:
         if [[ ${{ matrix.python-version }} == 3.9 ]]; then ./dev_setup.sh; fi
         if [[ ${{ matrix.python-version }} != 3.9 ]]; then ./dev_setup.sh -sm; fi
       env:
-        CC: gcc-4.8
         CI: true
     - name: Linting and code style
       run: |


### PR DESCRIPTION
## Description
GCC 4.8 seems to have been removed from ubuntu latest used by the github workflow. This drops the explicit use of the older version in favor for the default.

GCC 4.8 was previously hardcoded to make mimic build slightly faster. Either newer gcc has improved over gcc 6.x or gitlab has more horse powers but this seems to run just fine.

## How to test
Ensure that the unittests run by github passes for python 3.9 (which builds mimic)

## Contributor license agreement signed?
CLA [ Yes ]