### PR TITLE
Check for the AVX instruction set during install

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -184,7 +184,13 @@ in mycroft.conf.
   Y)es, I want to use the PocketSphinx engine or my own.
   N)o, stop the installation."
       if get_YN ; then
-        sed -i "s/\"use_precise\": true/\"use_precise\": false/" config/
+        if [[ ! -f /etc/mycroft/mycroft.conf ]]; then
+          if [[ ! -e /etc/mycroft/ ]]; then
+            $SUDO mkdir /etc/mycroft
+          fi
+          $SUDO cp $TOP/mycroft/configuration/mycroft.conf /etc/mycroft/
+        fi
+        sed -i "s/\"use_precise\": true/\"use_precise\": false/" /etc/mycroft/mycroft.conf
       else
         echo -e "$HIGHLIGHT N - quit the installation $RESET"
         exit 1

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -174,6 +174,22 @@ This script is designed to make working with Mycroft easy.  During this
 first run of dev_setup we will ask you a few questions to help setup
 your environment.'
     sleep 0.5
+    if ! grep -q avx /proc/cpuinfo; then
+      echo "
+The Precise Wake Word Engine requires the AVX instruction set, which is
+not supported on your CPU. Do you want to fall back to the PocketSphinx
+engine? Advanced users can build the precise engine with an older
+version of TensorFlow (v1.13) if desired and change use_precise to true
+in mycroft.conf.
+  Y)es, I want to use the PocketSphinx engine or my own.
+  N)o, stop the installation."
+      if get_YN ; then
+        sed -i "s/\"use_precise\": true/\"use_precise\": false/" config/
+      else
+        echo -e "$HIGHLIGHT N - quit the installation $RESET"
+        exit 1
+      fi
+    fi
     echo "
 Do you want to run on 'master' or against a dev branch?  Unless you are
 a developer modifying mycroft-core itself, you should run on the

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -185,16 +185,18 @@ in mycroft.conf.
   N)o, stop the installation."
       if get_YN ; then
         if [[ ! -f /etc/mycroft/mycroft.conf ]]; then
-          if [[ ! -e /etc/mycroft/ ]]; then
-            $SUDO mkdir /etc/mycroft
-          fi
-          $SUDO cp $TOP/mycroft/configuration/mycroft.conf /etc/mycroft/
+          $SUDO mkdir -p /etc/mycroft
+          $SUDO touch /etc/mycroft/mycroft.conf
+          $SUDO bash -c 'echo "{ \"use_precise\": true }" > /etc/mycroft/mycroft.conf'
+        else
+          $SUDO bash -c 'jq ". + { \"use_precise\": true }" /etc/mycroft/mycroft.conf > tmp.mycroft.conf' 
+          $SUDO mv -f tmp.mycroft.conf /etc/mycroft/mycroft.conf
         fi
-        $SUDO sed -i "s/\"use_precise\": true/\"use_precise\": false/" /etc/mycroft/mycroft.conf
       else
         echo -e "$HIGHLIGHT N - quit the installation $RESET"
         exit 1
       fi
+      echo
     fi
     echo "
 Do you want to run on 'master' or against a dev branch?  Unless you are

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -190,7 +190,7 @@ in mycroft.conf.
           fi
           $SUDO cp $TOP/mycroft/configuration/mycroft.conf /etc/mycroft/
         fi
-        sed -i "s/\"use_precise\": true/\"use_precise\": false/" /etc/mycroft/mycroft.conf
+        $SUDO sed -i "s/\"use_precise\": true/\"use_precise\": false/" /etc/mycroft/mycroft.conf
       else
         echo -e "$HIGHLIGHT N - quit the installation $RESET"
         exit 1

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -174,7 +174,7 @@ This script is designed to make working with Mycroft easy.  During this
 first run of dev_setup we will ask you a few questions to help setup
 your environment.'
     sleep 0.5
-    if ! grep -q avx /proc/cpuinfo; then
+    if ! grep -q avx /proc/cpuinfo && [[ ! $(uname -m) == 'arm'* ]]; then
       echo "
 The Precise Wake Word Engine requires the AVX instruction set, which is
 not supported on your CPU. Do you want to fall back to the PocketSphinx

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -174,6 +174,8 @@ This script is designed to make working with Mycroft easy.  During this
 first run of dev_setup we will ask you a few questions to help setup
 your environment.'
     sleep 0.5
+    # The AVX instruction set is an x86 construct
+    # ARM has a range of equivalents, unsure which are (un)supported by TF.
     if ! grep -q avx /proc/cpuinfo && [[ ! $(uname -m) == 'arm'* ]]; then
       echo "
 The Precise Wake Word Engine requires the AVX instruction set, which is

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -47,6 +47,10 @@ class NoModelAvailable(Exception):
     pass
 
 
+class PreciseUnavailable(Exception):
+    pass
+
+
 def msec_to_sec(msecs):
     """Convert milliseconds to seconds.
 
@@ -190,6 +194,8 @@ class PreciseHotword(HotWordEngine):
             PreciseRunner, PreciseEngine, ReadWriteStream
         )
         local_conf = LocalConf(USER_CONFIG)
+        if not local_conf.get('precise', {}).get('use_precise', True):
+            raise PreciseUnavailable
         if (local_conf.get('precise', {}).get('dist_url') ==
                 'http://bootstrap.mycroft.ai/artifacts/static/daily/'):
             del local_conf['precise']['dist_url']
@@ -486,6 +492,9 @@ class HotWordFactory:
                 LOG.warning('Could not found find model for {} on {}.'.format(
                     hotword, module
                 ))
+                instance = None
+            except PreciseUnavailable:
+                LOG.warning('Settings prevent Precise Engine use, falling back to default.')
                 instance = None
             except Exception:
                 LOG.exception(

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -494,8 +494,8 @@ class HotWordFactory:
                 ))
                 instance = None
             except PreciseUnavailable:
-                LOG.warning('Settings prevent Precise Engine use,
-                            falling back to default.')
+                LOG.warning('Settings prevent Precise Engine use, '
+                            'falling back to default.')
                 instance = None
             except Exception:
                 LOG.exception(

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -494,7 +494,8 @@ class HotWordFactory:
                 ))
                 instance = None
             except PreciseUnavailable:
-                LOG.warning('Settings prevent Precise Engine use, falling back to default.')
+                LOG.warning('Settings prevent Precise Engine use,
+                            falling back to default.')
                 instance = None
             except Exception:
                 LOG.exception(

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -199,6 +199,7 @@
 
   // Settings used for any precise wake words
   "precise": {
+    "use_precise": true,
     "dist_url": "https://github.com/MycroftAI/precise-data/raw/dist/{arch}/latest",
     "model_url": "https://raw.githubusercontent.com/MycroftAI/precise-data/models/{wake_word}.tar.gz"
   },


### PR DESCRIPTION
## Description
Add a check for the AVX instruction set on non-ARM processors during install. If this required instruction set is not found it will warn the user that the Precise Engine will not be supported.

Replaces #2269
Thanks to @mathmauney for the original work on this.

## How to test
Run installer on a machine that does not support AVX
or change line 140 so it is searching for something that definitely doesn't exist in the cpuinfo eg change "avx" to "avxzzz"

## Contributor license agreement signed?
Yes - both original author and myself.
