### PR TITLE
Replace hardcoded use of /tmp directory

### DIFF
--- a/mycroft/client/enclosure/mark1/__init__.py
+++ b/mycroft/client/enclosure/mark1/__init__.py
@@ -14,6 +14,8 @@
 #
 import subprocess
 import time
+import os
+import tempfile 
 import sys
 import os
 import tempfile

--- a/mycroft/client/enclosure/mark1/__init__.py
+++ b/mycroft/client/enclosure/mark1/__init__.py
@@ -35,7 +35,7 @@ from mycroft.util import play_wav, create_signal, connected, check_for_signal
 from mycroft.util.audio_test import record
 from mycroft.util.log import LOG
 from queue import Queue
-from mycroft.util import create_temp_path
+from mycroft.util.file_utils import create_temp_path
 
 # The Mark 1 hardware consists of a Raspberry Pi main CPU which is connected
 # to an Arduino over the serial port.  A custom serial protocol sends
@@ -189,12 +189,12 @@ class EnclosureReader(Thread):
                 'utterance': mycroft.dialog.get("ssh disabled")}))
 
         if "unit.enable-learning" in data or "unit.disable-learning" in data:
-            enable = 'enable' in data
-            word = 'enabled' if enable else 'disabled'
+            enable='enable' in data
+            word='enabled' if enable else 'disabled'
 
             LOG.info("Setting opt_in to: " + word)
-            new_config = {'opt_in': enable}
-            user_config = LocalConf(USER_CONFIG)
+            new_config={'opt_in': enable}
+            user_config=LocalConf(USER_CONFIG)
             user_config.merge(new_config)
             user_config.store()
 
@@ -202,7 +202,7 @@ class EnclosureReader(Thread):
                 'utterance': mycroft.dialog.get("learning " + word)}))
 
     def stop(self):
-        self.alive = False
+        self.alive=False
 
 
 class EnclosureWriter(Thread):
@@ -223,17 +223,17 @@ class EnclosureWriter(Thread):
 
     def __init__(self, serial, bus, size=16):
         super(EnclosureWriter, self).__init__(target=self.flush)
-        self.alive = True
-        self.daemon = True
-        self.serial = serial
-        self.bus = bus
-        self.commands = Queue(size)
+        self.alive=True
+        self.daemon=True
+        self.serial=serial
+        self.bus=bus
+        self.commands=Queue(size)
         self.start()
 
     def flush(self):
         while self.alive:
             try:
-                cmd = self.commands.get() + '\n'
+                cmd=self.commands.get() + '\n'
                 self.serial.write(cmd.encode())
                 self.commands.task_done()
             except Exception as e:
@@ -243,7 +243,7 @@ class EnclosureWriter(Thread):
         self.commands.put(str(command))
 
     def stop(self):
-        self.alive = False
+        self.alive=False
 
 
 class EnclosureMark1(Enclosure):
@@ -260,19 +260,19 @@ class EnclosureMark1(Enclosure):
     E.g. Start and Stop talk animation
     """
 
-    _last_internet_notification = 0
+    _last_internet_notification=0
 
     def __init__(self):
         super().__init__()
 
         self.__init_serial()
-        self.reader = EnclosureReader(self.serial, self.bus, self.lang)
-        self.writer = EnclosureWriter(self.serial, self.bus)
+        self.reader=EnclosureReader(self.serial, self.bus, self.lang)
+        self.writer=EnclosureWriter(self.serial, self.bus)
 
         # Prepare to receive message when the Arduino responds to the
         # following "system.version"
         self.bus.on("enclosure.started", self.on_arduino_responded)
-        self.arduino_responded = False
+        self.arduino_responded=False
         # Send a message to the Arduino across the serial line asking
         # for a reply with version info.
         self.writer.write("system.version")
@@ -289,13 +289,13 @@ class EnclosureMark1(Enclosure):
         # NOTE: this is a temporary place to connect the display manager
         init_display_manager_bus_connection()
 
-    def on_arduino_responded(self, event = None):
-        self.eyes = EnclosureEyes(self.bus, self.writer)
-        self.mouth = EnclosureMouth(self.bus, self.writer)
-        self.system = EnclosureArduino(self.bus, self.writer)
+    def on_arduino_responded(self, event=None):
+        self.eyes=EnclosureEyes(self.bus, self.writer)
+        self.mouth=EnclosureMouth(self.bus, self.writer)
+        self.system=EnclosureArduino(self.bus, self.writer)
         self.__register_events()
         self.__reset()
-        self.arduino_responded = True
+        self.arduino_responded=True
 
         # verify internet connection and prompt user on bootup if needed
         if not connected():
@@ -314,7 +314,7 @@ class EnclosureMark1(Enclosure):
             # don't bother the user with multiple notifications with 30 secs
             return
 
-        Enclosure._last_internet_notification = time.time()
+        Enclosure._last_internet_notification=time.time()
 
         # TODO: This should go into EnclosureMark1 subclass of Enclosure.
         if has_been_paired():
@@ -330,11 +330,11 @@ class EnclosureMark1(Enclosure):
 
     def __init_serial(self):
         try:
-            self.port = self.config.get("port")
-            self.rate = self.config.get("rate")
-            self.timeout = self.config.get("timeout")
-            self.serial = serial.serial_for_url(
-                url = self.port, baudrate=self.rate, timeout = self.timeout)
+            self.port=self.config.get("port")
+            self.rate=self.config.get("rate")
+            self.timeout=self.config.get("timeout")
+            self.serial=serial.serial_for_url(
+                url=self.port, baudrate=self.rate, timeout=self.timeout)
             LOG.info("Connected to: %s rate: %s timeout: %s" %
                      (self.port, self.rate, self.timeout))
         except Exception:
@@ -417,5 +417,5 @@ class EnclosureMark1(Enclosure):
                 time.sleep(2)  # a pause sounds better than just jumping in
 
                 # Kick off wifi-setup automatically
-                data = {'allow_timeout': False, 'lang': self.lang}
+                data={'allow_timeout': False, 'lang': self.lang}
                 self.bus.emit(Message('system.wifi.setup', data))

--- a/mycroft/client/enclosure/mark1/__init__.py
+++ b/mycroft/client/enclosure/mark1/__init__.py
@@ -14,8 +14,7 @@
 #
 import subprocess
 import time
-import os
-import tempfile 
+import tempfile
 import sys
 import os
 import tempfile
@@ -134,9 +133,9 @@ class EnclosureReader(Thread):
                 'utterance': "I am testing one two three"}))
 
             time.sleep(0.5)  # Prevents recording the loud button press
-            record(os.path.join(tempfile.gettempdir(), "test.wav"), 3.0)                   
+            record(os.path.join(tempfile.gettempdir(), "test.wav"), 3.0)
             mixer.setvolume(prev_vol)
-            play_wavv(os.path.join(tempfile.gettempdir(), "test.wav").communicate()           
+            play_wavv(os.path.join(tempfile.gettempdir(), "test.wav").communicate()
 
             # Test audio muting on arduino
             subprocess.call('speaker-test -P 10 -l 0 -s 1', shell=True)
@@ -192,12 +191,12 @@ class EnclosureReader(Thread):
                 'utterance': mycroft.dialog.get("ssh disabled")}))
 
         if "unit.enable-learning" in data or "unit.disable-learning" in data:
-            enable = 'enable' in data
-            word = 'enabled' if enable else 'disabled'
+            enable='enable' in data
+            word='enabled' if enable else 'disabled'
 
             LOG.info("Setting opt_in to: " + word)
-            new_config = {'opt_in': enable}
-            user_config = LocalConf(USER_CONFIG)
+            new_config={'opt_in': enable}
+            user_config=LocalConf(USER_CONFIG)
             user_config.merge(new_config)
             user_config.store()
 
@@ -205,7 +204,7 @@ class EnclosureReader(Thread):
                 'utterance': mycroft.dialog.get("learning " + word)}))
 
     def stop(self):
-        self.alive = False
+        self.alive=False
 
 
 class EnclosureWriter(Thread):
@@ -226,17 +225,17 @@ class EnclosureWriter(Thread):
 
     def __init__(self, serial, bus, size=16):
         super(EnclosureWriter, self).__init__(target=self.flush)
-        self.alive = True
-        self.daemon = True
-        self.serial = serial
-        self.bus = bus
-        self.commands = Queue(size)
+        self.alive=True
+        self.daemon=True
+        self.serial=serial
+        self.bus=bus
+        self.commands=Queue(size)
         self.start()
 
     def flush(self):
         while self.alive:
             try:
-                cmd = self.commands.get() + '\n'
+                cmd=self.commands.get() + '\n'
                 self.serial.write(cmd.encode())
                 self.commands.task_done()
             except Exception as e:
@@ -246,7 +245,7 @@ class EnclosureWriter(Thread):
         self.commands.put(str(command))
 
     def stop(self):
-        self.alive = False
+        self.alive=False
 
 
 class EnclosureMark1(Enclosure):
@@ -263,19 +262,19 @@ class EnclosureMark1(Enclosure):
     E.g. Start and Stop talk animation
     """
 
-    _last_internet_notification = 0
+    _last_internet_notification=0
 
     def __init__(self):
         super().__init__()
 
         self.__init_serial()
-        self.reader = EnclosureReader(self.serial, self.bus, self.lang)
-        self.writer = EnclosureWriter(self.serial, self.bus)
+        self.reader=EnclosureReader(self.serial, self.bus, self.lang)
+        self.writer=EnclosureWriter(self.serial, self.bus)
 
         # Prepare to receive message when the Arduino responds to the
         # following "system.version"
         self.bus.on("enclosure.started", self.on_arduino_responded)
-        self.arduino_responded = False
+        self.arduino_responded=False
         # Send a message to the Arduino across the serial line asking
         # for a reply with version info.
         self.writer.write("system.version")
@@ -293,12 +292,12 @@ class EnclosureMark1(Enclosure):
         init_display_manager_bus_connection()
 
     def on_arduino_responded(self, event=None):
-        self.eyes = EnclosureEyes(self.bus, self.writer)
-        self.mouth = EnclosureMouth(self.bus, self.writer)
-        self.system = EnclosureArduino(self.bus, self.writer)
+        self.eyes=EnclosureEyes(self.bus, self.writer)
+        self.mouth=EnclosureMouth(self.bus, self.writer)
+        self.system=EnclosureArduino(self.bus, self.writer)
         self.__register_events()
         self.__reset()
-        self.arduino_responded = True
+        self.arduino_responded=True
 
         # verify internet connection and prompt user on bootup if needed
         if not connected():
@@ -317,7 +316,7 @@ class EnclosureMark1(Enclosure):
             # don't bother the user with multiple notifications with 30 secs
             return
 
-        Enclosure._last_internet_notification = time.time()
+        Enclosure._last_internet_notification=time.time()
 
         # TODO: This should go into EnclosureMark1 subclass of Enclosure.
         if has_been_paired():
@@ -333,10 +332,10 @@ class EnclosureMark1(Enclosure):
 
     def __init_serial(self):
         try:
-            self.port = self.config.get("port")
-            self.rate = self.config.get("rate")
-            self.timeout = self.config.get("timeout")
-            self.serial = serial.serial_for_url(
+            self.port=self.config.get("port")
+            self.rate=self.config.get("rate")
+            self.timeout=self.config.get("timeout")
+            self.serial=serial.serial_for_url(
                 url=self.port, baudrate=self.rate, timeout=self.timeout)
             LOG.info("Connected to: %s rate: %s timeout: %s" %
                      (self.port, self.rate, self.timeout))
@@ -420,5 +419,5 @@ class EnclosureMark1(Enclosure):
                 time.sleep(2)  # a pause sounds better than just jumping in
 
                 # Kick off wifi-setup automatically
-                data = {'allow_timeout': False, 'lang': self.lang}
+                data={'allow_timeout': False, 'lang': self.lang}
                 self.bus.emit(Message('system.wifi.setup', data))

--- a/mycroft/client/enclosure/mark1/__init__.py
+++ b/mycroft/client/enclosure/mark1/__init__.py
@@ -54,9 +54,9 @@ class EnclosureReader(Thread):
     Mycroft Core.
 
     E.g. Mycroft Stop Feature
-        #. Arduino sends a Stop command after a button press on a Mycroft unit
-        #. ``EnclosureReader`` captures the Stop command
-        #. Notify all Mycroft Core processes (e.g. skills) to be stopped
+        # . Arduino sends a Stop command after a button press on a Mycroft unit
+        # . ``EnclosureReader`` captures the Stop command
+        # . Notify all Mycroft Core processes (e.g. skills) to be stopped
 
     Note: A command is identified by a line break
     """
@@ -131,7 +131,7 @@ class EnclosureReader(Thread):
                 'utterance': "I am testing one two three"}))
 
             time.sleep(0.5)  # Prevents recording the loud button press
-            record(create_temp_path('test.wav', 3.0)
+            record(create_temp_path('test.wav', 3.0))
             mixer.setvolume(prev_vol)
             play_wav(create_temp_path('test.wav')).communicate()
 
@@ -189,12 +189,12 @@ class EnclosureReader(Thread):
                 'utterance': mycroft.dialog.get("ssh disabled")}))
 
         if "unit.enable-learning" in data or "unit.disable-learning" in data:
-            enable='enable' in data
-            word='enabled' if enable else 'disabled'
+            enable = 'enable' in data
+            word = 'enabled' if enable else 'disabled'
 
             LOG.info("Setting opt_in to: " + word)
-            new_config={'opt_in': enable}
-            user_config=LocalConf(USER_CONFIG)
+            new_config = {'opt_in': enable}
+            user_config = LocalConf(USER_CONFIG)
             user_config.merge(new_config)
             user_config.store()
 
@@ -202,38 +202,38 @@ class EnclosureReader(Thread):
                 'utterance': mycroft.dialog.get("learning " + word)}))
 
     def stop(self):
-        self.alive=False
+        self.alive = False
 
 
 class EnclosureWriter(Thread):
     """
     Writes data to Serial port.
-        #. Enqueues all commands received from Mycroft enclosures
+        # . Enqueues all commands received from Mycroft enclosures
            implementation
-        #. Process them on the received order by writing on the Serial port
+        # . Process them on the received order by writing on the Serial port
 
     E.g. Displaying a text on Mycroft's Mouth
-        #. ``EnclosureMouth`` sends a text command
-        #. ``EnclosureWriter`` captures and enqueue the command
-        #. ``EnclosureWriter`` removes the next command from the queue
-        #. ``EnclosureWriter`` writes the command to Serial port
+        # . ``EnclosureMouth`` sends a text command
+        # . ``EnclosureWriter`` captures and enqueue the command
+        # . ``EnclosureWriter`` removes the next command from the queue
+        # . ``EnclosureWriter`` writes the command to Serial port
 
     Note: A command has to end with a line break
     """
 
     def __init__(self, serial, bus, size=16):
         super(EnclosureWriter, self).__init__(target=self.flush)
-        self.alive=True
-        self.daemon=True
-        self.serial=serial
-        self.bus=bus
-        self.commands=Queue(size)
+        self.alive = True
+        self.daemon = True
+        self.serial = serial
+        self.bus = bus
+        self.commands = Queue(size)
         self.start()
 
     def flush(self):
         while self.alive:
             try:
-                cmd=self.commands.get() + '\n'
+                cmd = self.commands.get() + '\n'
                 self.serial.write(cmd.encode())
                 self.commands.task_done()
             except Exception as e:
@@ -243,7 +243,7 @@ class EnclosureWriter(Thread):
         self.commands.put(str(command))
 
     def stop(self):
-        self.alive=False
+        self.alive = False
 
 
 class EnclosureMark1(Enclosure):
@@ -260,19 +260,19 @@ class EnclosureMark1(Enclosure):
     E.g. Start and Stop talk animation
     """
 
-    _last_internet_notification=0
+    _last_internet_notification = 0
 
     def __init__(self):
         super().__init__()
 
         self.__init_serial()
-        self.reader=EnclosureReader(self.serial, self.bus, self.lang)
-        self.writer=EnclosureWriter(self.serial, self.bus)
+        self.reader = EnclosureReader(self.serial, self.bus, self.lang)
+        self.writer = EnclosureWriter(self.serial, self.bus)
 
         # Prepare to receive message when the Arduino responds to the
         # following "system.version"
         self.bus.on("enclosure.started", self.on_arduino_responded)
-        self.arduino_responded=False
+        self.arduino_responded = False
         # Send a message to the Arduino across the serial line asking
         # for a reply with version info.
         self.writer.write("system.version")
@@ -290,12 +290,12 @@ class EnclosureMark1(Enclosure):
         init_display_manager_bus_connection()
 
     def on_arduino_responded(self, event=None):
-        self.eyes=EnclosureEyes(self.bus, self.writer)
-        self.mouth=EnclosureMouth(self.bus, self.writer)
-        self.system=EnclosureArduino(self.bus, self.writer)
+        self.eyes = EnclosureEyes(self.bus, self.writer)
+        self.mouth = EnclosureMouth(self.bus, self.writer)
+        self.system = EnclosureArduino(self.bus, self.writer)
         self.__register_events()
         self.__reset()
-        self.arduino_responded=True
+        self.arduino_responded = True
 
         # verify internet connection and prompt user on bootup if needed
         if not connected():
@@ -314,7 +314,7 @@ class EnclosureMark1(Enclosure):
             # don't bother the user with multiple notifications with 30 secs
             return
 
-        Enclosure._last_internet_notification=time.time()
+        Enclosure._last_internet_notification = time.time()
 
         # TODO: This should go into EnclosureMark1 subclass of Enclosure.
         if has_been_paired():
@@ -330,15 +330,15 @@ class EnclosureMark1(Enclosure):
 
     def __init_serial(self):
         try:
-            self.port=self.config.get("port")
-            self.rate=self.config.get("rate")
-            self.timeout=self.config.get("timeout")
-            self.serial=serial.serial_for_url(
+            self.port = self.config.get("port")
+            self.rate = self.config.get("rate")
+            self.timeout = self.config.get("timeout")
+            self.serial = serial.serial_for_url(
                 url=self.port, baudrate=self.rate, timeout=self.timeout)
             LOG.info("Connected to: %s rate: %s timeout: %s" %
                      (self.port, self.rate, self.timeout))
         except Exception:
-            LOG.error("Impossible to connect to serial port: "+str(self.port))
+            LOG.error("Impossible to connect to serial port: " + str(self.port))
             raise
 
     def __register_events(self):
@@ -417,5 +417,5 @@ class EnclosureMark1(Enclosure):
                 time.sleep(2)  # a pause sounds better than just jumping in
 
                 # Kick off wifi-setup automatically
-                data={'allow_timeout': False, 'lang': self.lang}
+                data = {'allow_timeout': False, 'lang': self.lang}
                 self.bus.emit(Message('system.wifi.setup', data))

--- a/mycroft/client/enclosure/mark1/__init__.py
+++ b/mycroft/client/enclosure/mark1/__init__.py
@@ -133,9 +133,9 @@ class EnclosureReader(Thread):
                 'utterance': "I am testing one two three"}))
 
             time.sleep(0.5)  # Prevents recording the loud button press
-            record(os.path.join(tempfile.gettempdir(), 'play.wav'), 3.0)
+            record(os.path.join(tempfile.gettempdir(), 'test.wav'), 3.0)
             mixer.setvolume(prev_vol)
-            play_wavv(os.path.join(tempfile.gettempdir(), 'play.wav').communicate()
+            play_wav(os.path.join(tempfile.gettempdir(), 'test.wav').communicate()
 
             # Test audio muting on arduino
             subprocess.call('speaker-test -P 10 -l 0 -s 1', shell=True)
@@ -204,7 +204,7 @@ class EnclosureReader(Thread):
                 'utterance': mycroft.dialog.get("learning " + word)}))
 
     def stop(self):
-        self.alive=False
+        self.alive = False
 
 
 class EnclosureWriter(Thread):
@@ -262,7 +262,7 @@ class EnclosureMark1(Enclosure):
     E.g. Start and Stop talk animation
     """
 
-    _last_internet_notification=0
+    _last_internet_notification = 0
 
     def __init__(self):
         super().__init__()

--- a/mycroft/client/enclosure/mark1/__init__.py
+++ b/mycroft/client/enclosure/mark1/__init__.py
@@ -14,7 +14,6 @@
 #
 import subprocess
 import time
-import tempfile
 import sys
 import os
 import tempfile
@@ -135,7 +134,7 @@ class EnclosureReader(Thread):
             time.sleep(0.5)  # Prevents recording the loud button press
             record(os.path.join(tempfile.gettempdir(), 'test.wav'), 3.0)
             mixer.setvolume(prev_vol)
-            play_wav(os.path.join(tempfile.gettempdir(), 'test.wav').communicate()
+            play_wav(os.path.join(tempfile.gettempdir(), 'test.wav').communicate())
 
             # Test audio muting on arduino
             subprocess.call('speaker-test -P 10 -l 0 -s 1', shell=True)
@@ -223,7 +222,7 @@ class EnclosureWriter(Thread):
     Note: A command has to end with a line break
     """
 
-    def __init__(self, serial, bus, size = 16):
+    def __init__(self, serial, bus, size=16):
         super(EnclosureWriter, self).__init__(target=self.flush)
         self.alive = True
         self.daemon = True

--- a/mycroft/client/enclosure/mark1/__init__.py
+++ b/mycroft/client/enclosure/mark1/__init__.py
@@ -133,9 +133,9 @@ class EnclosureReader(Thread):
                 'utterance': "I am testing one two three"}))
 
             time.sleep(0.5)  # Prevents recording the loud button press
-            record(os.path.join(tempfile.gettempdir(), "test.wav"), 3.0)
+            record(os.path.join(tempfile.gettempdir(), 'play.wav'), 3.0)
             mixer.setvolume(prev_vol)
-            play_wavv(os.path.join(tempfile.gettempdir(), "test.wav").communicate()
+            play_wavv(os.path.join(tempfile.gettempdir(), 'play.wav').communicate()
 
             # Test audio muting on arduino
             subprocess.call('speaker-test -P 10 -l 0 -s 1', shell=True)
@@ -191,12 +191,12 @@ class EnclosureReader(Thread):
                 'utterance': mycroft.dialog.get("ssh disabled")}))
 
         if "unit.enable-learning" in data or "unit.disable-learning" in data:
-            enable='enable' in data
-            word='enabled' if enable else 'disabled'
+            enable = 'enable' in data
+            word = 'enabled' if enable else 'disabled'
 
             LOG.info("Setting opt_in to: " + word)
-            new_config={'opt_in': enable}
-            user_config=LocalConf(USER_CONFIG)
+            new_config = {'opt_in': enable}
+            user_config = LocalConf(USER_CONFIG)
             user_config.merge(new_config)
             user_config.store()
 
@@ -223,19 +223,19 @@ class EnclosureWriter(Thread):
     Note: A command has to end with a line break
     """
 
-    def __init__(self, serial, bus, size=16):
+    def __init__(self, serial, bus, size = 16):
         super(EnclosureWriter, self).__init__(target=self.flush)
-        self.alive=True
-        self.daemon=True
-        self.serial=serial
-        self.bus=bus
-        self.commands=Queue(size)
+        self.alive = True
+        self.daemon = True
+        self.serial = serial
+        self.bus = bus
+        self.commands = Queue(size)
         self.start()
 
     def flush(self):
         while self.alive:
             try:
-                cmd=self.commands.get() + '\n'
+                cmd = self.commands.get() + '\n'
                 self.serial.write(cmd.encode())
                 self.commands.task_done()
             except Exception as e:
@@ -245,7 +245,7 @@ class EnclosureWriter(Thread):
         self.commands.put(str(command))
 
     def stop(self):
-        self.alive=False
+        self.alive = False
 
 
 class EnclosureMark1(Enclosure):
@@ -268,13 +268,13 @@ class EnclosureMark1(Enclosure):
         super().__init__()
 
         self.__init_serial()
-        self.reader=EnclosureReader(self.serial, self.bus, self.lang)
-        self.writer=EnclosureWriter(self.serial, self.bus)
+        self.reader = EnclosureReader(self.serial, self.bus, self.lang)
+        self.writer = EnclosureWriter(self.serial, self.bus)
 
         # Prepare to receive message when the Arduino responds to the
         # following "system.version"
         self.bus.on("enclosure.started", self.on_arduino_responded)
-        self.arduino_responded=False
+        self.arduino_responded = False
         # Send a message to the Arduino across the serial line asking
         # for a reply with version info.
         self.writer.write("system.version")
@@ -291,13 +291,13 @@ class EnclosureMark1(Enclosure):
         # NOTE: this is a temporary place to connect the display manager
         init_display_manager_bus_connection()
 
-    def on_arduino_responded(self, event=None):
-        self.eyes=EnclosureEyes(self.bus, self.writer)
-        self.mouth=EnclosureMouth(self.bus, self.writer)
-        self.system=EnclosureArduino(self.bus, self.writer)
+    def on_arduino_responded(self, event = None):
+        self.eyes = EnclosureEyes(self.bus, self.writer)
+        self.mouth = EnclosureMouth(self.bus, self.writer)
+        self.system = EnclosureArduino(self.bus, self.writer)
         self.__register_events()
         self.__reset()
-        self.arduino_responded=True
+        self.arduino_responded = True
 
         # verify internet connection and prompt user on bootup if needed
         if not connected():
@@ -316,7 +316,7 @@ class EnclosureMark1(Enclosure):
             # don't bother the user with multiple notifications with 30 secs
             return
 
-        Enclosure._last_internet_notification=time.time()
+        Enclosure._last_internet_notification = time.time()
 
         # TODO: This should go into EnclosureMark1 subclass of Enclosure.
         if has_been_paired():
@@ -332,11 +332,11 @@ class EnclosureMark1(Enclosure):
 
     def __init_serial(self):
         try:
-            self.port=self.config.get("port")
-            self.rate=self.config.get("rate")
-            self.timeout=self.config.get("timeout")
-            self.serial=serial.serial_for_url(
-                url=self.port, baudrate=self.rate, timeout=self.timeout)
+            self.port = self.config.get("port")
+            self.rate = self.config.get("rate")
+            self.timeout = self.config.get("timeout")
+            self.serial = serial.serial_for_url(
+                url = self.port, baudrate=self.rate, timeout = self.timeout)
             LOG.info("Connected to: %s rate: %s timeout: %s" %
                      (self.port, self.rate, self.timeout))
         except Exception:
@@ -419,5 +419,5 @@ class EnclosureMark1(Enclosure):
                 time.sleep(2)  # a pause sounds better than just jumping in
 
                 # Kick off wifi-setup automatically
-                data={'allow_timeout': False, 'lang': self.lang}
+                data = {'allow_timeout': False, 'lang': self.lang}
                 self.bus.emit(Message('system.wifi.setup', data))

--- a/mycroft/client/enclosure/mark1/__init__.py
+++ b/mycroft/client/enclosure/mark1/__init__.py
@@ -133,7 +133,7 @@ class EnclosureReader(Thread):
             time.sleep(0.5)  # Prevents recording the loud button press
             record(create_temp_path('test.wav', 3.0)
             mixer.setvolume(prev_vol)
-            play_wav(creat_temp_path('test.wav')).communicate()
+            play_wav(create_temp_path('test.wav')).communicate()
 
             # Test audio muting on arduino
             subprocess.call('speaker-test -P 10 -l 0 -s 1', shell=True)

--- a/mycroft/client/enclosure/mark1/__init__.py
+++ b/mycroft/client/enclosure/mark1/__init__.py
@@ -15,6 +15,8 @@
 import subprocess
 import time
 import sys
+import os
+import tempfile
 from alsaaudio import Mixer
 from threading import Thread, Timer
 
@@ -130,9 +132,9 @@ class EnclosureReader(Thread):
                 'utterance': "I am testing one two three"}))
 
             time.sleep(0.5)  # Prevents recording the loud button press
-            record("/tmp/test.wav", 3.0)
+            record(os.path.join(tempfile.gettempdir(), "test.wav"), 3.0)                   
             mixer.setvolume(prev_vol)
-            play_wav("/tmp/test.wav").communicate()
+            play_wavv(os.path.join(tempfile.gettempdir(), "test.wav").communicate()           
 
             # Test audio muting on arduino
             subprocess.call('speaker-test -P 10 -l 0 -s 1', shell=True)

--- a/mycroft/client/enclosure/mark1/__init__.py
+++ b/mycroft/client/enclosure/mark1/__init__.py
@@ -15,8 +15,6 @@
 import subprocess
 import time
 import sys
-import os
-import tempfile
 from alsaaudio import Mixer
 from threading import Thread, Timer
 
@@ -37,6 +35,7 @@ from mycroft.util import play_wav, create_signal, connected, check_for_signal
 from mycroft.util.audio_test import record
 from mycroft.util.log import LOG
 from queue import Queue
+from mycroft.util import create_temp_path
 
 # The Mark 1 hardware consists of a Raspberry Pi main CPU which is connected
 # to an Arduino over the serial port.  A custom serial protocol sends
@@ -132,9 +131,9 @@ class EnclosureReader(Thread):
                 'utterance': "I am testing one two three"}))
 
             time.sleep(0.5)  # Prevents recording the loud button press
-            record(os.path.join(tempfile.gettempdir(), 'test.wav'), 3.0)
+            record(create_temp_path('test.wav', 3.0)
             mixer.setvolume(prev_vol)
-            play_wav(os.path.join(tempfile.gettempdir(), 'test.wav').communicate())
+            play_wav(creat_temp_path('test.wav')).communicate()
 
             # Test audio muting on arduino
             subprocess.call('speaker-test -P 10 -l 0 -s 1', shell=True)

--- a/mycroft/client/enclosure/mark1/__init__.py
+++ b/mycroft/client/enclosure/mark1/__init__.py
@@ -35,7 +35,7 @@ from mycroft.util import play_wav, create_signal, connected, check_for_signal
 from mycroft.util.audio_test import record
 from mycroft.util.log import LOG
 from queue import Queue
-from mycroft.util.file_utils import create_temp_path
+from mycroft.util.file_utils import get_temp_path
 
 # The Mark 1 hardware consists of a Raspberry Pi main CPU which is connected
 # to an Arduino over the serial port.  A custom serial protocol sends
@@ -131,9 +131,9 @@ class EnclosureReader(Thread):
                 'utterance': "I am testing one two three"}))
 
             time.sleep(0.5)  # Prevents recording the loud button press
-            record(create_temp_path('test.wav', 3.0))
+            record(get_temp_path('test.wav', 3.0))
             mixer.setvolume(prev_vol)
-            play_wav(create_temp_path('test.wav')).communicate()
+            play_wav(get_temp_path('test.wav')).communicate()
 
             # Test audio muting on arduino
             subprocess.call('speaker-test -P 10 -l 0 -s 1', shell=True)
@@ -338,7 +338,8 @@ class EnclosureMark1(Enclosure):
             LOG.info("Connected to: %s rate: %s timeout: %s" %
                      (self.port, self.rate, self.timeout))
         except Exception:
-            LOG.error("Impossible to connect to serial port: " + str(self.port))
+            LOG.error("Impossible to connect to serial port: " +
+                      str(self.port))
             raise
 
     def __register_events(self):

--- a/mycroft/lock/__init__.py
+++ b/mycroft/lock/__init__.py
@@ -22,7 +22,7 @@ import os  # Operating System functions
 # Wrapper around chain of handler functions for a specific system level signal.
 # Often used to trap Ctrl-C for specific application purposes.
 from mycroft.util import LOG
-from mycroft.util.file_utils import create_temp_path
+from mycroft.util.file_utils import get_temp_path
 
 
 class Signal:  # python 3+ class Signal
@@ -99,7 +99,7 @@ class Lock:  # python 3+ 'class Lock'
 
     #
     # Class constants
-    DIRECTORY = create_temp_path('mycroft') 
+    DIRECTORY = get_temp_path('mycroft')
     FILE = '/{}.pid'
 
     #

--- a/mycroft/lock/__init__.py
+++ b/mycroft/lock/__init__.py
@@ -100,7 +100,7 @@ class Lock:  # python 3+ 'class Lock'
     #
     # Class constants
     DIRECTORY = os.path.join(tempfile.gettempdir(),
-                             "mycroft", "ipc")  # '/tmp/mycroft'
+                             'mycroft') 
     FILE = '/{}.pid'
 
     #

--- a/mycroft/lock/__init__.py
+++ b/mycroft/lock/__init__.py
@@ -16,13 +16,13 @@ from signal import getsignal, signal, SIGKILL, SIGINT, SIGTERM, \
     SIG_DFL, default_int_handler, SIG_IGN  # signals
 
 import os  # Operating System functions
-import tempfile
 
 
 #
 # Wrapper around chain of handler functions for a specific system level signal.
 # Often used to trap Ctrl-C for specific application purposes.
 from mycroft.util import LOG
+from mycroft.util import create_temp_path
 
 
 class Signal:  # python 3+ class Signal
@@ -99,8 +99,7 @@ class Lock:  # python 3+ 'class Lock'
 
     #
     # Class constants
-    DIRECTORY = os.path.join(tempfile.gettempdir(),
-                             'mycroft') 
+    DIRECTORY = create_temp_path('mycroft') 
     FILE = '/{}.pid'
 
     #

--- a/mycroft/lock/__init__.py
+++ b/mycroft/lock/__init__.py
@@ -98,7 +98,7 @@ class Lock:  # python 3+ 'class Lock'
 
     #
     # Class constants
-    DIRECTORY = '/tmp/mycroft'
+    DIRECTORY = os.path.join(tempfile.gettempdir(), "mycroft", "ipc")                 #'/tmp/mycroft'
     FILE = '/{}.pid'
 
     #

--- a/mycroft/lock/__init__.py
+++ b/mycroft/lock/__init__.py
@@ -16,6 +16,7 @@ from signal import getsignal, signal, SIGKILL, SIGINT, SIGTERM, \
     SIG_DFL, default_int_handler, SIG_IGN  # signals
 
 import os  # Operating System functions
+import tempfile 
 
 
 #

--- a/mycroft/lock/__init__.py
+++ b/mycroft/lock/__init__.py
@@ -22,7 +22,7 @@ import os  # Operating System functions
 # Wrapper around chain of handler functions for a specific system level signal.
 # Often used to trap Ctrl-C for specific application purposes.
 from mycroft.util import LOG
-from mycroft.util import create_temp_path
+from mycroft.util.file_utils import create_temp_path
 
 
 class Signal:  # python 3+ class Signal

--- a/mycroft/lock/__init__.py
+++ b/mycroft/lock/__init__.py
@@ -16,7 +16,7 @@ from signal import getsignal, signal, SIGKILL, SIGINT, SIGTERM, \
     SIG_DFL, default_int_handler, SIG_IGN  # signals
 
 import os  # Operating System functions
-import tempfile 
+import tempfile
 
 
 #
@@ -99,7 +99,8 @@ class Lock:  # python 3+ 'class Lock'
 
     #
     # Class constants
-    DIRECTORY = os.path.join(tempfile.gettempdir(), "mycroft", "ipc")                 #'/tmp/mycroft'
+    DIRECTORY = os.path.join(tempfile.gettempdir(),
+                             "mycroft", "ipc")  # '/tmp/mycroft'
     FILE = '/{}.pid'
 
     #

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -27,7 +27,7 @@ from msm import MycroftSkillsManager, SkillRepo
 
 from mycroft.util.combo_lock import ComboLock
 from mycroft.util.log import LOG
-from mycroft.util.file_utils import create_temp_path
+from mycroft.util.file_utils import get_temp_path
 
 MsmConfig = namedtuple(
     'MsmConfig',
@@ -45,7 +45,7 @@ MsmConfig = namedtuple(
 def _init_msm_lock():
     msm_lock = None
     try:
-        msm_lock = ComboLock(create_temp_path('mycroft-msm.lck'))
+        msm_lock = ComboLock(get_temp_path('mycroft-msm.lck'))
         LOG.debug('mycroft-msm combo lock instantiated')
     except Exception:
         LOG.exception('Failed to create msm lock!')

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -47,7 +47,8 @@ MsmConfig = namedtuple(
 def _init_msm_lock():
     msm_lock = None
     try:
-        msm_lock = ComboLock(os.path.join(tempfile.gettempdir(), "mycroft-msm.lck"))            
+        msm_lock = ComboLock(os.path.join(
+            tempfile.gettempdir(), "mycroft-msm.lck"))
         LOG.debug('mycroft-msm combo lock instantiated')
     except Exception:
         LOG.exception('Failed to create msm lock!')

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -44,7 +44,7 @@ MsmConfig = namedtuple(
 def _init_msm_lock():
     msm_lock = None
     try:
-        msm_lock = ComboLock('/tmp/mycroft-msm.lck')
+        msm_lock = ComboLock(os.path.join(tempfile.gettempdir(), "mycroft-msm.lck"))            
         LOG.debug('mycroft-msm combo lock instantiated')
     except Exception:
         LOG.exception('Failed to create msm lock!')

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -19,6 +19,9 @@ more skills that are installed on a device, the longer these interactions
 take.  This is especially true at boot time when MSM is instantiated
 frequently.  To improve performance, the MSM instance is cached.
 """
+
+import os
+import tempfile
 from collections import namedtuple
 from functools import lru_cache
 from os import path, makedirs

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -27,7 +27,7 @@ from msm import MycroftSkillsManager, SkillRepo
 
 from mycroft.util.combo_lock import ComboLock
 from mycroft.util.log import LOG
-from mycroft.util import create_temp_path
+from mycroft.util.file_utils import create_temp_path
 
 MsmConfig = namedtuple(
     'MsmConfig',

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -48,7 +48,7 @@ def _init_msm_lock():
     msm_lock = None
     try:
         msm_lock = ComboLock(os.path.join(
-            tempfile.gettempdir(), "mycroft-msm.lck"))
+            tempfile.gettempdir(), 'mycroft-msm.lck'))
         LOG.debug('mycroft-msm combo lock instantiated')
     except Exception:
         LOG.exception('Failed to create msm lock!')

--- a/mycroft/skills/msm_wrapper.py
+++ b/mycroft/skills/msm_wrapper.py
@@ -19,9 +19,6 @@ more skills that are installed on a device, the longer these interactions
 take.  This is especially true at boot time when MSM is instantiated
 frequently.  To improve performance, the MSM instance is cached.
 """
-
-import os
-import tempfile
 from collections import namedtuple
 from functools import lru_cache
 from os import path, makedirs
@@ -30,6 +27,7 @@ from msm import MycroftSkillsManager, SkillRepo
 
 from mycroft.util.combo_lock import ComboLock
 from mycroft.util.log import LOG
+from mycroft.util import create_temp_path
 
 MsmConfig = namedtuple(
     'MsmConfig',
@@ -47,8 +45,7 @@ MsmConfig = namedtuple(
 def _init_msm_lock():
     msm_lock = None
     try:
-        msm_lock = ComboLock(os.path.join(
-            tempfile.gettempdir(), 'mycroft-msm.lck'))
+        msm_lock = ComboLock(create_temp_path('mycroft-msm.lck'))
         LOG.debug('mycroft-msm combo lock instantiated')
     except Exception:
         LOG.exception('Failed to create msm lock!')

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -18,6 +18,7 @@ import tempfile
 import sys
 from datetime import datetime
 from time import time
+
 from msm import MsmException
 
 from mycroft.api import DeviceApi, is_paired
@@ -48,7 +49,7 @@ class SkillUpdater:
     _msm = None
 
     def __init__(self, bus=None):
-        self.msm_lock = ComboLock(os.path.join(tempfile.gettempdir(), "mycroft-msm.lck"))          
+        self.msm_lock = ComboLock(os.path.join(tempfile.gettempdir(), 'mycroft-msm.lck'))          
         self.install_retries = 0
         self.config = Configuration.get()
         update_interval = self.config['skills']['update_interval']

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -26,7 +26,7 @@ from mycroft.util import connected
 from mycroft.util.combo_lock import ComboLock
 from mycroft.util.log import LOG
 from .msm_wrapper import build_msm_config, create_msm
-from mycroft.util import create_temp_path
+from mycroft.util.file_utils import create_temp_path
 
 ONE_HOUR = 3600
 FIVE_MINUTES = 300  # number of seconds in a minute
@@ -49,7 +49,7 @@ class SkillUpdater:
     _msm = None
 
     def __init__(self, bus=None):
-        self.msm_lock = ComboLock(create_temp_path('mycroft-msm.lck'))        
+        self.msm_lock = ComboLock(create_temp_path('mycroft-msm.lck'))
         self.install_retries = 0
         self.config = Configuration.get()
         update_interval = self.config['skills']['update_interval']
@@ -73,8 +73,8 @@ class SkillUpdater:
         otherwise use the timestamp on .msm as a basis.
         """
         msm_files_exist = (
-                os.path.exists(self.dot_msm_path) and
-                os.path.exists(self.installed_skills_file_path)
+            os.path.exists(self.dot_msm_path) and
+            os.path.exists(self.installed_skills_file_path)
         )
         if msm_files_exist:
             mtime = os.path.getmtime(self.dot_msm_path)

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -48,7 +48,7 @@ class SkillUpdater:
     _msm = None
 
     def __init__(self, bus=None):
-        self.msm_lock = ComboLock('/tmp/mycroft-msm.lck')
+        self.msm_lock = ComboLock(os.path.join(tempfile.gettempdir(), "mycroft-msm.lck"))          
         self.install_retries = 0
         self.config = Configuration.get()
         update_interval = self.config['skills']['update_interval']

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -14,7 +14,6 @@
 #
 """Periodically run by skill manager to update skills and post the manifest."""
 import os
-import tempfile
 import sys
 from datetime import datetime
 from time import time
@@ -27,6 +26,7 @@ from mycroft.util import connected
 from mycroft.util.combo_lock import ComboLock
 from mycroft.util.log import LOG
 from .msm_wrapper import build_msm_config, create_msm
+from mycroft.util import create_temp_path
 
 ONE_HOUR = 3600
 FIVE_MINUTES = 300  # number of seconds in a minute
@@ -49,7 +49,7 @@ class SkillUpdater:
     _msm = None
 
     def __init__(self, bus=None):
-        self.msm_lock = ComboLock(os.path.join(tempfile.gettempdir(), 'mycroft-msm.lck'))          
+        self.msm_lock = ComboLock(create_temp_path('mycroft-msm.lck'))        
         self.install_retries = 0
         self.config = Configuration.get()
         update_interval = self.config['skills']['update_interval']

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -18,7 +18,6 @@ import tempfile
 import sys
 from datetime import datetime
 from time import time
-
 from msm import MsmException
 
 from mycroft.api import DeviceApi, is_paired

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -14,6 +14,7 @@
 #
 """Periodically run by skill manager to update skills and post the manifest."""
 import os
+import tempfile
 import sys
 from datetime import datetime
 from time import time

--- a/mycroft/skills/skill_updater.py
+++ b/mycroft/skills/skill_updater.py
@@ -26,7 +26,7 @@ from mycroft.util import connected
 from mycroft.util.combo_lock import ComboLock
 from mycroft.util.log import LOG
 from .msm_wrapper import build_msm_config, create_msm
-from mycroft.util.file_utils import create_temp_path
+from mycroft.util.file_utils import get_temp_path
 
 ONE_HOUR = 3600
 FIVE_MINUTES = 300  # number of seconds in a minute
@@ -49,7 +49,7 @@ class SkillUpdater:
     _msm = None
 
     def __init__(self, bus=None):
-        self.msm_lock = ComboLock(create_temp_path('mycroft-msm.lck'))
+        self.msm_lock = ComboLock(get_temp_path('mycroft-msm.lck'))
         self.install_retries = 0
         self.config = Configuration.get()
         update_interval = self.config['skills']['update_interval']

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -14,7 +14,6 @@
 #
 from copy import deepcopy
 import os
-import tempfile
 import random
 import re
 from abc import ABCMeta, abstractmethod
@@ -32,6 +31,7 @@ from mycroft.metrics import report_timing, Stopwatch
 from mycroft.util import (
     play_wav, play_mp3, check_for_signal, create_signal, resolve_resource_file
 )
+from mycroft.util import create_temp_path
 from mycroft.util.log import LOG
 from mycroft.util.plugins import load_plugin
 from queue import Queue, Empty
@@ -178,7 +178,7 @@ class TTS(metaclass=ABCMeta):
         self.ssml_tags = ssml_tags or []
 
         self.voice = config.get("voice")
-        self.filename = os.path.join(tempfile.gettempdir(), 'tts.wav')
+        self.filename = create_temp_path('tts.wav')
         self.enclosure = None
         random.seed()
         self.queue = Queue()

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -176,7 +176,7 @@ class TTS(metaclass=ABCMeta):
         self.ssml_tags = ssml_tags or []
 
         self.voice = config.get("voice")
-        self.filename = '/tmp/tts.wav'
+        self.filename = 'os.path.join(tempfile.gettempdir(), "tts.wav")'   
         self.enclosure = None
         random.seed()
         self.queue = Queue()

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -14,6 +14,7 @@
 #
 from copy import deepcopy
 import os
+import tempfile
 import random
 import re
 from abc import ABCMeta, abstractmethod

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -178,7 +178,7 @@ class TTS(metaclass=ABCMeta):
         self.ssml_tags = ssml_tags or []
 
         self.voice = config.get("voice")
-        self.filename = 'os.path.join(tempfile.gettempdir(), "tts.wav")'
+        self.filename = os.path.join(tempfile.gettempdir(), 'tts.wav')
         self.enclosure = None
         random.seed()
         self.queue = Queue()

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -31,7 +31,7 @@ from mycroft.metrics import report_timing, Stopwatch
 from mycroft.util import (
     play_wav, play_mp3, check_for_signal, create_signal, resolve_resource_file
 )
-from mycroft.util.file_utils import create_temp_path
+from mycroft.util.file_utils import get_temp_path
 from mycroft.util.log import LOG
 from mycroft.util.plugins import load_plugin
 from queue import Queue, Empty
@@ -178,7 +178,7 @@ class TTS(metaclass=ABCMeta):
         self.ssml_tags = ssml_tags or []
 
         self.voice = config.get("voice")
-        self.filename = create_temp_path('tts.wav')
+        self.filename = get_temp_path('tts.wav')
         self.enclosure = None
         random.seed()
         self.queue = Queue()

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -165,6 +165,7 @@ class TTS(metaclass=ABCMeta):
         phonetic_spelling (bool): Whether to spell certain words phonetically
         ssml_tags (list): Supported ssml properties. Ex. ['speak', 'prosody']
     """
+
     def __init__(self, lang, config, validator, audio_ext='wav',
                  phonetic_spelling=True, ssml_tags=None):
         super(TTS, self).__init__()
@@ -177,7 +178,7 @@ class TTS(metaclass=ABCMeta):
         self.ssml_tags = ssml_tags or []
 
         self.voice = config.get("voice")
-        self.filename = 'os.path.join(tempfile.gettempdir(), "tts.wav")'   
+        self.filename = 'os.path.join(tempfile.gettempdir(), "tts.wav")'
         self.enclosure = None
         random.seed()
         self.queue = Queue()
@@ -472,6 +473,7 @@ class TTSValidator(metaclass=ABCMeta):
     It exposes and implements ``validate(tts)`` function as a template to
     validate the TTS engines.
     """
+
     def __init__(self, tts):
         self.tts = tts
 

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -31,7 +31,7 @@ from mycroft.metrics import report_timing, Stopwatch
 from mycroft.util import (
     play_wav, play_mp3, check_for_signal, create_signal, resolve_resource_file
 )
-from mycroft.util import create_temp_path
+from mycroft.util.file_utils import create_temp_path
 from mycroft.util.log import LOG
 from mycroft.util.plugins import load_plugin
 from queue import Queue, Empty

--- a/mycroft/util/__init__.py
+++ b/mycroft/util/__init__.py
@@ -25,9 +25,15 @@ from mycroft.util.format import nice_number
 from .string_utils import camel_case_split
 from .audio_utils import (play_audio_file, play_wav, play_ogg, play_mp3,
                           record, find_input_device)
-from .file_utils import (resolve_resource_file, read_stripped_lines, read_dict,
-                         create_file, ensure_directory_exists,
-                         curate_cache, get_cache_directory)
+from .file_utils import (
+    resolve_resource_file,
+    read_stripped_lines,
+    read_dict,
+    create_file,
+    get_temp_path,
+    ensure_directory_exists,
+    curate_cache,
+    get_cache_directory)
 from .network_utils import connected
 from .process_utils import (reset_sigint_handler, create_daemon,
                             wait_for_exit_signal, create_echo_function,

--- a/mycroft/util/audio_test.py
+++ b/mycroft/util/audio_test.py
@@ -14,6 +14,7 @@
 #
 import argparse
 import os
+import tempfile
 import pyaudio
 from contextlib import contextmanager
 

--- a/mycroft/util/audio_test.py
+++ b/mycroft/util/audio_test.py
@@ -73,8 +73,8 @@ def record(filename, duration):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-f', '--filename', dest='filename', default=os.path.join(tempfile.gettempdir(), "test.wav"),
-        help="Filename for saved audio (Default:  os.path.join(tempfile.gettempdir(), "test.wav")")
+        '-f', '--filename', dest='filename', default = os.path.join(tempfile.gettempdir(), 'test.wav'),
+        help="Filename for saved audio (Default:{}".format(os.path.join(tempfile.gettempdir(), 'test.wav')))
     parser.add_argument(
         '-d', '--duration', dest='duration', type=int, default=10,
         help="Duration of recording in seconds (Default: 10)")

--- a/mycroft/util/audio_test.py
+++ b/mycroft/util/audio_test.py
@@ -73,8 +73,8 @@ def record(filename, duration):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-f', '--filename', dest='filename', default= os.path.join(tempfile.gettempdir(), "test.wav"),  
-        help="Filename for saved audio (Default:  os.path.join(tempfile.gettempdir(), "test.wav")")     
+        '-f', '--filename', dest='filename', default=os.path.join(tempfile.gettempdir(), "test.wav"),
+        help="Filename for saved audio (Default:  os.path.join(tempfile.gettempdir(), "test.wav")")
     parser.add_argument(
         '-d', '--duration', dest='duration', type=int, default=10,
         help="Duration of recording in seconds (Default: 10)")

--- a/mycroft/util/audio_test.py
+++ b/mycroft/util/audio_test.py
@@ -72,8 +72,8 @@ def record(filename, duration):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-f', '--filename', dest='filename', default="/tmp/test.wav",
-        help="Filename for saved audio (Default: /tmp/test.wav)")
+        '-f', '--filename', dest='filename', default= os.path.join(tempfile.gettempdir(), "test.wav"),  
+        help="Filename for saved audio (Default:  os.path.join(tempfile.gettempdir(), "test.wav")")     
     parser.add_argument(
         '-d', '--duration', dest='duration', type=int, default=10,
         help="Duration of recording in seconds (Default: 10)")

--- a/mycroft/util/audio_test.py
+++ b/mycroft/util/audio_test.py
@@ -24,7 +24,7 @@ from mycroft.configuration import Configuration
 from mycroft.util.audio_utils import play_wav
 from mycroft.util.log import LOG
 import logging
-from mycroft.util import create_temp_path
+from mycroft.util.file_utils import create_temp_path
 
 """
 Audio Test
@@ -73,7 +73,7 @@ def record(filename, duration):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-f', '--filename', dest='filename', default = create_temp_path('test.wav'),
+        '-f', '--filename', dest='filename', default=create_temp_path('test.wav'),
         help="Filename for saved audio (Default:{}".format(create_temp_path('test.wav')))
     parser.add_argument(
         '-d', '--duration', dest='duration', type=int, default=10,

--- a/mycroft/util/audio_test.py
+++ b/mycroft/util/audio_test.py
@@ -14,7 +14,6 @@
 #
 import argparse
 import os
-import tempfile
 import pyaudio
 from contextlib import contextmanager
 
@@ -25,6 +24,7 @@ from mycroft.configuration import Configuration
 from mycroft.util.audio_utils import play_wav
 from mycroft.util.log import LOG
 import logging
+from mycroft.util import create_temp_path
 
 """
 Audio Test
@@ -73,8 +73,8 @@ def record(filename, duration):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-f', '--filename', dest='filename', default = os.path.join(tempfile.gettempdir(), 'test.wav'),
-        help="Filename for saved audio (Default:{}".format(os.path.join(tempfile.gettempdir(), 'test.wav')))
+        '-f', '--filename', dest='filename', default = create_temp_path('test.wav'),
+        help="Filename for saved audio (Default:{}".format(create_temp_path('test.wav')))
     parser.add_argument(
         '-d', '--duration', dest='duration', type=int, default=10,
         help="Duration of recording in seconds (Default: 10)")

--- a/mycroft/util/audio_test.py
+++ b/mycroft/util/audio_test.py
@@ -24,7 +24,7 @@ from mycroft.configuration import Configuration
 from mycroft.util.audio_utils import play_wav
 from mycroft.util.log import LOG
 import logging
-from mycroft.util.file_utils import create_temp_path
+from mycroft.util.file_utils import get_temp_path
 
 """
 Audio Test
@@ -73,8 +73,12 @@ def record(filename, duration):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        '-f', '--filename', dest='filename', default=create_temp_path('test.wav'),
-        help="Filename for saved audio (Default:{}".format(create_temp_path('test.wav')))
+        '-f',
+        '--filename',
+        dest='filename',
+        default=get_temp_path('test.wav'),
+        help="Filename for saved audio (Default:{}".format(
+            get_temp_path('test.wav')))
     parser.add_argument(
         '-d', '--duration', dest='duration', type=int, default=10,
         help="Duration of recording in seconds (Default: 10)")

--- a/mycroft/util/file_utils.py
+++ b/mycroft/util/file_utils.py
@@ -77,6 +77,14 @@ def resolve_resource_file(res_name):
     return None  # Resource cannot be resolved
 
 
+def create_temp_path(*args):
+    try:
+        path = os.path.join(tempfile.gettempdir(), *args)
+    except TypeError:
+        path = None
+	LOG.error('Could not create a temp path, create_temp_path() only accepts Strings')
+    return path
+
 def read_stripped_lines(filename):
     """Read a file and return a list of stripped lines.
 
@@ -231,7 +239,7 @@ def get_cache_directory(domain=None):
     directory = config.get("cache_path")
     if not directory:
         # If not defined, use /tmp/mycroft/cache
-        directory = os.path.join(tempfile.gettempdir(), "mycroft", "cache")
+        directory = create_temp_path('mycroft', 'cache')
     return ensure_directory_exists(directory, domain)
 
 

--- a/mycroft/util/file_utils.py
+++ b/mycroft/util/file_utils.py
@@ -82,8 +82,10 @@ def create_temp_path(*args):
         path = os.path.join(tempfile.gettempdir(), *args)
     except TypeError:
         path = None
-	LOG.error('Could not create a temp path, create_temp_path() only accepts Strings')
+        LOG.error(
+            'Could not create a temp path, create_temp_path() only accepts Strings')
     return path
+
 
 def read_stripped_lines(filename):
     """Read a file and return a list of stripped lines.

--- a/mycroft/util/file_utils.py
+++ b/mycroft/util/file_utils.py
@@ -296,7 +296,6 @@ def get_temp_path(*args):
     try:
         path = os.path.join(tempfile.gettempdir(), *args)
     except TypeError:
-        path = None
-        LOG.error('Could not create a temp path, '
-                  'get_temp_path() only accepts Strings')
+        raise TypeError("Could not create a temp path, get_temp_path() only "
+                        "accepts Strings")
     return path

--- a/mycroft/util/file_utils.py
+++ b/mycroft/util/file_utils.py
@@ -77,16 +77,6 @@ def resolve_resource_file(res_name):
     return None  # Resource cannot be resolved
 
 
-def create_temp_path(*args):
-    try:
-        path = os.path.join(tempfile.gettempdir(), *args)
-    except TypeError:
-        path = None
-        LOG.error(
-            'Could not create a temp path, create_temp_path() only accepts Strings')
-    return path
-
-
 def read_stripped_lines(filename):
     """Read a file and return a list of stripped lines.
 
@@ -241,7 +231,7 @@ def get_cache_directory(domain=None):
     directory = config.get("cache_path")
     if not directory:
         # If not defined, use /tmp/mycroft/cache
-        directory = create_temp_path('mycroft', 'cache')
+        directory = get_temp_path('mycroft', 'cache')
     return ensure_directory_exists(directory, domain)
 
 
@@ -285,3 +275,28 @@ def create_file(filename):
     ensure_directory_exists(os.path.dirname(filename), permissions=0o775)
     with open(filename, 'w') as f:
         f.write('')
+
+
+def get_temp_path(*args):
+    """Generate a valid path in the system temp directory.
+
+    This method accepts one or more strings as arguments. The arguments are
+    joined and returned as a complete path inside the systems temp directory.
+    Importantly, this will not create any directories or files.
+
+    Example usage: get_temp_path('mycroft', 'audio', 'example.wav')
+    Will return the equivalent of: '/tmp/mycroft/audio/example.wav'
+
+    Args:
+        path_element (str): directories and/or filename
+
+    Returns:
+        (str) a valid path in the systems temp directory
+    """
+    try:
+        path = os.path.join(tempfile.gettempdir(), *args)
+    except TypeError:
+        path = None
+        LOG.error('Could not create a temp path, '
+                  'get_temp_path() only accepts Strings')
+    return path

--- a/test/unittests/audio/test_utils.py
+++ b/test/unittests/audio/test_utils.py
@@ -14,6 +14,8 @@
 #
 import unittest
 import unittest.mock as mock
+import os
+import tempfile
 
 from shutil import rmtree
 from threading import Thread

--- a/test/unittests/audio/test_utils.py
+++ b/test/unittests/audio/test_utils.py
@@ -23,7 +23,7 @@ from os.path import exists
 
 import mycroft.audio
 from mycroft.util import create_signal, check_for_signal
-from mycroft.util import create_temp_path
+from mycroft.util.file_utils import create_temp_path
 
 """Tests for public audio service utils."""
 

--- a/test/unittests/audio/test_utils.py
+++ b/test/unittests/audio/test_utils.py
@@ -38,8 +38,8 @@ def wait_while_speaking_thread():
 
 class TestInterface(unittest.TestCase):
     def setUp(self):
-        if exists('/tmp/mycroft'):
-            rmtree('/tmp/mycroft')
+        if exists(os.path.join(tempfile.gettempdir(), "mycroft")):         
+            rmtree(os.path.join(tempfile.gettempdir(), "mycroft"))          
 
     def test_is_speaking(self):
         create_signal('isSpeaking')

--- a/test/unittests/audio/test_utils.py
+++ b/test/unittests/audio/test_utils.py
@@ -14,8 +14,6 @@
 #
 import unittest
 import unittest.mock as mock
-import os
-import tempfile
 
 from shutil import rmtree
 from threading import Thread
@@ -25,6 +23,7 @@ from os.path import exists
 
 import mycroft.audio
 from mycroft.util import create_signal, check_for_signal
+from mycroft.util import create_temp_path
 
 """Tests for public audio service utils."""
 
@@ -40,8 +39,8 @@ def wait_while_speaking_thread():
 
 class TestInterface(unittest.TestCase):
     def setUp(self):
-        if exists(os.path.join(tempfile.gettempdir(), 'mycroft')):
-            rmtree(os.path.join(tempfile.gettempdir(), 'mycroft'))
+        if exists(create_temp_path('mycroft')):
+            rmtree(create_temp_path('mycroft'))
 
     def test_is_speaking(self):
         create_signal('isSpeaking')

--- a/test/unittests/audio/test_utils.py
+++ b/test/unittests/audio/test_utils.py
@@ -19,7 +19,7 @@ import tempfile
 
 from shutil import rmtree
 from threading import Thread
-from time import sleepfarstack:bugfix/issue-2727
+from time import sleep
 
 from os.path import exists
 

--- a/test/unittests/audio/test_utils.py
+++ b/test/unittests/audio/test_utils.py
@@ -23,7 +23,7 @@ from os.path import exists
 
 import mycroft.audio
 from mycroft.util import create_signal, check_for_signal
-from mycroft.util.file_utils import create_temp_path
+from mycroft.util.file_utils import get_temp_path
 
 """Tests for public audio service utils."""
 
@@ -39,8 +39,8 @@ def wait_while_speaking_thread():
 
 class TestInterface(unittest.TestCase):
     def setUp(self):
-        if exists(create_temp_path('mycroft')):
-            rmtree(create_temp_path('mycroft'))
+        if exists(get_temp_path('mycroft')):
+            rmtree(get_temp_path('mycroft'))
 
     def test_is_speaking(self):
         create_signal('isSpeaking')

--- a/test/unittests/audio/test_utils.py
+++ b/test/unittests/audio/test_utils.py
@@ -19,7 +19,7 @@ import tempfile
 
 from shutil import rmtree
 from threading import Thread
-from time import sleep
+from time import sleepfarstack:bugfix/issue-2727
 
 from os.path import exists
 
@@ -40,8 +40,8 @@ def wait_while_speaking_thread():
 
 class TestInterface(unittest.TestCase):
     def setUp(self):
-        if exists(os.path.join(tempfile.gettempdir(), "mycroft")):         
-            rmtree(os.path.join(tempfile.gettempdir(), "mycroft"))          
+        if exists(os.path.join(tempfile.gettempdir(), 'mycroft')):
+            rmtree(os.path.join(tempfile.gettempdir(), 'mycroft'))
 
     def test_is_speaking(self):
         create_signal('isSpeaking')

--- a/test/unittests/lock/test_lock.py
+++ b/test/unittests/lock/test_lock.py
@@ -26,28 +26,28 @@ from mycroft.lock import Lock
 
 class TestLock(unittest.TestCase):
     def setUp(self):
-        if exists(os.path.join(tempfile.gettempdir(), "mycroft")):
-            rmtree(os.path.join(tempfile.gettempdir(), "mycroft"))
+        if exists(os.path.join(tempfile.gettempdir(), 'mycroft')):
+            rmtree(os.path.join(tempfile.gettempdir(), 'mycroft'))
 
     def test_create_lock(self):
         l1 = Lock('test')
         self.assertTrue(
-            isfile(os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))
+            isfile(os.path.join(tempfile.gettempdir(), 'mycroft', 'test.pid')))
 
     def test_delete_lock(self):
         l1 = Lock('test')
         self.assertTrue(
-            isfile(os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))
+            isfile(os.path.join(tempfile.gettempdir(), 'mycroft', 'test.pid')))
         l1.delete()
         self.assertFalse(
-            isfile(os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))
+            isfile(os.path.join(tempfile.gettempdir(), 'mycroft', 'test.pid')))
 
     @patch('os.kill')
     def test_existing_lock(self, mock_kill):
         """ Test that an existing lock will kill the old pid. """
         l1 = Lock('test')
         self.assertTrue(
-            isfile(os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))
+            isfile(os.path.join(tempfile.gettempdir(), 'mycroft', 'test.pid')))
         l2 = Lock('test2')
         self.assertFalse(mock_kill.called)
         l2 = Lock('test')
@@ -56,13 +56,13 @@ class TestLock(unittest.TestCase):
     def test_keyboard_interrupt(self):
         l1 = Lock('test')
         self.assertTrue(
-            isfile(os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))
+            isfile(os.path.join(tempfile.gettempdir(), 'mycroft', 'test.pid')))
         try:
             os.kill(os.getpid(), signal.SIGINT)
         except KeyboardInterrupt:
             pass
         self.assertFalse(
-            isfile(os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))
+            isfile(os.path.join(tempfile.gettempdir(), 'mycroft', 'test.pid')))
 
 
 if __name__ == '__main__':

--- a/test/unittests/lock/test_lock.py
+++ b/test/unittests/lock/test_lock.py
@@ -21,33 +21,33 @@ import os
 from os.path import exists, isfile
 
 from mycroft.lock import Lock
-from mycroft.util.file_utils import create_temp_path
+from mycroft.util.file_utils import get_temp_path
 
 
 class TestLock(unittest.TestCase):
     def setUp(self):
-        if exists(create_temp_path('mycroft')):
-            rmtree(create_temp_path('mycroft'))
+        if exists(get_temp_path('mycroft')):
+            rmtree(get_temp_path('mycroft'))
 
     def test_create_lock(self):
         l1 = Lock('test')
         self.assertTrue(
-            isfile(create_temp_path('mycroft', 'test.pid')))
+            isfile(get_temp_path('mycroft', 'test.pid')))
 
     def test_delete_lock(self):
         l1 = Lock('test')
         self.assertTrue(
-            isfile(create_temp_path('mycroft', 'test.pid')))
+            isfile(get_temp_path('mycroft', 'test.pid')))
         l1.delete()
         self.assertFalse(
-            isfile(create_temp_path('mycroft', 'test.pid')))
+            isfile(get_temp_path('mycroft', 'test.pid')))
 
     @patch('os.kill')
     def test_existing_lock(self, mock_kill):
         """ Test that an existing lock will kill the old pid. """
         l1 = Lock('test')
         self.assertTrue(
-            isfile(create_temp_path('mycroft', 'test.pid')))
+            isfile(get_temp_path('mycroft', 'test.pid')))
         l2 = Lock('test2')
         self.assertFalse(mock_kill.called)
         l2 = Lock('test')
@@ -56,13 +56,13 @@ class TestLock(unittest.TestCase):
     def test_keyboard_interrupt(self):
         l1 = Lock('test')
         self.assertTrue(
-            isfile(create_temp_path('mycroft', 'test.pid')))
+            isfile(get_temp_path('mycroft', 'test.pid')))
         try:
             os.kill(os.getpid(), signal.SIGINT)
         except KeyboardInterrupt:
             pass
         self.assertFalse(
-            isfile(create_temp_path('mycroft', 'test.pid')))
+            isfile(get_temp_path('mycroft', 'test.pid')))
 
 
 if __name__ == '__main__':

--- a/test/unittests/lock/test_lock.py
+++ b/test/unittests/lock/test_lock.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #
 import signal
+import tempfile
 import unittest
 from shutil import rmtree
 

--- a/test/unittests/lock/test_lock.py
+++ b/test/unittests/lock/test_lock.py
@@ -21,7 +21,7 @@ import os
 from os.path import exists, isfile
 
 from mycroft.lock import Lock
-from mycroft.util import create_temp_path
+from mycroft.util.file_utils import create_temp_path
 
 
 class TestLock(unittest.TestCase):

--- a/test/unittests/lock/test_lock.py
+++ b/test/unittests/lock/test_lock.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 import signal
-import tempfile
 import unittest
 from shutil import rmtree
 
@@ -22,32 +21,33 @@ import os
 from os.path import exists, isfile
 
 from mycroft.lock import Lock
+from mycroft.util import create_temp_path
 
 
 class TestLock(unittest.TestCase):
     def setUp(self):
-        if exists(os.path.join(tempfile.gettempdir(), 'mycroft')):
-            rmtree(os.path.join(tempfile.gettempdir(), 'mycroft'))
+        if exists(create_temp_path('mycroft')):
+            rmtree(create_temp_path('mycroft'))
 
     def test_create_lock(self):
         l1 = Lock('test')
         self.assertTrue(
-            isfile(os.path.join(tempfile.gettempdir(), 'mycroft', 'test.pid')))
+            isfile(create_temp_path('mycroft', 'test.pid')))
 
     def test_delete_lock(self):
         l1 = Lock('test')
         self.assertTrue(
-            isfile(os.path.join(tempfile.gettempdir(), 'mycroft', 'test.pid')))
+            isfile(create_temp_path('mycroft', 'test.pid')))
         l1.delete()
         self.assertFalse(
-            isfile(os.path.join(tempfile.gettempdir(), 'mycroft', 'test.pid')))
+            isfile(create_temp_path('mycroft', 'test.pid')))
 
     @patch('os.kill')
     def test_existing_lock(self, mock_kill):
         """ Test that an existing lock will kill the old pid. """
         l1 = Lock('test')
         self.assertTrue(
-            isfile(os.path.join(tempfile.gettempdir(), 'mycroft', 'test.pid')))
+            isfile(create_temp_path('mycroft', 'test.pid')))
         l2 = Lock('test2')
         self.assertFalse(mock_kill.called)
         l2 = Lock('test')
@@ -56,13 +56,13 @@ class TestLock(unittest.TestCase):
     def test_keyboard_interrupt(self):
         l1 = Lock('test')
         self.assertTrue(
-            isfile(os.path.join(tempfile.gettempdir(), 'mycroft', 'test.pid')))
+            isfile(create_temp_path('mycroft', 'test.pid')))
         try:
             os.kill(os.getpid(), signal.SIGINT)
         except KeyboardInterrupt:
             pass
         self.assertFalse(
-            isfile(os.path.join(tempfile.gettempdir(), 'mycroft', 'test.pid')))
+            isfile(create_temp_path('mycroft', 'test.pid')))
 
 
 if __name__ == '__main__':

--- a/test/unittests/lock/test_lock.py
+++ b/test/unittests/lock/test_lock.py
@@ -26,24 +26,28 @@ from mycroft.lock import Lock
 
 class TestLock(unittest.TestCase):
     def setUp(self):
-        if exists(os.path.join(tempfile.gettempdir(), "mycroft")):                  
-            rmtree(os.path.join(tempfile.gettempdir(), "mycroft"))             
+        if exists(os.path.join(tempfile.gettempdir(), "mycroft")):
+            rmtree(os.path.join(tempfile.gettempdir(), "mycroft"))
 
     def test_create_lock(self):
         l1 = Lock('test')
-        self.assertTrue(isfile (os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))              
+        self.assertTrue(
+            isfile(os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))
 
     def test_delete_lock(self):
         l1 = Lock('test')
-        self.assertTrue(isfile (os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))                    
+        self.assertTrue(
+            isfile(os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))
         l1.delete()
-        self.assertFalse(isfile (os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))                    
+        self.assertFalse(
+            isfile(os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))
 
     @patch('os.kill')
     def test_existing_lock(self, mock_kill):
         """ Test that an existing lock will kill the old pid. """
         l1 = Lock('test')
-        self.assertTrue(isfile (os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")) )                 
+        self.assertTrue(
+            isfile(os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))
         l2 = Lock('test2')
         self.assertFalse(mock_kill.called)
         l2 = Lock('test')
@@ -51,12 +55,15 @@ class TestLock(unittest.TestCase):
 
     def test_keyboard_interrupt(self):
         l1 = Lock('test')
-        self.assertTrue(isfile (os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")) )                                
+        self.assertTrue(
+            isfile(os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))
         try:
             os.kill(os.getpid(), signal.SIGINT)
         except KeyboardInterrupt:
             pass
-        self.assertFalse(isfile (os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")) )                       
+        self.assertFalse(
+            isfile(os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unittests/lock/test_lock.py
+++ b/test/unittests/lock/test_lock.py
@@ -25,24 +25,24 @@ from mycroft.lock import Lock
 
 class TestLock(unittest.TestCase):
     def setUp(self):
-        if exists('/tmp/mycroft'):
-            rmtree('/tmp/mycroft')
+        if exists(os.path.join(tempfile.gettempdir(), "mycroft")):                  
+            rmtree(os.path.join(tempfile.gettempdir(), "mycroft"))             
 
     def test_create_lock(self):
         l1 = Lock('test')
-        self.assertTrue(isfile('/tmp/mycroft/test.pid'))
+        self.assertTrue(isfile (os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))              
 
     def test_delete_lock(self):
         l1 = Lock('test')
-        self.assertTrue(isfile('/tmp/mycroft/test.pid'))
+        self.assertTrue(isfile (os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))                    
         l1.delete()
-        self.assertFalse(isfile('/tmp/mycroft/test.pid'))
+        self.assertFalse(isfile (os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")))                    
 
     @patch('os.kill')
     def test_existing_lock(self, mock_kill):
         """ Test that an existing lock will kill the old pid. """
         l1 = Lock('test')
-        self.assertTrue(isfile('/tmp/mycroft/test.pid'))
+        self.assertTrue(isfile (os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")) )                 
         l2 = Lock('test2')
         self.assertFalse(mock_kill.called)
         l2 = Lock('test')
@@ -50,13 +50,12 @@ class TestLock(unittest.TestCase):
 
     def test_keyboard_interrupt(self):
         l1 = Lock('test')
-        self.assertTrue(isfile('/tmp/mycroft/test.pid'))
+        self.assertTrue(isfile (os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")) )                                
         try:
             os.kill(os.getpid(), signal.SIGINT)
         except KeyboardInterrupt:
             pass
-        self.assertFalse(isfile('/tmp/mycroft/test.pid'))
-
+        self.assertFalse(isfile (os.path.join(tempfile.gettempdir(), "mycroft", "test.pid")) )                       
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/unittests/util/test_audio_utils.py
+++ b/test/unittests/util/test_audio_utils.py
@@ -1,6 +1,6 @@
 
-import os 
-import tempfile 
+import os
+import tempfile
 
 from unittest import TestCase, mock
 
@@ -141,7 +141,7 @@ class TestRecordSounds(TestCase):
         mock_subprocess.Popen.return_value = mock_proc
         rate = 16000
         channels = 1
-        filename =   os.path.join(tempfile.gettempdir(), "test.wav")   
+        filename = os.path.join(tempfile.gettempdir(), "test.wav")
         duration = 42
         res = record(filename, duration, rate, channels)
         mock_subprocess.Popen.assert_called_once_with(['arecord',
@@ -156,7 +156,7 @@ class TestRecordSounds(TestCase):
         mock_subprocess.Popen.return_value = mock_proc
         rate = 16000
         channels = 1
-        filename = os.path.join(tempfile.gettempdir(), "test.wav")           
+        filename = os.path.join(tempfile.gettempdir(), "test.wav")
         duration = 0
         res = record(filename, duration, rate, channels)
         mock_subprocess.Popen.assert_called_once_with(['arecord',

--- a/test/unittests/util/test_audio_utils.py
+++ b/test/unittests/util/test_audio_utils.py
@@ -141,7 +141,7 @@ class TestRecordSounds(TestCase):
         mock_subprocess.Popen.return_value = mock_proc
         rate = 16000
         channels = 1
-        filename = os.path.join(tempfile.gettempdir(), "test.wav")
+        filename = os.path.join(tempfile.gettempdir(), 'test.wav')
         duration = 42
         res = record(filename, duration, rate, channels)
         mock_subprocess.Popen.assert_called_once_with(['arecord',
@@ -156,7 +156,7 @@ class TestRecordSounds(TestCase):
         mock_subprocess.Popen.return_value = mock_proc
         rate = 16000
         channels = 1
-        filename = os.path.join(tempfile.gettempdir(), "test.wav")
+        filename = os.path.join(tempfile.gettempdir(), 'test.wav')
         duration = 0
         res = record(filename, duration, rate, channels)
         mock_subprocess.Popen.assert_called_once_with(['arecord',

--- a/test/unittests/util/test_audio_utils.py
+++ b/test/unittests/util/test_audio_utils.py
@@ -1,3 +1,7 @@
+
+import os 
+import tempfile 
+
 from unittest import TestCase, mock
 
 from test.util import Anything

--- a/test/unittests/util/test_audio_utils.py
+++ b/test/unittests/util/test_audio_utils.py
@@ -4,7 +4,7 @@ from unittest import TestCase, mock
 from test.util import Anything
 from mycroft.util import (play_ogg, play_mp3, play_wav, play_audio_file,
                           record)
-from mycroft.util import create_temp_path
+from mycroft.util.file_utils import create_temp_path
 
 test_config = {
     'play_wav_cmdline': 'mock_wav %1',

--- a/test/unittests/util/test_audio_utils.py
+++ b/test/unittests/util/test_audio_utils.py
@@ -137,7 +137,7 @@ class TestRecordSounds(TestCase):
         mock_subprocess.Popen.return_value = mock_proc
         rate = 16000
         channels = 1
-        filename = '/tmp/test.wav'
+        filename =   os.path.join(tempfile.gettempdir(), "test.wav")   
         duration = 42
         res = record(filename, duration, rate, channels)
         mock_subprocess.Popen.assert_called_once_with(['arecord',
@@ -152,7 +152,7 @@ class TestRecordSounds(TestCase):
         mock_subprocess.Popen.return_value = mock_proc
         rate = 16000
         channels = 1
-        filename = '/tmp/test.wav'
+        filename = os.path.join(tempfile.gettempdir(), "test.wav")           
         duration = 0
         res = record(filename, duration, rate, channels)
         mock_subprocess.Popen.assert_called_once_with(['arecord',

--- a/test/unittests/util/test_audio_utils.py
+++ b/test/unittests/util/test_audio_utils.py
@@ -4,7 +4,7 @@ from unittest import TestCase, mock
 from test.util import Anything
 from mycroft.util import (play_ogg, play_mp3, play_wav, play_audio_file,
                           record)
-from mycroft.util.file_utils import create_temp_path
+from mycroft.util.file_utils import get_temp_path
 
 test_config = {
     'play_wav_cmdline': 'mock_wav %1',
@@ -139,7 +139,7 @@ class TestRecordSounds(TestCase):
         mock_subprocess.Popen.return_value = mock_proc
         rate = 16000
         channels = 1
-        filename = create_temp_path('test.wav')
+        filename = get_temp_path('test.wav')
         duration = 42
         res = record(filename, duration, rate, channels)
         mock_subprocess.Popen.assert_called_once_with(['arecord',
@@ -154,7 +154,7 @@ class TestRecordSounds(TestCase):
         mock_subprocess.Popen.return_value = mock_proc
         rate = 16000
         channels = 1
-        filename = create_temp_path('test.wav')
+        filename = get_temp_path('test.wav')
         duration = 0
         res = record(filename, duration, rate, channels)
         mock_subprocess.Popen.assert_called_once_with(['arecord',

--- a/test/unittests/util/test_audio_utils.py
+++ b/test/unittests/util/test_audio_utils.py
@@ -1,12 +1,10 @@
 
-import os
-import tempfile
-
 from unittest import TestCase, mock
 
 from test.util import Anything
 from mycroft.util import (play_ogg, play_mp3, play_wav, play_audio_file,
                           record)
+from mycroft.util import create_temp_path
 
 test_config = {
     'play_wav_cmdline': 'mock_wav %1',
@@ -141,7 +139,7 @@ class TestRecordSounds(TestCase):
         mock_subprocess.Popen.return_value = mock_proc
         rate = 16000
         channels = 1
-        filename = os.path.join(tempfile.gettempdir(), 'test.wav')
+        filename = create_temp_path('test.wav')
         duration = 42
         res = record(filename, duration, rate, channels)
         mock_subprocess.Popen.assert_called_once_with(['arecord',
@@ -156,7 +154,7 @@ class TestRecordSounds(TestCase):
         mock_subprocess.Popen.return_value = mock_proc
         rate = 16000
         channels = 1
-        filename = os.path.join(tempfile.gettempdir(), 'test.wav')
+        filename = create_temp_path('test.wav')
         duration = 0
         res = record(filename, duration, rate, channels)
         mock_subprocess.Popen.assert_called_once_with(['arecord',

--- a/test/unittests/util/test_download.py
+++ b/test/unittests/util/test_download.py
@@ -4,10 +4,10 @@ from unittest import TestCase, mock
 
 from mycroft.util.download import (download, _running_downloads,
                                    _get_download_tmp)
-from mycroft.util.file_utils import create_temp_path
+from mycroft.util.file_utils import get_temp_path
 
 TEST_URL = 'http://example.com/mycroft-test.tar.gz'
-TEST_DEST = create_temp_path('file.tar.gz')
+TEST_DEST = get_temp_path('file.tar.gz')
 
 
 @mock.patch('mycroft.util.download.subprocess')
@@ -92,18 +92,18 @@ class TestDownload(TestCase):
 class TestGetTemp(TestCase):
     def test_no_existing(self, mock_glob):
         mock_glob.return_value = []
-        dest = create_temp_path('test')
+        dest = get_temp_path('test')
         self.assertEqual(_get_download_tmp(dest), dest + '.part')
 
     def test_existing(self, mock_glob):
-        mock_glob.return_value = [create_temp_path('test.part')]
-        dest = create_temp_path('test')
+        mock_glob.return_value = [get_temp_path('test.part')]
+        dest = get_temp_path('test')
         self.assertEqual(_get_download_tmp(dest), dest + '.part.1')
 
     def test_multiple_existing(self, mock_glob):
-        mock_glob.return_value = [create_temp_path('test.part'),
-                                  create_temp_path('test.part.1'),
-                                  create_temp_path('test.part.2')]
+        mock_glob.return_value = [get_temp_path('test.part'),
+                                  get_temp_path('test.part.1'),
+                                  get_temp_path('test.part.2')]
 
-        dest = create_temp_path('test')
+        dest = get_temp_path('test')
         self.assertEqual(_get_download_tmp(dest), dest + '.part.3')

--- a/test/unittests/util/test_download.py
+++ b/test/unittests/util/test_download.py
@@ -4,7 +4,7 @@ from unittest import TestCase, mock
 
 from mycroft.util.download import (download, _running_downloads,
                                    _get_download_tmp)
-from mycroft.util import create_temp_path
+from mycroft.util.file_utils import create_temp_path
 
 TEST_URL = 'http://example.com/mycroft-test.tar.gz'
 TEST_DEST = create_temp_path('file.tar.gz')

--- a/test/unittests/util/test_download.py
+++ b/test/unittests/util/test_download.py
@@ -1,3 +1,6 @@
+
+import os 
+import tempfile 
 from threading import Event
 from unittest import TestCase, mock
 

--- a/test/unittests/util/test_download.py
+++ b/test/unittests/util/test_download.py
@@ -101,7 +101,7 @@ class TestGetTemp(TestCase):
         self.assertEqual(_get_download_tmp(dest), dest + '.part.1')
 
     def test_multiple_existing(self, mock_glob):
-        mock_glob.return_value = [create_temp_path('test.part'), 
+        mock_glob.return_value = [create_temp_path('test.part'),
                                   create_temp_path('test.part.1'),
                                   create_temp_path('test.part.2')]
 

--- a/test/unittests/util/test_download.py
+++ b/test/unittests/util/test_download.py
@@ -101,7 +101,8 @@ class TestGetTemp(TestCase):
         self.assertEqual(_get_download_tmp(dest), dest + '.part.1')
 
     def test_multiple_existing(self, mock_glob):
-        mock_glob.return_value = [create_temp_path('test.part'), create_temp_path('test.part.1'),
+        mock_glob.return_value = [create_temp_path('test.part'), 
+                                  create_temp_path('test.part.1'),
                                   create_temp_path('test.part.2')]
 
         dest = create_temp_path('test')

--- a/test/unittests/util/test_download.py
+++ b/test/unittests/util/test_download.py
@@ -1,6 +1,6 @@
 
-import os 
-import tempfile 
+import os
+import tempfile
 from threading import Event
 from unittest import TestCase, mock
 
@@ -8,7 +8,7 @@ from mycroft.util.download import (download, _running_downloads,
                                    _get_download_tmp)
 
 TEST_URL = 'http://example.com/mycroft-test.tar.gz'
-TEST_DEST = os.path.join(tempfile.gettempdir(), "file.tar.gz")            
+TEST_DEST = os.path.join(tempfile.gettempdir(), "file.tar.gz")
 
 
 @mock.patch('mycroft.util.download.subprocess')
@@ -93,17 +93,18 @@ class TestDownload(TestCase):
 class TestGetTemp(TestCase):
     def test_no_existing(self, mock_glob):
         mock_glob.return_value = []
-        dest = os.path.join(tempfile.gettempdir(), "test")         
+        dest = os.path.join(tempfile.gettempdir(), "test")
         self.assertEqual(_get_download_tmp(dest), dest + '.part')
 
     def test_existing(self, mock_glob):
-        mock_glob.return_value = [os.path.join(tempfile.gettempdir(), "test.part")]               
-        dest = os.path.join(tempfile.gettempdir(), "test")               
+        mock_glob.return_value = [os.path.join(
+            tempfile.gettempdir(), "test.part")]
+        dest = os.path.join(tempfile.gettempdir(), "test")
         self.assertEqual(_get_download_tmp(dest), dest + '.part.1')
 
     def test_multiple_existing(self, mock_glob):
         mock_glob.return_value = [os.path.join(tempfile.gettempdir(), "test.part"), os.path.join(tempfile.gettempdir(), "test.part.1"),
-                                os.path.join(tempfile.gettempdir(), "test.part.2")]
-        
-        dest = os.path.join(tempfile.gettempdir(), "test")             
+                                  os.path.join(tempfile.gettempdir(), "test.part.2")]
+
+        dest = os.path.join(tempfile.gettempdir(), "test")
         self.assertEqual(_get_download_tmp(dest), dest + '.part.3')

--- a/test/unittests/util/test_download.py
+++ b/test/unittests/util/test_download.py
@@ -8,7 +8,7 @@ from mycroft.util.download import (download, _running_downloads,
                                    _get_download_tmp)
 
 TEST_URL = 'http://example.com/mycroft-test.tar.gz'
-TEST_DEST = os.path.join(tempfile.gettempdir(), "file.tar.gz")
+TEST_DEST = os.path.join(tempfile.gettempdir(), 'file.tar.gz')
 
 
 @mock.patch('mycroft.util.download.subprocess')
@@ -93,18 +93,18 @@ class TestDownload(TestCase):
 class TestGetTemp(TestCase):
     def test_no_existing(self, mock_glob):
         mock_glob.return_value = []
-        dest = os.path.join(tempfile.gettempdir(), "test")
+        dest = os.path.join(tempfile.gettempdir(), 'test')
         self.assertEqual(_get_download_tmp(dest), dest + '.part')
 
     def test_existing(self, mock_glob):
         mock_glob.return_value = [os.path.join(
-            tempfile.gettempdir(), "test.part")]
-        dest = os.path.join(tempfile.gettempdir(), "test")
+            tempfile.gettempdir(), 'test.part')]
+        dest = os.path.join(tempfile.gettempdir(), 'test')
         self.assertEqual(_get_download_tmp(dest), dest + '.part.1')
 
     def test_multiple_existing(self, mock_glob):
-        mock_glob.return_value = [os.path.join(tempfile.gettempdir(), "test.part"), os.path.join(tempfile.gettempdir(), "test.part.1"),
-                                  os.path.join(tempfile.gettempdir(), "test.part.2")]
+        mock_glob.return_value = [os.path.join(tempfile.gettempdir(), 'test.part'), os.path.join(tempfile.gettempdir(), 'test.part.1'),
+                                  os.path.join(tempfile.gettempdir(), 'test.part.2')]
 
-        dest = os.path.join(tempfile.gettempdir(), "test")
+        dest = os.path.join(tempfile.gettempdir(), 'test')
         self.assertEqual(_get_download_tmp(dest), dest + '.part.3')

--- a/test/unittests/util/test_download.py
+++ b/test/unittests/util/test_download.py
@@ -5,7 +5,7 @@ from mycroft.util.download import (download, _running_downloads,
                                    _get_download_tmp)
 
 TEST_URL = 'http://example.com/mycroft-test.tar.gz'
-TEST_DEST = '/tmp/file.tar.gz'
+TEST_DEST = os.path.join(tempfile.gettempdir(), "file.tar.gz")            
 
 
 @mock.patch('mycroft.util.download.subprocess')
@@ -90,16 +90,17 @@ class TestDownload(TestCase):
 class TestGetTemp(TestCase):
     def test_no_existing(self, mock_glob):
         mock_glob.return_value = []
-        dest = '/tmp/test'
+        dest = os.path.join(tempfile.gettempdir(), "test")         
         self.assertEqual(_get_download_tmp(dest), dest + '.part')
 
     def test_existing(self, mock_glob):
-        mock_glob.return_value = ['/tmp/test.part']
-        dest = '/tmp/test'
+        mock_glob.return_value = [os.path.join(tempfile.gettempdir(), "test.part")]               
+        dest = os.path.join(tempfile.gettempdir(), "test")               
         self.assertEqual(_get_download_tmp(dest), dest + '.part.1')
 
     def test_multiple_existing(self, mock_glob):
-        mock_glob.return_value = ['/tmp/test.part', '/tmp/test.part.1',
-                                  '/tmp/test.part.2']
-        dest = '/tmp/test'
+        mock_glob.return_value = [os.path.join(tempfile.gettempdir(), "test.part"), os.path.join(tempfile.gettempdir(), "test.part.1"),
+                                os.path.join(tempfile.gettempdir(), "test.part.2")]
+        
+        dest = os.path.join(tempfile.gettempdir(), "test")             
         self.assertEqual(_get_download_tmp(dest), dest + '.part.3')

--- a/test/unittests/util/test_download.py
+++ b/test/unittests/util/test_download.py
@@ -1,14 +1,13 @@
 
-import os
-import tempfile
 from threading import Event
 from unittest import TestCase, mock
 
 from mycroft.util.download import (download, _running_downloads,
                                    _get_download_tmp)
+from mycroft.util import create_temp_path
 
 TEST_URL = 'http://example.com/mycroft-test.tar.gz'
-TEST_DEST = os.path.join(tempfile.gettempdir(), 'file.tar.gz')
+TEST_DEST = create_temp_path('file.tar.gz')
 
 
 @mock.patch('mycroft.util.download.subprocess')
@@ -93,18 +92,17 @@ class TestDownload(TestCase):
 class TestGetTemp(TestCase):
     def test_no_existing(self, mock_glob):
         mock_glob.return_value = []
-        dest = os.path.join(tempfile.gettempdir(), 'test')
+        dest = create_temp_path('test')
         self.assertEqual(_get_download_tmp(dest), dest + '.part')
 
     def test_existing(self, mock_glob):
-        mock_glob.return_value = [os.path.join(
-            tempfile.gettempdir(), 'test.part')]
-        dest = os.path.join(tempfile.gettempdir(), 'test')
+        mock_glob.return_value = [create_temp_path('test.part')]
+        dest = create_temp_path('test')
         self.assertEqual(_get_download_tmp(dest), dest + '.part.1')
 
     def test_multiple_existing(self, mock_glob):
-        mock_glob.return_value = [os.path.join(tempfile.gettempdir(), 'test.part'), os.path.join(tempfile.gettempdir(), 'test.part.1'),
-                                  os.path.join(tempfile.gettempdir(), 'test.part.2')]
+        mock_glob.return_value = [create_temp_path('test.part'), create_temp_path('test.part.1'),
+                                  create_temp_path('test.part.2')]
 
-        dest = os.path.join(tempfile.gettempdir(), 'test')
+        dest = create_temp_path('test')
         self.assertEqual(_get_download_tmp(dest), dest + '.part.3')

--- a/test/unittests/util/test_file_utils.py
+++ b/test/unittests/util/test_file_utils.py
@@ -6,8 +6,14 @@ import tempfile
 from unittest import TestCase, mock
 
 from mycroft import MYCROFT_ROOT_PATH
-from mycroft.util import (resolve_resource_file, curate_cache, create_file,
-                          get_cache_directory, read_stripped_lines, read_dict)
+from mycroft.util import (
+    resolve_resource_file,
+    curate_cache,
+    create_file,
+    create_temp_path,
+    get_cache_directory,
+    read_stripped_lines,
+    read_dict)
 
 
 test_config = {
@@ -194,6 +200,13 @@ class TestCreateFile(TestCase):
         test_path = join(TEST_CREATE_FILE_DIR, 'test_file')
         create_file(test_path)
         self.assertTrue(exists(test_path))
+
+    def test_create_temp_path(self):
+        temp_dir = tempfile.gettempdir()
+        temp_path = create_temp_path('mycroft', 'example.txt')
+        self.assertEqual(temp_path, f'{temp_dir}/mycroft/example.txt')
+        failed_temp_path = create_temp_path(1)
+        self.assertEqual(failed_temp_path, None)
 
     def tearDownClass():
         shutil.rmtree(TEST_CREATE_FILE_DIR, ignore_errors=True)

--- a/test/unittests/util/test_file_utils.py
+++ b/test/unittests/util/test_file_utils.py
@@ -207,8 +207,8 @@ class TestCreateFile(TestCase):
         self.assertEqual(temp_file, temp_dir + '/example.txt')
         temp_path = get_temp_path('mycroft', 'audio', 'example.wav')
         self.assertEqual(temp_path, temp_dir + '/mycroft/audio/example.wav')
-        failed_temp_path = get_temp_path(1)
-        self.assertEqual(failed_temp_path, None)
+        with self.assertRaises(TypeError):
+            failed_temp_path = get_temp_path(1)
 
     def tearDownClass():
         shutil.rmtree(TEST_CREATE_FILE_DIR, ignore_errors=True)

--- a/test/unittests/util/test_file_utils.py
+++ b/test/unittests/util/test_file_utils.py
@@ -10,7 +10,7 @@ from mycroft.util import (
     resolve_resource_file,
     curate_cache,
     create_file,
-    create_temp_path,
+    get_temp_path,
     get_cache_directory,
     read_stripped_lines,
     read_dict)
@@ -201,11 +201,13 @@ class TestCreateFile(TestCase):
         create_file(test_path)
         self.assertTrue(exists(test_path))
 
-    def test_create_temp_path(self):
+    def test_get_temp_path(self):
         temp_dir = tempfile.gettempdir()
-        temp_path = create_temp_path('mycroft', 'example.txt')
-        self.assertEqual(temp_path, f'{temp_dir}/mycroft/example.txt')
-        failed_temp_path = create_temp_path(1)
+        temp_file = get_temp_path('example.txt')
+        self.assertEqual(temp_file, temp_dir + '/example.txt')
+        temp_path = get_temp_path('mycroft', 'audio', 'example.wav')
+        self.assertEqual(temp_path, temp_dir + '/mycroft/audio/example.wav')
+        failed_temp_path = get_temp_path(1)
         self.assertEqual(failed_temp_path, None)
 
     def tearDownClass():


### PR DESCRIPTION
## Description
This adds a new method `get_temp_path()` that should be used anytime a temporary file or directory is needed. This replaces all uses of the hard coded `/tmp` directory, in favor of the cross-system `tempfile.gettempdir()`

The new method does not create any directories or files as it has no concept of whether the requested path contains a file or not.

Fixes #2727
Replaces #2740

All credit to @dzekem who identified the issue and did the bulk of the work on this.

## How to test
Unit tests included. 
This also touches many parts of the code base.

## Contributor license agreement signed?
- [x] CLA - including @dzekem
