### PR TITLE
dev_setup.sh: install Alpine deps to a virtual meta package

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -375,7 +375,7 @@ function gentoo_install() {
 }
 
 function alpine_install() {
-    $SUDO apk add alpine-sdk git python3 py3-pip py3-setuptools py3-virtualenv mpg123 vorbis-tools pulseaudio-utils fann-dev automake autoconf libtool pcre2-dev pulseaudio-dev alsa-lib-dev swig python3-dev portaudio-dev libjpeg-turbo-dev
+    $SUDO apk add --virtual makedeps-mycroft-core alpine-sdk git python3 py3-pip py3-setuptools py3-virtualenv mpg123 vorbis-tools pulseaudio-utils fann-dev automake autoconf libtool pcre2-dev pulseaudio-dev alsa-lib-dev swig python3-dev portaudio-dev libjpeg-turbo-dev
 }
 
 function install_deps() {


### PR DESCRIPTION
## Description
This allows easy uninstalling of the deps later on by just running `apk del makedeps-mycroft-core`

## How to test
On an Alpine Linux system, run `dev_setup.sh` like normal. Once finished, run `apk del makedeps-mycroft-core` and see it uninstalling everything properly.

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
