### PR TITLE
Fix dev_setup.sh max cores detection

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -17,6 +17,7 @@
 
 # Set a default locale to handle output from commands reliably
 export LANG=C.UTF-8
+export LANGUAGE=en
 
 # exit on any error
 set -Ee


### PR DESCRIPTION
## Description
Fixes issue with non-english setups calculating number of CPU's to use when building mimic.

Define LANGUAGE along with LANG to ensure that free uses english output.

Alternative solution seems to be to use LANG=C (and dropping the utf-8 part), not sure which is technically better.

## How to test
Using non-english locale and ensure the script doesn't report error on line 541 similar to

```
./dev_setup.sh: rad 541: / 2202010: syntaxfel: en operand förväntades (felsymbol är ”/ 2202010”)
```

## Contributor license agreement signed?
CLA [ Yes ]