### PR TITLE
Sync curated cache with dict of cached sentences

### DIFF
--- a/mycroft/tts/cache.py
+++ b/mycroft/tts/cache.py
@@ -71,6 +71,20 @@ def hash_sentence(sentence: str):
     return sentence_hash
 
 
+def hash_from_path(path: Path) -> str:
+    """Returns hash from a given path.
+
+    Simply removes extension and folder structure leaving the hash.
+
+    Arguments:
+        path: path to get hash from
+
+    Returns:
+        Hash reference for file.
+    """
+    return path.with_suffix('').name
+
+
 class AudioFile:
     def __init__(self, cache_dir: Path, sentence_hash: str, file_type: str):
         self.name = f"{sentence_hash}.{file_type}"
@@ -284,7 +298,13 @@ class TextToSpeechCache:
 
     def curate(self):
         """Remove cache data if disk space is running low."""
-        curate_cache(self.temporary_cache_dir, min_free_percent=100)
+        files_removed = curate_cache(self.temporary_cache_dir,
+                                     min_free_percent=100)
+
+        hashes = set([hash_from_path(Path(path)) for path in files_removed])
+        for sentence_hash in hashes:
+            if sentence_hash in self.cached_sentences:
+                self.cached_sentences.pop(sentence_hash)
 
     def define_audio_file(self, sentence_hash: str) -> AudioFile:
         """Build an instance of an object representing an audio file."""

--- a/test/unittests/tts/test_cache.py
+++ b/test/unittests/tts/test_cache.py
@@ -102,6 +102,22 @@ class TestCache(TestCase):
             tts_name="Test",
             audio_file_type="wav"
         )
+        # Setup content of sentence cache
+        files = {'kermit': tts_cache.define_audio_file('kermit'),
+                 'fozzie': tts_cache.define_audio_file('fozzie'),
+                 'gobo': tts_cache.define_audio_file('gobo')}
+        for sentence_hash, audio_file in files.items():
+            tts_cache.cached_sentences[sentence_hash] = (audio_file, None)
+
+        # Set curate_cache() to report that paths to kermit and gobo
+        # was removed
+        curate_mock.return_value = [files['kermit'].path,
+                                    files['gobo'].path]
         tts_cache.curate()
         curate_mock.assert_called_with(tts_cache.temporary_cache_dir,
                                        min_free_percent=100)
+
+        # Verify that the "hashes" kermit and gobo was removed from the
+        # dict of hashes.
+        self.assertEqual(tts_cache.cached_sentences,
+                         {'fozzie': (files['fozzie'], None)})


### PR DESCRIPTION
## Description
Currently the curation of cache (removal in case of low diskspace) will remove files without the dict of cached files being updated to match. This may lead to errors where tts thinks it should use cache instead of generating 

## How to test
Ensure the unit tests pass. Test by filling up the /tmp partition so only a few MB are available and that TTS audio still works for sentences that has been spoken.

## Contributor license agreement signed?
CLA [ yes ]