### PR TITLE
Update Readthedocs conf to handle mycroft-messagebus-client

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,7 +66,8 @@ autodoc_mock_imports = list(autodoc_mock_imports) + [
     'serial',
     'websocket',
     'speech_recognition',
-    'yaml'
+    'yaml',
+    'mycroft_bus_client'
 ]
 
 templates_path = ['_templates']

--- a/doc/source/plugins.rst
+++ b/doc/source/plugins.rst
@@ -7,30 +7,45 @@ TTS - Base for TTS plugins
 .. autoclass:: mycroft.tts.TTS
     :members:
 
+|
+|
+
 STT - base for STT plugins
 --------------------------
 .. autoclass:: mycroft.stt.STT
     :members:
+
 |
 |
+
 .. autoclass:: mycroft.stt.StreamingSTT
     :members:
+
 |
 |
+
 .. autoclass:: mycroft.stt.StreamThread
     :members:
+
+|
+|
 
 HotWordEngine - Base for Hotword engine plugins
 -----------------------------------------------
 .. autoclass:: mycroft.client.speech.hotword_factory.HotWordEngine
     :members:
 
+|
+|
+
 AudioBackend - Base for audioservice backend plugins
-------------------
+----------------------------------------------------
 .. autoclass:: mycroft.audio.services.AudioBackend
     :members:
+
 |
 |
+
 .. autoclass:: mycroft.audio.services.RemoteAudioBackend
     :members:
 


### PR DESCRIPTION
## Description
- Fixes the current module not found error causing the read the docs to fail to render correctly for latest
- Fixes a couple of warnings in plugins.rst

## Contributor license agreement signed?
CLA [ Yes ]