### PR TITLE
Suggestion Skillframework v2.1

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -63,6 +63,10 @@ from ..skill_data import (
 )
 
 
+def skill_id_from_path(skill_directory):
+    return basename(skill_directory)
+
+
 def simple_trace(stack_trace):
     """Generate a simplified traceback.
 
@@ -119,13 +123,13 @@ class MycroftSkill:
     def __init__(self, name=None, bus=None, use_settings=True):
         self.name = name or self.__class__.__name__
         self.resting_name = None
-        self.skill_id = ''  # will be set from the path, so guaranteed unique
         self.settings_meta = None  # set when skill is loaded in SkillLoader
 
         # Get directory of skill
         #: Member variable containing the absolute path of the skill's root
         #: directory. E.g. /opt/mycroft/skills/my-skill.me/
         self.root_dir = dirname(abspath(sys.modules[self.__module__].__file__))
+        self.skill_id = skill_id_from_path(self.root_dir)
 
         self.gui = SkillGUI(self)
 
@@ -164,6 +168,24 @@ class MycroftSkill:
 
         # Skill Public API
         self.public_api = {}
+
+        if bus:
+            self._startup(bus)
+
+    def _startup(self, bus):
+        self.bind(bus)
+        try:
+            self.load_data_files()
+            # Set up intent handlers
+            self._register_decorated()
+            self.register_resting_screen()
+            self.initialize()
+        except Exception as e:
+            # If an exception occurs, make sure to clean up the skill
+            self.default_shutdown()
+            log_msg = 'Skill initialization failed with {}'
+            LOG.exception(log_msg.format(repr(e)))
+            raise e
 
     def _init_settings(self):
         """Setup skill settings."""


### PR DESCRIPTION
## Description
Currently the skill is is loaded in several steps where the skill-loader code calls the startup sequence and doesn't provide the working skill until after calling `bind()`, `load_data_files()`, etc. All which really should be part of the skill `__init__()`. Skill creator are left with doing their init code in `initialize` a unique method just used by skills and not common across python.

Current skill system also requires some further boiler plate in the form of the `create_skill()` function instantiating the skill and returning it to the SkillLoader. 

This is a suggestion to allow the skill creators to do all their custom initialization in `__init__()` like a regular python class and remove the extra `create_skill()`boilerplate.

 To be backwards compatible this keeps two skill loading functions in the SkillLoader `_create_v2_skill_instance()` and `_create_v3_skill_instance()`, the v2 version will be used if create_skill is found in the skill module, if no such function is found and there is a MycroftSkill based object the loader will consider this a v3 skill module.

Requirements of the v3 skill:

For this to work the skill creator will need to setup their skill `__init__()` (if used) to forward the keyword arguments to the base class.

Example:
```python
from mycroft import MycroftSkill, skill_handler


class MySkill(MycroftSkill):
    def __init__(**kwarg):
        super().__init__(name='My Cool Skill', **kwarg)  # Name is of course optional
        [ Further init code ]

    @skill_handler('Cool.intent')
    def cool_handler(self, _):
        self.speak('My skill is so cool!')
```

This requirement to pass along kwarg could also be avoided with a custom `__new__()` but I think it's better to have an explicit pass-along so skill creators are aware that Mycroft is doing stuff.

Since we now get a class from the skill and not a loaded object the class can provide compatibility information. In this proposal the skill creator can have several skill classes in their module and use the class method is_compatible to select which of the provided classes to use.


In summary this would reduce some of the boiler plate code needed and make the skill loading more pythonic.

## Contributor license agreement signed?
CLA [ yes ]