### PR TITLE
Fix replacement of existing Skill loader in queue

### DIFF
--- a/mycroft/skills/skill_manager.py
+++ b/mycroft/skills/skill_manager.py
@@ -81,7 +81,7 @@ class UploadQueue:
             LOG.info('Updating settings meta during runtime...')
         with self.lock:
             # Remove existing loader
-            self._queue == [e for e in self._queue if e != loader]
+            self._queue = [e for e in self._queue if e != loader]
             self._queue.append(loader)
 
 

--- a/test/unittests/skills/test_skill_manager.py
+++ b/test/unittests/skills/test_skill_manager.py
@@ -23,6 +23,7 @@ from ..mocks import mock_msm
 
 
 class TestUploadQueue(TestCase):
+
     def test_upload_queue_create(self):
         queue = UploadQueue()
         self.assertFalse(queue.started)
@@ -32,11 +33,15 @@ class TestUploadQueue(TestCase):
     def test_upload_queue_use(self):
         queue = UploadQueue()
         queue.start()
+        specific_loader = Mock(spec=SkillLoader, instance=Mock())
+        loaders = [Mock(), specific_loader, Mock(), Mock()]
         # Check that putting items on the queue makes it longer
-        loaders = [Mock(), Mock(), Mock(), Mock()]
         for i, l in enumerate(loaders):
             queue.put(l)
             self.assertEqual(len(queue), i + 1)
+        # Check that adding an existing item replaces that item
+        queue.put(specific_loader)
+        self.assertEqual(len(queue), len(loaders))
         # Check that sending items empties the queue
         queue.send()
         self.assertEqual(len(queue), 0)


### PR DESCRIPTION
## Description
Fixes a typo in the Skill loader queue methods. It was evaluating rather than assigning the output of a list comprehension.

This would prevent the existing Skill loader from being removed from the queue but still append the new one.

Thanks to @JarbasAI for spotting this!

## How to test
Extended existing unit tests to check for this scenario.

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
