### PR TITLE
Add Common Play to active Skills when invoked

### DIFF
--- a/mycroft/skills/common_play_skill.py
+++ b/mycroft/skills/common_play_skill.py
@@ -55,6 +55,7 @@ class CommonPlaySkill(MycroftSkill, ABC):
     mycroft-playback-control skill and no special vocab for starting playback
     is needed.
     """
+
     def __init__(self, name=None, bus=None):
         super().__init__(name, bus)
         self.audioservice = None
@@ -164,6 +165,8 @@ class CommonPlaySkill(MycroftSkill, ABC):
         # Save for CPS_play() later, e.g. if phrase includes modifiers like
         # "... on the chromecast"
         self.play_service_string = phrase
+
+        self.make_active()
 
         # Invoke derived class to provide playback data
         self.CPS_start(phrase, data)


### PR DESCRIPTION
## Description
Emit message on bus to add Common Play to the active Skills list when it is invoked. 

This prevented `converse()` methods in Skills using the Common Play Framework from being registered as active, hence they would not work as expected.

Note: Companion PR to #2897 for the dev branch of core

## How to test
Use the `fix_no_stop` branch of the News Skill

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
