### PR TITLE
Remove websockets-client dependency

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,6 @@ PyAudio==0.2.11
 pyee==8.1.0
 SpeechRecognition==3.8.1
 tornado==6.0.3
-websocket-client==0.54.0
 requests-futures==0.9.5
 pyserial==3.0
 psutil==5.6.6


### PR DESCRIPTION
## Description
The websocket client dependency is now handled by mycroft-messagebus-client and not needed here anymore.

## Contributor license agreement signed?
CLA [ Yes ]