### PR TITLE
set STT response encoding to utf-8 (deepspeech local)

### DIFF
--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -333,6 +333,7 @@ class DeepSpeechServerSTT(STT):
     def execute(self, audio, language=None):
         language = language or self.lang
         response = post(self.config.get("uri"), data=audio.get_wav_data())
+        response.encoding = 'utf-8'
         return response.text
 
 


### PR DESCRIPTION
## Description
Setting STT response encoding to utf-8 for local deepspeech server, by setting encoding attribute of urllib-response to utf-8 to omit encoding auto-detection, that fails sometimes.

## How to test
Use Mycroft with local deepspeech server with German language model: umlauts aren't encoded correctly and therefore response is not understood.

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
