### PR TITLE
Fix a bug with TTS engine changes not taking effect.

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -182,20 +182,27 @@ def init(messagebus):
     """
 
     global bus
-    global tts
-    global tts_hash
     global config
-
     bus = messagebus
     Configuration.set_config_update_handlers(bus)
-    config = Configuration.get()
     bus.on('mycroft.stop', handle_stop)
     bus.on('mycroft.audio.speech.stop', handle_stop)
     bus.on('speak', handle_speak)
+    bus.on('configuration.updated', _create_tts)
+    _create_tts(None)
 
+
+def _create_tts(_):
+    global config
+    global tts
+    global tts_hash
+    LOG.info('waiting for config reload')
+    time.sleep(1)  # Give the config object time to update.
+    config = Configuration.get()
+    LOG.info('Loading the {} TTS engine'.format(config['tts']['module']))
     tts = TTSFactory.create()
     tts.init(bus)
-    tts_hash = hash(str(config.get('tts', '')))
+    tts_hash = hash(str(config['tts']))
 
 
 def shutdown():


### PR DESCRIPTION
## Description
Use the TTS factory to reload the TTS engine when config changes.

## How to test
Change the TTS engine for the device being tested in Selene.  The new engine should be effective soon after the config change is applied to core.

## Contributor license agreement signed?
CLA [Y]
