### PR TITLE
Update Adapt intent parser from v0.3.7 to v0.4.1

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -19,7 +19,7 @@ lingua-franca==0.4.1
 msm==0.8.9
 msk==0.3.16
 mycroft-messagebus-client==0.9.1
-adapt-parser==0.3.7
+adapt-parser==0.4.1
 padatious==0.4.8
 fann2==1.0.7
 padaos==0.1.9


### PR DESCRIPTION
## Description
Upgrades the Adapt parser from v0.3.7 to v0.4.1

See release notes:
https://github.com/MycroftAI/adapt/releases

## How to test
VK Tests
