### PR TITLE
Add exact optional param to voc_match

### DIFF
--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -552,6 +552,17 @@ class TestMycroftSkill(unittest.TestCase):
         self.assertFalse(s.voc_match("My hovercraft is full of eels",
                                      "turn_off_test"))
 
+    def test_voc_match_exact(self):
+        s = SimpleSkill1()
+        s.root_dir = abspath(dirname(__file__))
+
+        self.assertTrue(s.voc_match("yes", "yes", exact=True))
+        self.assertFalse(s.voc_match("yes please", "yes", exact=True))
+        self.assertTrue(s.voc_match("switch off", "turn_off_test",
+                                    exact=True))
+        self.assertFalse(s.voc_match("would you please turn off the lights",
+                                     "turn_off_test", exact=True))
+
     def test_translate_locations(self):
         """Assert that the a translatable list can be loaded from dialog and
         locale.


### PR DESCRIPTION
## Description
This adds the option to require an exact match of vocab. 

It has been taken from the Playback Control Skill, and will be removed from there once available in core.

Credit to Jarbas for the push to shift this.

## How to test
Unit tests included.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
