### PR TITLE
Update CommonPlaySkill and CommonQuerySkill to pass messages

### DIFF
--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -97,7 +97,8 @@ class CommonPlaySkill(MycroftSkill, ABC):
 
         # Now invoke the CPS handler to let the skill perform its search
         if 'phrase' in signature(self.CPS_match_query_phrase).parameters:
-            LOG.warning(f"Depreciated CPS method in {self.skill_id}! Message should be referenced")
+            LOG.warning(f"Depreciated CPS method in {self.skill_id}!"
+                        f" Message should be referenced")
             result = self.CPS_match_query_phrase(search_phrase)
         else:
             result = self.CPS_match_query_phrase(message=message)
@@ -134,7 +135,7 @@ class CommonPlaySkill(MycroftSkill, ABC):
         """
         consumed_pct = len(match.split()) / len(phrase.split())
         if consumed_pct > 1.0:
-            consumed_pct = 1.0 / consumed_pct  # deal with over/under-matching
+            consumed_pct = 1.0 / consumed_pct  # deal with over/under-match
 
         # We'll use this to modify the level, but don't want it to allow a
         # match to jump to the next match level.  So bonus is 0 - 0.05 (1/20)
@@ -174,7 +175,8 @@ class CommonPlaySkill(MycroftSkill, ABC):
 
         # Invoke derived class to provide playback data
         if 'phrase' in signature(self.CPS_start).parameters:
-            LOG.warning(f"Depreciated CPS method in {self.skill_id}! Message should be referenced")
+            LOG.warning(f"Depreciated CPS method in {self.skill_id}!"
+                        f" Message should be referenced")
             self.CPS_start(phrase, data)
         else:
             self.CPS_start(message=message, callback_data=data)

--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -248,7 +248,8 @@ class CommonPlaySkill(MycroftSkill, ABC):
 
         Arguments:
             message (Message): Message associated with playback request
-            callback_data (dict): Callback data specified in match_query_phrase()
+            callback_data (dict): Callback data specified in
+                match_query_phrase()
         """
         # Derived classes must implement this, e.g.
         # self.CPS_play("http://zoosh.com/stream_music")

--- a/mycroft/skills/common_query_skill.py
+++ b/mycroft/skills/common_query_skill.py
@@ -76,7 +76,8 @@ class CommonQuerySkill(MycroftSkill, ABC):
 
         # Now invoke the CQS handler to let the skill perform its search
         if 'phrase' in signature(self.CQS_match_query_phrase).parameters:
-            LOG.warning(f"Depreciated CQS method in {self.skill_id}! Message should be referenced")
+            LOG.warning(f"Depreciated CQS method in {self.skill_id}!"
+                        f" Message should be referenced")
             result = self.CQS_match_query_phrase(search_phrase)
         else:
             result = self.CQS_match_query_phrase(message=message)
@@ -133,7 +134,8 @@ class CommonQuerySkill(MycroftSkill, ABC):
         data = message.data.get("callback_data")
         # Invoke derived class to provide playback data
         if 'phrase' in signature(self.CQS_action).parameters:
-            LOG.warning(f"Depreciated CQS method in {self.skill_id}! Message should be referenced")
+            LOG.warning(f"Depreciated CQS method in {self.skill_id}!"
+                        f" Message should be referenced")
             self.CQS_action(phrase, data)
         else:
             self.CQS_action(message=message, callback_data=data)
@@ -178,7 +180,8 @@ class CommonQuerySkill(MycroftSkill, ABC):
 
         Args:
             message (Message): Message associated with query
-            callback_data (dict): Callback data specified in match_query_phrase()
+            callback_data (dict): Callback data specified in
+                match_query_phrase()
         """
         # Derived classes may implement this if they use additional media
         # or wish to set context after being called.

--- a/test/unittests/skills/test_common_query_skill.py
+++ b/test/unittests/skills/test_common_query_skill.py
@@ -34,11 +34,11 @@ class TestCommonQuerySkill(TestCase):
         query_action(Message('query:action', data={
             'phrase': 'What\'s the meaning of life',
             'skill_id': 'asdf'}))
-        self.skill.CQS_action.assert_not_called()
+        self.skill.CQS_action_mock.assert_not_called()
         query_action(Message('query:action', data={
             'phrase': 'What\'s the meaning of life',
             'skill_id': 'CQSTest'}))
-        self.skill.CQS_action.assert_called_once_with(
+        self.skill.CQS_action_mock.assert_called_once_with(
             'What\'s the meaning of life', None)
 
 
@@ -53,7 +53,7 @@ class TestCommonQueryMatching(TestCase):
         self.query_phrase = self.bus.on.call_args_list[-2][0][1]
 
     def test_failing_match_query_phrase(self):
-        self.skill.CQS_match_query_phrase.return_value = None
+        self.skill.CQS_match_mock.return_value = None
         self.query_phrase(Message('question:query',
                                   data={
                                       'phrase': 'What\'s the meaning of life'
@@ -75,7 +75,7 @@ class TestCommonQueryMatching(TestCase):
         self.assertEqual(response.data['searching'], False)
 
     def test_successful_match_query_phrase(self):
-        self.skill.CQS_match_query_phrase.return_value = (
+        self.skill.CQS_match_mock.return_value = (
             'What\'s the meaning of life', CQSMatchLevel.EXACT, '42')
 
         self.query_phrase(Message('question:query',
@@ -101,7 +101,7 @@ class TestCommonQueryMatching(TestCase):
     def test_successful_visual_match_query_phrase(self):
         self.skill.config_core['enclosure']['platform'] = 'mycroft_mark_2'
         query_phrase = self.bus.on.call_args_list[-2][0][1]
-        self.skill.CQS_match_query_phrase.return_value = (
+        self.skill.CQS_match_mock.return_value = (
             'What\'s the meaning of life', CQSVisualMatchLevel.EXACT, '42')
 
         query_phrase(Message('question:query',
@@ -127,12 +127,12 @@ class CQSTest(CommonQuerySkill):
     """Simple skill for testing the CommonQuerySkill"""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.CQS_match_query_phrase = mock.Mock(name='match_phrase')
-        self.CQS_action = mock.Mock(name='selected_action')
+        self.CQS_match_mock = mock.Mock(name='match_phrase')
+        self.CQS_action_mock = mock.Mock(name='selected_action')
         self.skill_id = 'CQSTest'
 
     def CQS_match_query_phrase(self, phrase):
-        pass
+        return self.CQS_match_mock(phrase)
 
     def CQS_action(self, phrase, data):
-        pass
+        return self.CQS_action_mock(phrase, data)


### PR DESCRIPTION
## Description
Fixes #2875 
Similar to #2813, this updates the CPS and CQS abstract methods to expect Messages instead of Strings. Inspecting the method signatures provides backwards compatibitliy.

## How to test
This should work with all existing skills as-is. New functionality can be tested by modifying `match_query_phrase` and `action` overriding methods to match the new signature

## Contributor license agreement signed?
CLA [x ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
