### PR TITLE
Remove example entries in blacklisted_skills config

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -113,8 +113,8 @@
     // blacklisted skills to not load
     // NB: This is the basename() of the directory where the skill lives, so if
     // the skill you want to blacklist is in /opt/mycroft/skills/mycroft-alarm.mycroftai/
-    // then you should write "mycroft-alarm.mycroftai" below.
-    "blacklisted_skills": ["skill-media", "send_sms", "skill-wolfram-alpha", "pianobar-skill"],
+    // then you should write `["mycroft-alarm.mycroftai"]` below.
+    "blacklisted_skills": [],
     // priority skills to be loaded first
     "priority_skills": ["mycroft-pairing", "mycroft-volume"],
     // Time between updating skills in hours


### PR DESCRIPTION
The default mycroft.conf included a short list of Skills in the `blacklisted_skills` configuration. This was put in place when Skills were moved and renamed to prevent two versions of the Skill being loaded. 

If a user now attempted to use a Skill that matched one of these names, it would be prevented from loading. This removes the old Skill names from the config.

## How to test
Clone the [pianobar-skill](https://github.com/MycroftAI/pianobar-skill) rather than installing via MSM.
- On all current releases, this will be blacklisted.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
