### PR TITLE
feat/ask_confirm

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -23,7 +23,7 @@ from os import walk
 from os.path import join, abspath, dirname, basename, exists
 from pathlib import Path
 from threading import Event, Timer
-
+from enum import Enum
 from xdg import BaseDirectory
 
 from adapt.intent import Intent, IntentBuilder
@@ -61,6 +61,11 @@ from ..skill_data import (
     read_value_file,
     read_translated_file
 )
+
+
+class UserReply(str, Enum):
+    YES = "yes"
+    NO = "no"
 
 
 def simple_trace(stack_trace):
@@ -489,11 +494,31 @@ class MycroftSkill:
         resp = self.get_response(dialog=prompt, data=data)
 
         if self.voc_match(resp, 'yes'):
-            return 'yes'
+            return UserReply.YES
         elif self.voc_match(resp, 'no'):
-            return 'no'
+            return UserReply.NO
         else:
             return resp
+
+    def ask_confirm(self, dialog, data=None):
+        """Read prompt and wait for a yes/no answer
+
+        This automatically deals with translation and common variants,
+        such as 'yeah', 'sure', etc.
+
+        Args:
+              dialog (str): a dialog id or string to read
+              data (dict): response data
+        Returns:
+              bool: True if 'yes', False if 'no', None for all other
+                    responses or no response
+        """
+        resp = self.ask_yesno(dialog, data=data)
+        if resp == UserReply.YES:
+            return True
+        elif resp == UserReply.NO:
+            return False
+        return None
 
     def ask_selection(self, options, dialog='',
                       data=None, min_conf=0.65, numeric=False):


### PR DESCRIPTION
adds a new method, `ask_confirm`, which is an alternative to `ask_yesno` that returns booleans

closes https://github.com/MycroftAI/mycroft-core/issues/2835


```python
if self.ask_confirm(...):
    self.speak("got it")
else:
    self.speak("task failed successfully")
```

EDIT:

added an Enum to make `ask_yesno` somewhat more language agnostic which was part of the original issue

```python
result = self.ask_yesno(...)
if result == UserReply.YES:
    self.speak("you agree with me")
elif result == UserReply.NO:
    self.speak("you do not agree with me")
elif result is None:
    self.speak("you did not answer")
else:
    self.speak("stay on topic you fool")
```

should be backwards compatible with raw string comparisons

```python
assert "yes" == UserReply.YES
assert "no" == UserReply.NO
```