### PR TITLE
Cleanup Adapt ContextManager implementation

### DIFF
--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -408,7 +408,7 @@ class IntentService:
         entity['match'] = word
         entity['key'] = word
         entity['origin'] = origin
-        self.adapt_service.context_manager.inject_context(entity)
+        self.adapt_service.add_context(entity)
 
     def handle_remove_context(self, message):
         """Remove specific context


### PR DESCRIPTION
## Description
Makes the Mycroft-core Adapt Context Manager depend on the ContextManager in Adapt. This removes a bunch of duplicated code. The current state of the class reflects _only_ the modifications done to integrate the context with the Mycroft intent system. The handling of timeout has been moved into the earlier weird tuple-thing into the context frame metadata.

The key differences from the default Adapt context manager are
1. Frames are timed out after a set time
1. `get_context()` will only return the latest match
1. methods for removing context (all and specific)

This keeps the current implementation as-is, I need to dig into the history to see why point 2 was added and will be working to integrate some of the functionality in the context manager from adapt. (clear, remove and maybe a canonical way to limit the frame_stack)

I do however think this is a good first step.

## How to test
Ensure unit tests still work, check that wikipedia skill "tell more" functionality works

## Contributor license agreement signed?
CLA [ Yes ]