### PR TITLE
Prioritise remote user config over device

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -230,8 +230,7 @@ class Configuration:
                isinstance(config, LocalConf) and config.path == USER_CONFIG:
                 if user_config_disabled:
                     continue
-                for key in protected_keys:
-                    config = delete_key_from_dict(key, config)
+                prune_config(config, protected_keys)
 
             merge_dict(base, config)
 
@@ -285,3 +284,9 @@ class Configuration:
         """
         Configuration.__patch = {}
         Configuration.load_config_stack(cache=True)
+
+    @staticmethod
+    def prune_config(config, prune_list):
+        for key in prune_list:
+            config = delete_key_from_dict(key, config)
+        return config

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -46,6 +46,20 @@ def is_remote_list(values):
     return True
 
 
+def prune_config(config, prune_list):
+    """Delete list of nested keys from the provided config.
+
+    Arguments:
+        config (dict): config to prune
+        prune_list (list(str)): list of keys to delete. Each item may be a
+                                period separated list of nested keys eg
+                                ["nested.dict.key", "listener.sample_rate"]
+    """
+    for key in prune_list:
+        config = delete_key_from_dict(key, config)
+    return config
+
+
 def translate_remote(config, setting):
     """Translate config names from server to equivalents for mycroft-core.
 
@@ -246,7 +260,7 @@ class Configuration:
             elif isinstance(config, LocalConf) and config.path == USER_CONFIG:
                 if user_config_disabled:
                     continue
-                Configuration.prune_config(config, protected_keys)
+                prune_config(config, protected_keys)
 
             merge_dict(base, config)
 
@@ -300,9 +314,3 @@ class Configuration:
         """
         Configuration.__patch = {}
         Configuration.load_config_stack(cache=True)
-
-    @staticmethod
-    def prune_config(config, prune_list):
-        for key in prune_list:
-            config = delete_key_from_dict(key, config)
-        return config

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -20,11 +20,19 @@ import inflection
 from os.path import exists, isfile
 from requests import RequestException
 
-from mycroft.util.json_helper import delete_key_from_dict, load_commented_json, merge_dict
+from mycroft.util.json_helper import (
+    delete_key_from_dict,
+    load_commented_json,
+    merge_dict
+)
 from mycroft.util.log import LOG
 
-from .locations import (DEFAULT_CONFIG, SYSTEM_CONFIG, USER_CONFIG,
-                        WEB_CONFIG_CACHE)
+from .locations import (
+    DEFAULT_CONFIG,
+    SYSTEM_CONFIG,
+    USER_CONFIG,
+    WEB_CONFIG_CACHE
+)
 
 
 def is_remote_list(values):
@@ -83,6 +91,7 @@ def translate_list(config, values):
 
 class LocalConf(dict):
     """Config dictionary from file."""
+
     def __init__(self, path):
         super(LocalConf, self).__init__()
         if path:
@@ -124,6 +133,7 @@ class LocalConf(dict):
 
 class RemoteConf(LocalConf):
     """Config dictionary fetched from mycroft.ai."""
+
     def __init__(self, cache=None):
         super(RemoteConf, self).__init__(None)
 
@@ -219,7 +229,8 @@ class Configuration:
         # modifying specific keys within the configuration.
         enclosure_config = LocalConf(SYSTEM_CONFIG).get('enclosure', {})
         protected_keys = enclosure_config.get('protected_keys', [])
-        user_config_disabled = enclosure_config.get('disable_user_config', False)
+        user_config_disabled = enclosure_config.get(
+            'disable_user_config', False)
 
         # Merge all configs into one
         base = {}

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -204,8 +204,8 @@ class Configuration:
             (dict) merged dict of all configuration files
         """
         if not configs:
-            configs = [LocalConf(DEFAULT_CONFIG), RemoteConf(),
-                       LocalConf(SYSTEM_CONFIG), LocalConf(USER_CONFIG),
+            configs = [LocalConf(DEFAULT_CONFIG), LocalConf(SYSTEM_CONFIG),
+                       RemoteConf(), LocalConf(USER_CONFIG),
                        Configuration.__patch]
         else:
             # Handle strings in stack

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -241,7 +241,7 @@ class Configuration:
                isinstance(config, LocalConf) and config.path == USER_CONFIG:
                 if user_config_disabled:
                     continue
-                prune_config(config, protected_keys)
+                Configuration.prune_config(config, protected_keys)
 
             merge_dict(base, config)
 

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -18,6 +18,16 @@
   // specific system can set relevant attributes at the SYSTEM level, and users
   // can further customize their experience at the REMOTE or USER levels.
 
+  // REMOTE or USER configurations can be disabled thereby requiring root
+  // access to the system to change any config parameters.
+  "disable_remote_config": false,
+  "disable_user_config": false,
+
+  // Alternatively a set of protected keys can be defined. This prevents
+  // either REMOTE or USER from modifying these settings. Nested keys should
+  // be provided as period separated strings eg ["listener.sample_rate"]
+  "protected_keys": [],
+
   // Language used for speech-to-text and text-to-speech.
   // Code is a BCP-47 identifier (https://tools.ietf.org/html/bcp47), lowercased
   // TODO: save unmodified, lowercase upon demand
@@ -234,8 +244,6 @@
     // Override: SYSTEM (set by specific enclosures)
     // "platform": "picroft",
     // "platform_enclosure_path": "/etc/myenclosure/code.py",
-    "protected_keys": [],
-    "disable_user_config": false,
 
     // COMM params to the Arduino/faceplate
     "port": "/dev/ttyAMA0",

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -2,20 +2,21 @@
   // Definition and documentation of all variables used by mycroft-core.
   //
   // Settings seen here are considered DEFAULT.  Settings can also be
-  // overridden at the REMOTE level (set by the user via
-  // https://home.mycroft.ai), at the SYSTEM level (typically in the file
-  // '/etc/mycroft/mycroft.conf'), or at the USER level (typically in the
+  // overridden at the SYSTEM level (typically in the file
+  // '/etc/mycroft/mycroft.conf'), at the REMOTE level (set by the user via
+  // https://home.mycroft.ai), or at the USER level (typically in the
   // file '~/.mycroft/mycroft.conf').
   //
   // The load order of settings is:
   //   DEFAULT
-  //   REMOTE
   //   SYSTEM
+  //   REMOTE
   //   USER
   //
   // The Override: comments below indicates where these settings are generally
-  // set outside of this file.  The load order is always followed, so an
-  // individual systems can still apply changes at the SYSTEM or USER levels.
+  // set outside of this file.  The load order is always followed, so a
+  // specific system can set relevant attributes at the SYSTEM level, and users
+  // can further customize their experience at the REMOTE or USER levels.
 
   // Language used for speech-to-text and text-to-speech.
   // Code is a BCP-47 identifier (https://tools.ietf.org/html/bcp47), lowercased
@@ -233,6 +234,8 @@
     // Override: SYSTEM (set by specific enclosures)
     // "platform": "picroft",
     // "platform_enclosure_path": "/etc/myenclosure/code.py",
+    "protected_keys": [],
+    "disable_user_config": false,
 
     // COMM params to the Arduino/faceplate
     "port": "/dev/ttyAMA0",

--- a/mycroft/util/json_helper.py
+++ b/mycroft/util/json_helper.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import json
+from copy import copy
 
 
 def merge_dict(base, delta):
@@ -30,6 +31,27 @@ def merge_dict(base, delta):
             merge_dict(bv, dv)
         else:
             base[k] = dv
+
+
+def delete_key_from_dict(key, dictionary):
+    """Recursivily find nested key in a dict and delete it.
+
+    Arguments:
+        key (str): a period separated list of nested keys to remove
+                   eg "nested.dict.keys"
+        dictionary (dict): the dictionary to remove keys from
+    Returns:
+        Dict: original dictionary with specified keys deleted.
+    """
+    modified_dict = copy(dictionary)
+    key_list = key.split('.')
+    if len(key_list) == 1 and modified_dict.get(key) is not None:
+        del modified_dict[key]
+    elif len(key_list) > 1:
+        remaining_keys = '.'.join(key_list[1:])
+        if modified_dict.get(key_list[0]) is not None:
+            modified_dict[key_list[0]] = delete_key_from_dict(remaining_keys, modified_dict[key_list[0]])
+    return modified_dict
 
 
 def load_commented_json(filename):

--- a/mycroft/util/json_helper.py
+++ b/mycroft/util/json_helper.py
@@ -50,7 +50,8 @@ def delete_key_from_dict(key, dictionary):
     elif len(key_list) > 1:
         remaining_keys = '.'.join(key_list[1:])
         if modified_dict.get(key_list[0]) is not None:
-            modified_dict[key_list[0]] = delete_key_from_dict(remaining_keys, modified_dict[key_list[0]])
+            modified_dict[key_list[0]] = delete_key_from_dict(
+                remaining_keys, modified_dict[key_list[0]])
     return modified_dict
 
 

--- a/test/unittests/configuration/test_configuration.py
+++ b/test/unittests/configuration/test_configuration.py
@@ -4,6 +4,7 @@ import mycroft.configuration
 from mycroft.configuration.locations import SYSTEM_CONFIG, USER_CONFIG
 from mycroft.util.json_helper import merge_dict
 
+
 class TestConfiguration(TestCase):
     def setUp(self):
         """
@@ -65,25 +66,18 @@ class TestConfiguration(TestCase):
         lc = mycroft.configuration.LocalConf('test')
         self.assertEqual(lc, {})
 
-    # # @patch('mycroft.configuration.config.LocalConf')
-    # def test_protected_keys(self):
-    #     system_conf = mycroft.configuration.LocalConf(SYSTEM_CONFIG)
-    #     if system_conf.get("enclosure") is not None:
-    #         existing_conf = system_conf["enclosure"].get("protected_keys")
-    #     system_conf_patch = {"enclosure": {"protected_keys": ['secured', 'so.very.secure']}}
-    #     merge_dict(system_conf, system_conf_patch)
-    #     user_conf = mycroft.configuration.LocalConf(USER_CONFIG)
-    #     user_conf_patch = {"secured": "test1", "so": {"very": {"secure": "test2"}, "test3": "test"}}
-    #     merge_dict(user_conf, user_conf_patch)
-    #     loaded_config = mycroft.configuration.Configuration.load_config_stack([system_conf, user_conf])
-    #     # self.assertDictContainsSubset({"secured": "test1"}, loaded_config)
-    #     self.assertEqual(loaded_config.get("secured"), None)
+    def test_prune_config(self):
+        prune_config = mycroft.configuration.Configuration.prune_config
+        config = {'a': 1, 'b': {'c': 1, 'd': 2}, 'e': 3}
+        self.assertEqual(prune_config(config, ['b']), {'a': 1, 'e': 3})
+        self.assertEqual(prune_config(config, ['b.c']), {
+                         'a': 1, 'b': {'d': 2}, 'e': 3})
+        self.assertEqual(prune_config(config, ['b', 'e']), {'a': 1})
+        self.assertEqual(prune_config(config, ['b', 'b.c']), {'a': 1, 'e': 3})
 
-
-    @patch('mycroft.configuration.config.RemoteConf')
-    @patch('mycroft.configuration.config.LocalConf')
+    @patch('mycroft.configuration.config.RemoteConf.__new__')
+    @patch('mycroft.configuration.config.LocalConf.__new__')
     def test_update(self, mock_remote, mock_local):
-        mock_remote.return_value = {}
         mock_local.return_value = {'a': 1}
         c = mycroft.configuration.Configuration.get()
         self.assertEqual(c, {'a': 1})

--- a/test/unittests/configuration/test_configuration.py
+++ b/test/unittests/configuration/test_configuration.py
@@ -1,7 +1,8 @@
 from unittest.mock import MagicMock, patch
 from unittest import TestCase
 import mycroft.configuration
-
+from mycroft.configuration.locations import SYSTEM_CONFIG, USER_CONFIG
+from mycroft.util.json_helper import merge_dict
 
 class TestConfiguration(TestCase):
     def setUp(self):
@@ -63,6 +64,21 @@ class TestConfiguration(TestCase):
         mock_exists.return_value = False
         lc = mycroft.configuration.LocalConf('test')
         self.assertEqual(lc, {})
+
+    # # @patch('mycroft.configuration.config.LocalConf')
+    # def test_protected_keys(self):
+    #     system_conf = mycroft.configuration.LocalConf(SYSTEM_CONFIG)
+    #     if system_conf.get("enclosure") is not None:
+    #         existing_conf = system_conf["enclosure"].get("protected_keys")
+    #     system_conf_patch = {"enclosure": {"protected_keys": ['secured', 'so.very.secure']}}
+    #     merge_dict(system_conf, system_conf_patch)
+    #     user_conf = mycroft.configuration.LocalConf(USER_CONFIG)
+    #     user_conf_patch = {"secured": "test1", "so": {"very": {"secure": "test2"}, "test3": "test"}}
+    #     merge_dict(user_conf, user_conf_patch)
+    #     loaded_config = mycroft.configuration.Configuration.load_config_stack([system_conf, user_conf])
+    #     # self.assertDictContainsSubset({"secured": "test1"}, loaded_config)
+    #     self.assertEqual(loaded_config.get("secured"), None)
+
 
     @patch('mycroft.configuration.config.RemoteConf')
     @patch('mycroft.configuration.config.LocalConf')

--- a/test/unittests/configuration/test_configuration.py
+++ b/test/unittests/configuration/test_configuration.py
@@ -67,7 +67,7 @@ class TestConfiguration(TestCase):
         self.assertEqual(lc, {})
 
     def test_prune_config(self):
-        prune_config = mycroft.configuration.Configuration.prune_config
+        prune_config = mycroft.configuration.config.prune_config
         config = {'a': 1, 'b': {'c': 1, 'd': 2}, 'e': 3}
         self.assertEqual(prune_config(config, ['b']), {'a': 1, 'e': 3})
         self.assertEqual(prune_config(config, ['b.c']), {

--- a/test/unittests/util/test_json_helper.py
+++ b/test/unittests/util/test_json_helper.py
@@ -17,7 +17,16 @@ import unittest
 
 from os.path import dirname, join
 
-from mycroft.util.json_helper import load_commented_json
+from mycroft.util.json_helper import delete_key_from_dict, load_commented_json
+
+
+class TestDictUtils(unittest.TestCase):
+
+    def test_delete_key_from_dict(self):
+        dct = {'a': 1, 'b': {'c': 1, 'd': 2}}
+        self.assertEqual(delete_key_from_dict("b", dct), {'a': 1})
+        self.assertEqual(delete_key_from_dict("b.c", dct), {'a': 1, 'b': {'d': 2}})
+        self.assertEqual(delete_key_from_dict("b.c", dct), {'a': 1, 'b': {'d': 2}})
 
 
 class TestFileLoad(unittest.TestCase):

--- a/test/unittests/util/test_json_helper.py
+++ b/test/unittests/util/test_json_helper.py
@@ -25,8 +25,10 @@ class TestDictUtils(unittest.TestCase):
     def test_delete_key_from_dict(self):
         dct = {'a': 1, 'b': {'c': 1, 'd': 2}}
         self.assertEqual(delete_key_from_dict("b", dct), {'a': 1})
-        self.assertEqual(delete_key_from_dict("b.c", dct), {'a': 1, 'b': {'d': 2}})
-        self.assertEqual(delete_key_from_dict("b.c", dct), {'a': 1, 'b': {'d': 2}})
+        self.assertEqual(delete_key_from_dict(
+            "b.c", dct), {'a': 1, 'b': {'d': 2}})
+        self.assertEqual(delete_key_from_dict(
+            "b.c", dct), {'a': 1, 'b': {'d': 2}})
 
 
 class TestFileLoad(unittest.TestCase):


### PR DESCRIPTION
## Description
This re-orders the `mycroft.conf` priority order to use remote settings over device defaults.

Currently the priority order is:
1. Default - from mycroft-core
2. Remote - home.mycroft.ai
3. System - `/etc/mycroft/mycroft.conf`
4. User - `~/.mycroft/mycroft`

This switches 2 and 3 so that devices can declare default values that differ from the default mycroft-core but can also be overridden by the user modifying settings on home.mycroft.ai or their preferred backend.

## How to test
Change the voice on a Mark II Dev Kit - this will not change because the device level settings have Mimic2 as the default voice.

## Contributor license agreement signed?
- [x] CLA
