### PR TITLE
Remove intent-service backwards compatibilities

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -250,8 +250,6 @@ def _register_intent_services(bus):
         'mycroft.skills.fallback',
         FallbackSkill.make_intent_failure_handler(bus)
     )
-    # Backwards compatibility TODO: remove in 20.08
-    bus.on('intent_failure', FallbackSkill.make_intent_failure_handler(bus))
     return service
 
 

--- a/mycroft/skills/fallback_skill.py
+++ b/mycroft/skills/fallback_skill.py
@@ -95,11 +95,6 @@ class FallbackSkill(MycroftSkill):
                     bus.emit(message.forward('mycroft.skill.handler.complete',
                                              data={'handler': "fallback",
                                                    'exception': warning}))
-                    if 'fallback_range' not in message.data:
-                        # Old system TODO: Remove in 20.08
-                        # No fallback could handle the utterance
-                        bus.emit(message.forward('complete_intent_failure'))
-                        LOG.warning(warning)
 
             # return if the utterance was handled to the caller
             bus.emit(message.response(data={'handled': status}))

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -26,9 +26,6 @@ from .intent_services import (
 )
 from .intent_service_interface import open_intent_envelope
 
-# TODO: Remove in 20.08 (Backwards compatibility)
-from .intent_services.adapt_service import ContextManager
-
 
 def _get_message_lang(message):
     """Get the language from the message or the default language.

--- a/test/unittests/skills/test_intent_service.py
+++ b/test/unittests/skills/test_intent_service.py
@@ -18,8 +18,9 @@ from adapt.intent import IntentBuilder
 
 from mycroft.configuration import Configuration
 from mycroft.messagebus import Message
-from mycroft.skills.intent_service import (ContextManager, IntentService,
-                                           _get_message_lang, AdaptIntent)
+from mycroft.skills.intent_service import IntentService, _get_message_lang
+from mycroft.skills.intent_services.adapt_service import (ContextManager,
+                                                          AdaptIntent)
 
 from test.util import base_config
 


### PR DESCRIPTION
## Description
This removes the now unused and deprecated imports and message handling code left to keep compatibility when the intent_service.py was refactored.

- Remove unused ContextManager import from mycroft.skills.intent_service
- Remove Old 'intent_failure' -> fallback handler
- Remove handling of fallback messages without the fallback_range parameter

## How to test
Make sure the intents work properly still.

## Contributor license agreement signed?
CLA [ yes ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
