### PR TITLE
Add ask_confirm method

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -23,7 +23,7 @@ from os import walk
 from os.path import join, abspath, dirname, basename, exists
 from pathlib import Path
 from threading import Event, Timer
-
+from enum import Enum
 from xdg import BaseDirectory
 
 from adapt.intent import Intent, IntentBuilder
@@ -61,6 +61,11 @@ from ..skill_data import (
     read_value_file,
     read_translated_file
 )
+
+
+class UserReply(str, Enum):
+    YES = "yes"
+    NO = "no"
 
 
 def simple_trace(stack_trace):
@@ -489,11 +494,31 @@ class MycroftSkill:
         resp = self.get_response(dialog=prompt, data=data)
 
         if self.voc_match(resp, 'yes'):
-            return 'yes'
+            return UserReply.YES
         elif self.voc_match(resp, 'no'):
-            return 'no'
+            return UserReply.NO
         else:
             return resp
+
+    def ask_confirm(self, dialog, data=None):
+        """Read prompt and wait for a yes/no answer
+
+        This automatically deals with translation and common variants,
+        such as 'yeah', 'sure', etc.
+
+        Args:
+              dialog (str): a dialog id or string to read
+              data (dict): response data
+        Returns:
+              bool: True if 'yes', False if 'no', None for all other
+                    responses or no response
+        """
+        resp = self.ask_yesno(dialog, data=data)
+        if resp == UserReply.YES:
+            return True
+        elif resp == UserReply.NO:
+            return False
+        return None
 
     def ask_selection(self, options, dialog='',
                       data=None, min_conf=0.65, numeric=False):

--- a/test/unittests/skills/test_mycroft_skill_get_response.py
+++ b/test/unittests/skills/test_mycroft_skill_get_response.py
@@ -188,6 +188,44 @@ class TestMycroftSkillAskYesNo(TestCase):
         self.assertEqual(response, 'yes')
 
 
+class TestMycroftSkillAskConfirm(TestCase):
+    def test_ask_confirm_yes(self):
+        """Check that a positive response is interpreted as a yes."""
+        skill = create_skill()
+        skill.get_response = mock.Mock()
+        skill.get_response.return_value = 'yeah please'
+
+        response = skill.ask_confirm('Do you like breakfast')
+        self.assertTrue(response)
+
+    def test_ask_confirm_no(self):
+        """Check that a negative response is interpreted as a no."""
+        skill = create_skill()
+        skill.get_response = mock.Mock()
+        skill.get_response.return_value = 'nope'
+
+        response = skill.ask_confirm('Do you like breakfast')
+        self.assertFalse(response)
+
+    def test_ask_confirm_other(self):
+        """Check that any other response returns None."""
+        skill = create_skill()
+        skill.get_response = mock.Mock()
+        skill.get_response.return_value = 'vegemite'
+
+        response = skill.ask_confirm('Do you like breakfast')
+        self.assertEqual(response, None)
+
+    def test_ask_confirm_no_response(self):
+        """Check that any other response returns None."""
+        skill = create_skill()
+        skill.get_response = mock.Mock()
+        skill.get_response.return_value = None
+
+        response = skill.ask_confirm('Do you like breakfast')
+        self.assertEqual(response, None)
+
+
 class TestMycroftAskSelection(TestCase):
     def test_selection_number(self):
         """Test selection by number."""


### PR DESCRIPTION
Adds a new method, `ask_confirm()`, an alternative to `ask_yesno` that returns only a Boolean or None.

closes #2835 
replacing PR #2837 

```python
if self.ask_confirm('question'):
    self.speak("got it")
else:
    self.speak("task failed successfully")
```

This PR also adds an Enum to make `ask_yesno` somewhat more language agnostic which was part of the original issue

```python
result = self.ask_yesno(...)
if result == UserReply.YES:
    self.speak("you agree with me")
elif result == UserReply.NO:
    self.speak("you do not agree with me")
elif result is None:
    self.speak("you did not answer")
else:
    self.speak("stay on topic you fool")
```

The Enum is backwards compatible with raw string comparisons

```python
assert "yes" == UserReply.YES
assert "no" == UserReply.NO
```