### PR TITLE
Simple Play Video Implementation for Mycroft GUI

### DIFF
--- a/mycroft/enclosure/gui.py
+++ b/mycroft/enclosure/gui.py
@@ -62,6 +62,8 @@ class SkillGUI:
         """Sets the handlers for the default messages."""
         msg_type = self.build_message_type('set')
         self.skill.add_event(msg_type, self.gui_set)
+        self.skill.gui.register_handler('video.media.playback.ended',
+                                        self.stop_video)
 
     def register_handler(self, event, handler):
         """Register a handler for GUI events.
@@ -357,6 +359,40 @@ class SkillGUI:
         self["url"] = url
         self.show_page("SYSTEM_UrlFrame.qml", override_idle,
                        override_animations)
+
+    def play_video(self, url, title="", repeat=None, override_idle=True,
+                   override_animations=None):
+        """ Play video stream
+
+        Arguments:
+            url (str): URL of video source
+            title (str): Title of media to be displayed
+            repeat (boolean, int):
+                True: Infinitly loops the current video track
+                (int): Loops the video track for specified number of
+                times.
+            override_idle (boolean, int):
+                True: Takes over the resting page indefinitely
+                (int): Delays resting page for the specified number of
+                       seconds.
+            override_animations (boolean):
+                True: Disables showing all platform skill animations.
+                False: 'Default' always show animations.
+        """
+        self["playStatus"] = "play"
+        self["video"] = url
+        self["title"] = title
+        self["playerRepeat"] = repeat
+        self.video_info = {"title": title, "url": url}
+        self.show_page("SYSTEM_VideoPlayer.qml",
+                       override_idle=override_idle,
+                       override_animations=override_animations)
+
+    def stop_video(self):
+        """Stop video playback."""
+        self["playStatus"] = "stop"
+        self.skill.bus.emit(Message("mycroft.gui.screen.close",
+                                    {"skill_id": self.skill.skill_id}))
 
     def release(self):
         """Signal that this skill is no longer using the GUI,

--- a/mycroft/res/ui/SYSTEM_VideoPlayer.qml
+++ b/mycroft/res/ui/SYSTEM_VideoPlayer.qml
@@ -1,0 +1,225 @@
+import QtMultimedia 5.12
+import QtQuick.Layouts 1.4
+import QtQuick 2.9
+import QtQuick.Controls 2.12 as Controls
+import org.kde.kirigami 2.10 as Kirigami
+import QtQuick.Window 2.3
+import QtGraphicalEffects 1.0
+import Mycroft 1.0 as Mycroft
+import "." as Local
+
+Mycroft.Delegate {
+    id: root
+
+    property var videoSource: sessionData.video
+    property var videoStatus: sessionData.playStatus
+    property var videoRepeat: sessionData.playerRepeat
+    property var videoThumb: sessionData.videoThumb
+    property var videoTitle: sessionData.title
+    property bool busyIndicate: false
+
+    fillWidth: true
+    background: Rectangle {
+        color: "black"
+    }
+    leftPadding: 0
+    topPadding: 0
+    rightPadding: 0
+    bottomPadding: 0
+
+    onEnabledChanged: syncStatusTimer.restart()
+    onVideoSourceChanged: syncStatusTimer.restart()
+    
+    Component.onCompleted: {
+        syncStatusTimer.restart()
+    }
+    
+    Keys.onDownPressed: {
+        controlBarItem.opened = true
+        controlBarItem.forceActiveFocus()
+    }
+
+    onFocusChanged: {
+        video.forceActiveFocus();
+    }
+    
+    onVideoRepeatChanged: {
+        if(typeof videoRepeat !== "undefined" && typeof videoRepeat == "boolean"){
+            if(videoRepeat){
+                video.loops = MediaPlayer.Infinite
+                video.flushMode = VideoOutput.LastFrame
+            }
+        } else if(typeof videoRepeat !== "undefined" && typeof videoRepeat == "number"){
+            if(videoRepeat > 1){
+                video.loops = videoRepeat
+                video.flushMode = VideoOutput.LastFrame
+            }
+        } else {
+            video.loops = 1
+            video.flushMode = VideoOutput.EmptyFrame
+        }
+    }
+    
+    onVideoStatusChanged: {
+        switch(videoStatus){
+        case "stop":
+            video.stop();
+            break;
+        case "pause":
+            video.pause()
+            break;
+        case "play":
+            video.play()
+            delay(6000, function() {
+                infomationBar.visible = false;
+            })
+            break;
+        }
+    }
+    
+    Connections {
+        target: Window.window
+        onVisibleChanged: {
+            if(video.playbackState == MediaPlayer.PlayingState) {
+                video.stop()
+            }
+        }
+    }
+    
+    Timer {
+        id: syncStatusTimer
+        interval: 0
+        onTriggered: {
+            if (enabled && videoStatus == "play") {
+                video.play();
+            } else if (videoStatus == "stop") {
+                video.stop();
+            } else {
+                video.pause();
+            }
+        }
+    }
+    
+    Timer {
+        id: delaytimer
+    }
+
+    function delay(delayTime, cb) {
+        delaytimer.interval = delayTime;
+        delaytimer.repeat = false;
+        delaytimer.triggered.connect(cb);
+        delaytimer.start();
+    }
+    
+    controlBar: Local.SeekControl {
+        id: seekControl
+        anchors {
+            bottom: parent.bottom
+        }
+        title: videoTitle
+        videoControl: video
+        duration: video.duration
+        playPosition: video.position
+        onSeekPositionChanged: video.seek(seekPosition);
+        z: 1000
+    }
+    
+    Item {
+        id: videoRoot
+        anchors.fill: parent
+
+        Rectangle {
+            id: infomationBar
+            anchors.left: parent.left
+            anchors.right: parent.right
+            anchors.top: parent.top
+            visible: false
+            color: Qt.rgba(Kirigami.Theme.backgroundColor.r, Kirigami.Theme.backgroundColor.g, Kirigami.Theme.backgroundColor.b, 0.6)
+            implicitHeight: vidTitle.implicitHeight + Kirigami.Units.largeSpacing * 2
+            z: 1001
+            
+            onVisibleChanged: {
+                delay(15000, function() {
+                    infomationBar.visible = false;
+                })
+            }
+            
+            Controls.Label {
+                id: vidTitle
+                visible: true
+                maximumLineCount: 2
+                wrapMode: Text.Wrap
+                anchors.left: parent.left
+                anchors.leftMargin: Kirigami.Units.largeSpacing
+                anchors.verticalCenter: parent.verticalCenter
+                text: videoTitle
+                z: 100
+            }
+        }
+
+        Video {
+            id: video
+            anchors.fill: parent
+            focus: true
+            autoLoad: true
+            autoPlay: false
+            loops: 1
+            source: videoSource
+            
+            Keys.onReturnPressed: {
+                video.playbackState == MediaPlayer.PlayingState ? video.pause() : video.play()
+            }
+
+            Keys.onDownPressed: {
+                controlBarItem.opened = true
+                controlBarItem.forceActiveFocus()
+            }
+            
+            MouseArea {
+                anchors.fill: parent
+                onClicked: {
+                    controlBarItem.opened = !controlBarItem.opened
+                }
+            }
+            
+            onStatusChanged: {
+                console.log(status)
+                if(status == MediaPlayer.EndOfMedia) {
+                    triggerGuiEvent("video.media.playback.ended", {})
+                    busyIndicatorPop.enabled = false
+                }
+                if(status == MediaPlayer.Loading) {
+                    busyIndicatorPop.visible = true
+                    busyIndicatorPop.enabled = true
+                }
+                if(status == MediaPlayer.Loaded || status == MediaPlayer.Buffered){
+                    busyIndicatorPop.visible = false
+                    busyIndicatorPop.enabled = false
+                }
+            }
+            
+            Rectangle {
+                id: busyIndicatorPop
+                width: parent.width
+                height: parent.height
+                color: Qt.rgba(0, 0, 0, 0.2)
+                visible: false
+                enabled: false
+                
+                Controls.BusyIndicator {
+                    id: busyIndicate
+                    running: busyIndicate
+                    anchors.centerIn: parent
+                }
+                
+                onEnabledChanged: {
+                    if(busyIndicatorPop.enabled){
+                        busyIndicate.running = true
+                    } else {
+                        busyIndicate.running = false
+                    }
+                }
+            }
+        }
+    }
+}

--- a/mycroft/res/ui/SeekControl.qml
+++ b/mycroft/res/ui/SeekControl.qml
@@ -1,0 +1,271 @@
+import QtMultimedia 5.12
+import QtQuick.Layouts 1.4
+import QtQuick 2.9
+import QtQuick.Controls 2.12 as Controls
+import org.kde.kirigami 2.10 as Kirigami
+import QtQuick.Templates 2.2 as Templates
+import QtGraphicalEffects 1.0
+
+import Mycroft 1.0 as Mycroft
+
+Item {
+    id: seekControl
+    property bool opened: false
+    property int duration: 0
+    property int playPosition: 0
+    property int seekPosition: 0
+    property bool enabled: true
+    property bool seeking: false
+    property var videoControl
+    property string title
+
+    clip: true
+    implicitWidth: parent.width
+    implicitHeight: mainLayout.implicitHeight + Kirigami.Units.largeSpacing * 2
+    opacity: opened
+
+    onOpenedChanged: {
+        if (opened) {
+            hideTimer.restart();
+        }
+    }
+    
+    onFocusChanged: {
+        if(focus) {
+            backButton.forceActiveFocus()
+        }
+    }
+
+    Timer {
+        id: hideTimer
+        interval: 5000
+        onTriggered: {
+            seekControl.opened = false;
+            videoRoot.forceActiveFocus();
+        }
+    }
+    
+    Rectangle {
+        width: parent.width
+        height: parent.height
+        color: Qt.rgba(0, 0, 0, 0.8)
+        y: opened ? 0 : parent.height
+
+        ColumnLayout {
+            id: mainLayout
+            
+            anchors {
+                fill: parent
+                margins: Kirigami.Units.largeSpacing
+            }
+            
+            RowLayout {
+                id: mainLayout2
+                Layout.fillHeight: true
+                Controls.RoundButton {
+                    id: backButton
+                    Layout.preferredWidth: parent.width > 600 ? Kirigami.Units.iconSizes.large : Kirigami.Units.iconSizes.medium
+                    Layout.preferredHeight: Layout.preferredWidth
+                    highlighted: focus ? 1 : 0
+                    z: 1000
+                    
+                    background: Rectangle {
+                        radius: 200
+                        color: "#1a1a1a"
+                        border.width: 1.25
+                        border.color: "white"
+                    }
+                    
+                    contentItem: Item {
+                        Image {
+                            width: parent.width - Kirigami.Units.largeSpacing
+                            height: width
+                            anchors.centerIn: parent
+                            source: "images/back.svg"
+                        }
+                    }
+                    
+                    onClicked: {
+                        triggerGuiEvent("video.media.playback.ended", {})
+                        video.stop();
+                    }
+                    KeyNavigation.up: video
+                    KeyNavigation.right: button
+                    Keys.onReturnPressed: {
+                        hideTimer.restart();
+                        triggerGuiEvent("video.media.playback.ended", {})
+                        video.stop();
+                    }
+                    onFocusChanged: {
+                        hideTimer.restart();
+                    }
+                }
+                Controls.RoundButton {
+                    id: button
+                    Layout.preferredWidth: parent.width > 600 ? Kirigami.Units.iconSizes.large : Kirigami.Units.iconSizes.medium
+                    Layout.preferredHeight: Layout.preferredWidth
+                    highlighted: focus ? 1 : 0
+                    z: 1000
+                    
+                    background: Rectangle {
+                        radius: 200
+                        color: "#1a1a1a"
+                        border.width: 1.25
+                        border.color: "white"
+                    }
+                    
+                    contentItem: Item {
+                        Image {
+                            width: parent.width - Kirigami.Units.largeSpacing
+                            height: width
+                            anchors.centerIn: parent
+                            source: videoControl.playbackState === MediaPlayer.PlayingState ? "images/media-pause.svg" : "images/media-play.svg"
+                        }
+                    }
+                    
+                    onClicked: {
+                        video.playbackState === MediaPlayer.PlayingState ? video.pause() : video.play();
+                        hideTimer.restart();
+                    }
+                    KeyNavigation.up: video
+                    KeyNavigation.left: backButton
+                    KeyNavigation.right: slider
+                    Keys.onReturnPressed: {
+                        video.playbackState === MediaPlayer.PlayingState ? video.pause() : video.play();
+                        hideTimer.restart();
+                    }
+                    onFocusChanged: {
+                        hideTimer.restart();
+                    }
+                }
+
+                Templates.Slider {
+                    id: slider
+                    Layout.fillWidth: true
+                    Layout.alignment: Qt.AlignVCenter
+                    implicitHeight: Kirigami.Units.gridUnit
+                    value: seekControl.playPosition
+                    from: 0
+                    to: seekControl.duration
+                    z: 1000
+                    property bool navSliderItem
+                    property int minimumValue: 0
+                    property int maximumValue: 20
+                    onMoved: {
+                        seekControl.seekPosition = value;
+                        hideTimer.restart();
+                    }
+                    
+                    onNavSliderItemChanged: {
+                        if(slider.navSliderItem){
+                            recthandler.color = "red"
+                        } else if (slider.focus) {
+                            recthandler.color = Kirigami.Theme.linkColor
+                        }
+                    }
+                    
+                    onFocusChanged: {
+                        if(!slider.focus){
+                            recthandler.color = Kirigami.Theme.textColor
+                        } else {
+                            recthandler.color = Kirigami.Theme.linkColor
+                        }
+                    }
+                    
+                    handle: Rectangle {
+                        id: recthandler
+                        x: slider.position * (parent.width - width)
+                        implicitWidth: Kirigami.Units.gridUnit
+                        implicitHeight: implicitWidth
+                        radius: width
+                        color: Kirigami.Theme.textColor
+                    }
+                    background: Item {
+                        Rectangle {
+                            id: groove
+                            anchors {
+                                verticalCenter: parent.verticalCenter
+                                left: parent.left
+                                right: parent.right
+                            }
+                            radius: height
+                            height: Math.round(Kirigami.Units.gridUnit/3)
+                            color: Qt.rgba(Kirigami.Theme.textColor.r, Kirigami.Theme.textColor.g, Kirigami.Theme.textColor.b, 0.3)
+                            Rectangle {
+                                anchors {
+                                    left: parent.left
+                                    top: parent.top
+                                    bottom: parent.bottom
+                                }
+                                radius: height
+                                color: Kirigami.Theme.highlightColor
+                                width: slider.position * (parent.width - slider.handle.width/2) + slider.handle.width/2
+                            }
+                        }
+
+                        Controls.Label {
+                            anchors {
+                                left: parent.left
+                                top: groove.bottom
+                                topMargin: Kirigami.Units.smallSpacing
+                            }
+                            horizontalAlignment: Text.AlignLeft
+                            verticalAlignment: Text.AlignVCenter
+                            text: formatTime(playPosition)
+                            color: "white"
+                        }
+
+                        Controls.Label {
+                            anchors {
+                                right: parent.right
+                                top: groove.bottom
+                                topMargin: Kirigami.Units.smallSpacing
+                            }
+                            horizontalAlignment: Text.AlignRight
+                            verticalAlignment: Text.AlignVCenter
+                            text: formatTime(duration)
+                        }
+                    }
+                    KeyNavigation.up: video
+                    KeyNavigation.left: button
+                    Keys.onReturnPressed: {
+                        hideTimer.restart();
+                        if(!navSliderItem){
+                            navSliderItem = true
+                        } else {
+                            navSliderItem = false
+                        }
+                    }
+
+                    Keys.onLeftPressed: {
+                        console.log("leftPressedonSlider")
+                        hideTimer.restart();
+                        if(navSliderItem) {
+                            video.seek(video.position - 5000)
+                        } else {
+                            button.forceActiveFocus()
+                        }
+                    }
+
+                    Keys.onRightPressed: {
+                        hideTimer.restart();
+                        if(navSliderItem) {
+                            video.seek(video.position + 5000)
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+    
+
+    function formatTime(timeInMs) {
+        if (!timeInMs || timeInMs <= 0) return "0:00"
+        var seconds = timeInMs / 1000;
+        var minutes = Math.floor(seconds / 60)
+        seconds = Math.floor(seconds % 60)
+        if (seconds < 10) seconds = "0" + seconds;
+        return minutes + ":" + seconds
+    }
+}

--- a/mycroft/res/ui/images/back.svg
+++ b/mycroft/res/ui/images/back.svg
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="256px"
+   height="256px"
+   viewBox="0 0 256 256"
+   version="1.1"
+   id="SVGRoot"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="back.svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="-398"
+     inkscape:cy="128"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="985"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:grid-bbox="true"
+     showborder="true"
+     inkscape:showpageshadow="false"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid856" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata13">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#1a1a1a;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 172,4 48,128 172,252 184,240 72,128 184,16 Z"
+       id="path945" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path947"
+       d="M 172,4 48,128 172,252 184,240 72,128 184,16 Z"
+       style="fill:#b3b3b3;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#ffffff;stroke:#000000;stroke-width:0;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 196,4 72,128 196,252 208,240 96,128 208,16 Z"
+       id="path961"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/mycroft/res/ui/images/media-fullscreen.svg
+++ b/mycroft/res/ui/images/media-fullscreen.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="123.409"
+   height="123.409"
+   viewBox="0 0 32.651966 32.651966"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="simple-fullscreen.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.32"
+     inkscape:cx="0.11440656"
+     inkscape:cy="118.5751"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     width="256px"
+     inkscape:window-width="1920"
+     inkscape:window-height="985"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-1.2159538,-263.13209)">
+    <circle
+       style="fill:#1a1a1a;stroke-width:0.13229674"
+       id="path12"
+       cx="17.541937"
+       cy="279.45807"
+       r="16.325983" />
+    <path
+       sodipodi:type="star"
+       style="fill:#ffffff;stroke-width:0.26458332"
+       id="path30"
+       sodipodi:sides="4"
+       sodipodi:cx="32.676765"
+       sodipodi:cy="262.69937"
+       sodipodi:r1="19.787439"
+       sodipodi:r2="9.8937197"
+       sodipodi:arg1="2.0943951"
+       sodipodi:arg2="2.8797933"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.04"
+       inkscape:randomized="0"
+       d="m 22.783046,279.8358 c -0.969383,-0.55968 -7.802379,-26.06077 -7.242706,-27.03015 0.559674,-0.96938 26.060762,-7.80238 27.030145,-7.2427 0.969383,0.55967 7.802379,26.06076 7.242706,27.03014 -0.559674,0.96938 -26.060763,7.80238 -27.030145,7.24271 z"
+       inkscape:transform-center-x="0.58258212"
+       transform="matrix(-0.12941449,0.48298145,-0.48298146,-0.12941449,148.64971,297.67289)"
+       inkscape:transform-center-y="2.1742078" />
+    <path
+       sodipodi:type="star"
+       style="fill:#1a1a1a;stroke-width:0.26458332"
+       id="path30-3"
+       sodipodi:sides="4"
+       sodipodi:cx="32.676765"
+       sodipodi:cy="262.69937"
+       sodipodi:r1="19.787439"
+       sodipodi:r2="9.8937197"
+       sodipodi:arg1="2.0943951"
+       sodipodi:arg2="2.8797933"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.04"
+       inkscape:randomized="0"
+       d="m 22.783046,279.8358 c -0.969383,-0.55968 -7.802379,-26.06077 -7.242706,-27.03015 0.559674,-0.96938 26.060762,-7.80238 27.030145,-7.2427 0.969383,0.55967 7.802379,26.06076 7.242706,27.03014 -0.559674,0.96938 -26.060763,7.80238 -27.030145,7.24271 z"
+       inkscape:transform-center-x="0.53926856"
+       transform="matrix(-0.11978344,0.44703777,-0.44703777,-0.11978341,138.89261,296.31734)"
+       inkscape:transform-center-y="2.0124097" />
+    <rect
+       style="fill:#1a1a1a;stroke-width:0.13229674"
+       id="rect146"
+       width="3.7065897"
+       height="7.1280575"
+       x="15.688642"
+       y="268.42383" />
+    <rect
+       y="283.36426"
+       x="15.688642"
+       height="7.1280575"
+       width="3.7065897"
+       id="rect161"
+       style="fill:#1a1a1a;stroke-width:0.13229674" />
+    <rect
+       style="fill:#1a1a1a;stroke-width:0.13229674"
+       id="rect146-6"
+       width="3.7065897"
+       height="7.1280575"
+       x="-281.57596"
+       y="7.0254865"
+       transform="rotate(-90)" />
+    <rect
+       transform="rotate(-90)"
+       y="20.784359"
+       x="-281.57596"
+       height="7.1280575"
+       width="3.7065897"
+       id="rect199"
+       style="fill:#1a1a1a;stroke-width:0.13229674" />
+  </g>
+</svg>

--- a/mycroft/res/ui/images/media-mute.svg
+++ b/mycroft/res/ui/images/media-mute.svg
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="123.409"
+   height="123.409"
+   viewBox="0 0 32.651966 32.651966"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="simple-audio-off.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.2809755"
+     inkscape:cx="102.89363"
+     inkscape:cy="109.06554"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     width="256px"
+     inkscape:window-width="1920"
+     inkscape:window-height="985"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-1.2159538,-263.13209)">
+    <circle
+       style="fill:#1a1a1a;stroke-width:0.13229674"
+       id="path12"
+       cx="17.541937"
+       cy="279.45807"
+       r="16.325983" />
+    <path
+       sodipodi:type="star"
+       style="fill:#ffffff;stroke-width:0.26458332"
+       id="path30"
+       sodipodi:sides="3"
+       sodipodi:cx="32.676765"
+       sodipodi:cy="262.69937"
+       sodipodi:r1="19.787439"
+       sodipodi:r2="9.8937197"
+       sodipodi:arg1="2.0943951"
+       sodipodi:arg2="3.1415927"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.04"
+       inkscape:randomized="0"
+       d="m 22.783046,279.8358 c -1.187247,-0.68546 -1.187247,-33.5874 0,-34.27285 1.187246,-0.68546 29.681159,15.76551 29.681159,17.13642 0,1.37092 -28.493913,17.82188 -29.681159,17.13643 z"
+       inkscape:transform-center-x="0.23292106"
+       transform="matrix(0.2500096,-0.43302933,0.43302933,0.2500096,-107.64087,227.9307)"
+       inkscape:transform-center-y="-0.40343855" />
+    <rect
+       style="fill:#1a1a1a;stroke-width:0.19363759"
+       id="rect226"
+       width="3.9917119"
+       height="13.514797"
+       x="6.9604759"
+       y="272.44635" />
+    <rect
+       y="275.1265"
+       x="3.7078028"
+       height="7.9263997"
+       width="4.3338585"
+       id="rect228"
+       style="fill:#1a1a1a;stroke-width:0.15451857" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.13229674"
+       id="rect232"
+       width="2.8877196"
+       height="8.6631584"
+       x="7.7770677"
+       y="275.1265"
+       rx="0.5"
+       ry="0.5" />
+    <rect
+       style="fill:#ff0000;stroke-width:0.10191034"
+       id="rect236"
+       width="0.2174269"
+       height="11.803174"
+       x="215.30339"
+       y="173.89969"
+       rx="0.49999902"
+       ry="0.49999902"
+       transform="rotate(45)" />
+    <rect
+       transform="matrix(-0.70710678,0.70710678,0.70710678,0.70710678,0,0)"
+       ry="0.49999902"
+       rx="0.49999902"
+       y="209.51051"
+       x="179.69257"
+       height="11.803174"
+       width="0.2174269"
+       id="rect278"
+       style="fill:#ff0000;stroke-width:0.10191034" />
+  </g>
+</svg>

--- a/mycroft/res/ui/images/media-next.svg
+++ b/mycroft/res/ui/images/media-next.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="123.409"
+   height="123.409"
+   viewBox="0 0 32.651966 32.651966"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="simple-previous.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.32"
+     inkscape:cx="-34.368354"
+     inkscape:cy="118.5751"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     width="256px"
+     inkscape:window-width="1920"
+     inkscape:window-height="985"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-1.2159538,-263.13209)">
+    <circle
+       style="fill:#1a1a1a;stroke-width:0.13229674"
+       id="path12"
+       cx="17.541937"
+       cy="279.45807"
+       r="16.325983" />
+    <path
+       sodipodi:type="star"
+       style="fill:#ffffff;stroke-width:0.26458332"
+       id="path30"
+       sodipodi:sides="4"
+       sodipodi:cx="32.676765"
+       sodipodi:cy="262.69937"
+       sodipodi:r1="19.787439"
+       sodipodi:r2="9.8937197"
+       sodipodi:arg1="2.0943951"
+       sodipodi:arg2="2.8797933"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.04"
+       inkscape:randomized="0"
+       d="m 22.783046,279.8358 c -0.969383,-0.55968 -7.802379,-26.06077 -7.242706,-27.03015 0.559674,-0.96938 26.060762,-7.80238 27.030145,-7.2427 0.969383,0.55967 7.802379,26.06076 7.242706,27.03014 -0.559674,0.96938 -26.060763,7.80238 -27.030145,7.24271 z"
+       inkscape:transform-center-x="1.9493474"
+       transform="matrix(-0.43302933,0.2500096,-0.2500096,-0.43302933,93.481173,385.73229)"
+       inkscape:transform-center-y="1.1254515" />
+    <rect
+       style="fill:#1a1a1a;stroke-width:0.23068132"
+       id="rect70"
+       width="13.343724"
+       height="15.966846"
+       x="182.59291"
+       y="-213.62311"
+       ry="0"
+       transform="rotate(135)" />
+  </g>
+</svg>

--- a/mycroft/res/ui/images/media-pause.svg
+++ b/mycroft/res/ui/images/media-pause.svg
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="123.409"
+   height="123.409"
+   viewBox="0 0 32.651966 32.651966"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="simple-pause.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.32"
+     inkscape:cx="0.63476656"
+     inkscape:cy="113.17576"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     width="256px"
+     inkscape:window-width="1920"
+     inkscape:window-height="985"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-1.2159538,-263.13209)">
+    <circle
+       style="fill:#1a1a1a;stroke-width:0.13229674"
+       id="path12"
+       cx="17.541937"
+       cy="279.45807"
+       r="16.325983" />
+    <path
+       sodipodi:type="star"
+       style="fill:#ffffff;stroke-width:0.26458332"
+       id="path30"
+       sodipodi:sides="4"
+       sodipodi:cx="32.676765"
+       sodipodi:cy="262.69937"
+       sodipodi:r1="19.787439"
+       sodipodi:r2="9.8937197"
+       sodipodi:arg1="2.0943951"
+       sodipodi:arg2="2.8797933"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.04"
+       inkscape:randomized="0"
+       d="m 22.783046,279.8358 c -0.969383,-0.55968 -7.802379,-26.06077 -7.242706,-27.03015 0.559674,-0.96938 26.060762,-7.80238 27.030145,-7.2427 0.969383,0.55967 7.802379,26.06076 7.242706,27.03014 -0.559674,0.96938 -26.060763,7.80238 -27.030145,7.24271 z"
+       inkscape:transform-center-x="-2.1742093"
+       transform="matrix(0.48298146,0.12941449,-0.12941449,0.48298146,35.756769,148.35029)"
+       inkscape:transform-center-y="0.58258066" />
+    <rect
+       style="fill:#1a1a1a;stroke-width:0.15985475"
+       id="rect70"
+       width="4.162786"
+       height="24.577539"
+       x="15.460543"
+       y="267.48065"
+       ry="0" />
+  </g>
+</svg>

--- a/mycroft/res/ui/images/media-play.svg
+++ b/mycroft/res/ui/images/media-play.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="123.409"
+   height="123.409"
+   viewBox="0 0 32.651966 32.651966"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="simple-play.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.32"
+     inkscape:cx="24.557187"
+     inkscape:cy="113.17576"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     width="256px"
+     inkscape:window-width="1920"
+     inkscape:window-height="985"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-1.2159538,-263.13209)">
+    <circle
+       style="fill:#1a1a1a;stroke-width:0.13229674"
+       id="path12"
+       cx="17.541937"
+       cy="279.45807"
+       r="16.325983" />
+    <path
+       sodipodi:type="star"
+       style="fill:#ffffff;stroke-width:0.13229674"
+       id="path30"
+       sodipodi:sides="3"
+       sodipodi:cx="16.946964"
+       sodipodi:cy="279.24106"
+       sodipodi:r1="9.8940992"
+       sodipodi:r2="4.9470496"
+       sodipodi:arg1="2.0943951"
+       sodipodi:arg2="3.1415927"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.04"
+       inkscape:randomized="0"
+       d="m 11.999915,287.8096 c -0.593646,-0.34274 -0.593646,-16.79434 0,-17.13708 0.593646,-0.34274 14.841148,7.88306 14.841148,8.56854 1e-6,0.68548 -14.247502,8.91128 -14.841148,8.56854 z"
+       inkscape:transform-center-x="-2.2509079"
+       inkscape:transform-center-y="-1.3242705e-05" />
+  </g>
+</svg>

--- a/mycroft/res/ui/images/media-playback-pause.svg
+++ b/mycroft/res/ui/images/media-playback-pause.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="media-playback-pause.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="760"
+     inkscape:window-height="480"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8.3389831"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <defs
+     id="defs3051">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#4d4d4d;
+      }
+      </style>
+  </defs>
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     d="m 3 3 0 10 4 0 0 -10 z m 6 0 0 10 4 0 0 -10 z"
+     class="ColorScheme-Text"
+     id="path4" />
+</svg>

--- a/mycroft/res/ui/images/media-playback-start.svg
+++ b/mycroft/res/ui/images/media-playback-start.svg
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 16 16"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="media-playback-start.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata10">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="993"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="8.3389831"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <defs
+     id="defs3051">
+    <style
+       type="text/css"
+       id="current-color-scheme">
+      .ColorScheme-Text {
+        color:#4d4d4d;
+      }
+      </style>
+  </defs>
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none"
+     d="m 3 3 0 10 10 -5 z"
+     class="ColorScheme-Text"
+     id="path4" />
+</svg>

--- a/mycroft/res/ui/images/media-previous.svg
+++ b/mycroft/res/ui/images/media-previous.svg
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="123.40901"
+   height="123.40899"
+   viewBox="0 0 32.651968 32.651961"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="simple-next.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.32"
+     inkscape:cx="-34.368354"
+     inkscape:cy="118.57509"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     width="256px"
+     inkscape:window-width="1920"
+     inkscape:window-height="985"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-1.2159538,-263.13209)">
+    <circle
+       style="fill:#1a1a1a;stroke-width:0.13229673"
+       id="path12"
+       cx="17.541935"
+       cy="279.45807"
+       r="16.325981" />
+    <path
+       sodipodi:type="star"
+       style="fill:#ffffff;stroke-width:0.26458332"
+       id="path30"
+       sodipodi:sides="4"
+       sodipodi:cx="32.676765"
+       sodipodi:cy="262.69937"
+       sodipodi:r1="19.787439"
+       sodipodi:r2="9.8937197"
+       sodipodi:arg1="2.0943951"
+       sodipodi:arg2="2.8797933"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.04"
+       inkscape:randomized="0"
+       d="m 22.783046,279.8358 c -0.969383,-0.55968 -7.802379,-26.06077 -7.242706,-27.03015 0.559674,-0.96938 26.060762,-7.80238 27.030145,-7.2427 0.969383,0.55967 7.802379,26.06076 7.242706,27.03014 -0.559674,0.96938 -26.060763,7.80238 -27.030145,7.24271 z"
+       inkscape:transform-center-x="-1.9493437"
+       transform="matrix(0.43302928,-0.25000957,0.25000957,0.43302928,-58.397291,173.18385)"
+       inkscape:transform-center-y="-1.1254492" />
+    <rect
+       style="fill:#1a1a1a;stroke-width:0.23068129"
+       id="rect70"
+       width="13.343723"
+       height="15.966844"
+       x="-187.81242"
+       y="206.39833"
+       ry="0"
+       transform="rotate(-45)" />
+  </g>
+</svg>

--- a/mycroft/res/ui/images/media-repeat.svg
+++ b/mycroft/res/ui/images/media-repeat.svg
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="123.409"
+   height="123.409"
+   viewBox="0 0 32.651966 32.651966"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="simple-repeat.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.32"
+     inkscape:cx="0.11440656"
+     inkscape:cy="118.5751"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     width="256px"
+     inkscape:window-width="1920"
+     inkscape:window-height="985"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-1.2159538,-263.13209)">
+    <circle
+       style="fill:#1a1a1a;stroke-width:0.13229674"
+       id="path12"
+       cx="17.541937"
+       cy="279.45807"
+       r="16.325983" />
+    <path
+       sodipodi:type="star"
+       style="fill:#ffffff;stroke-width:0.26458332"
+       id="path30"
+       sodipodi:sides="4"
+       sodipodi:cx="32.676765"
+       sodipodi:cy="262.69937"
+       sodipodi:r1="19.787439"
+       sodipodi:r2="9.8937197"
+       sodipodi:arg1="2.0943951"
+       sodipodi:arg2="2.8797933"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.04"
+       inkscape:randomized="0"
+       d="m 22.783046,279.8358 c -0.969383,-0.55968 -7.802379,-26.06077 -7.242706,-27.03015 0.559674,-0.96938 26.060762,-7.80238 27.030145,-7.2427 0.969383,0.55967 7.802379,26.06076 7.242706,27.03014 -0.559674,0.96938 -26.060763,7.80238 -27.030145,7.24271 z"
+       inkscape:transform-center-x="0.58258212"
+       transform="matrix(-0.12941449,0.48298146,-0.48298146,-0.12941449,148.64971,297.67289)"
+       inkscape:transform-center-y="2.1742084" />
+    <path
+       sodipodi:type="star"
+       style="fill:#1a1a1a;stroke-width:0.26458332"
+       id="path30-3"
+       sodipodi:sides="4"
+       sodipodi:cx="32.676765"
+       sodipodi:cy="262.69937"
+       sodipodi:r1="19.787439"
+       sodipodi:r2="9.8937197"
+       sodipodi:arg1="2.0943951"
+       sodipodi:arg2="2.8797933"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.04"
+       inkscape:randomized="0"
+       d="m 22.783046,279.8358 c -0.969383,-0.55968 -7.802379,-26.06077 -7.242706,-27.03015 0.559674,-0.96938 26.060762,-7.80238 27.030145,-7.2427 0.969383,0.55967 7.802379,26.06076 7.242706,27.03014 -0.559674,0.96938 -26.060763,7.80238 -27.030145,7.24271 z"
+       inkscape:transform-center-x="0.53926856"
+       transform="matrix(-0.11978344,0.44703777,-0.44703777,-0.11978341,138.89261,296.31734)"
+       inkscape:transform-center-y="2.0124099" />
+    <rect
+       style="fill:#1a1a1a;stroke-width:0.13229674"
+       id="rect146"
+       width="3.7065897"
+       height="7.1280575"
+       x="15.688642"
+       y="268.42383" />
+    <path
+       sodipodi:type="star"
+       style="fill:#ffffff;stroke-width:0.13229674"
+       id="path150"
+       sodipodi:sides="3"
+       sodipodi:cx="16.228092"
+       sodipodi:cy="272.43719"
+       sodipodi:r1="1.2519433"
+       sodipodi:r2="0.62597173"
+       sodipodi:arg1="2.0943951"
+       sodipodi:arg2="3.1415927"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.04"
+       inkscape:randomized="0"
+       d="m 15.602121,273.52141 c -0.07512,-0.0434 -0.07512,-2.12506 0,-2.16843 0.07512,-0.0434 1.877915,0.99748 1.877915,1.08421 0,0.0867 -1.802799,1.12759 -1.877915,1.08422 z"
+       inkscape:transform-center-x="-0.28481568"
+       inkscape:transform-center-y="-1.1438637e-05" />
+    <rect
+       y="283.36426"
+       x="15.688642"
+       height="7.1280575"
+       width="3.7065897"
+       id="rect161"
+       style="fill:#1a1a1a;stroke-width:0.13229674" />
+    <path
+       inkscape:transform-center-x="0.28481524"
+       d="m -19.550185,-285.35347 c -0.07512,-0.0434 -0.07512,-2.12506 0,-2.16843 0.07512,-0.0434 1.877915,0.99748 1.877915,1.08422 0,0.0867 -1.802798,1.12758 -1.877915,1.08421 z"
+       inkscape:randomized="0"
+       inkscape:rounded="0.04"
+       inkscape:flatsided="true"
+       sodipodi:arg2="3.1415927"
+       sodipodi:arg1="2.0943951"
+       sodipodi:r2="0.62597173"
+       sodipodi:r1="1.2519433"
+       sodipodi:cy="-286.43768"
+       sodipodi:cx="-18.924213"
+       sodipodi:sides="3"
+       id="path163"
+       style="fill:#ffffff;stroke-width:0.13229674"
+       sodipodi:type="star"
+       transform="scale(-1)"
+       inkscape:transform-center-y="1.5652489e-05" />
+  </g>
+</svg>

--- a/mycroft/res/ui/images/media-stop.svg
+++ b/mycroft/res/ui/images/media-stop.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="123.409"
+   height="123.409"
+   viewBox="0 0 32.651966 32.651966"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="simple-stop.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.32"
+     inkscape:cx="0.63476656"
+     inkscape:cy="113.17576"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     width="256px"
+     inkscape:window-width="1920"
+     inkscape:window-height="985"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-1.2159538,-263.13209)">
+    <circle
+       style="fill:#1a1a1a;stroke-width:0.13229674"
+       id="path12"
+       cx="17.541937"
+       cy="279.45807"
+       r="16.325983" />
+    <path
+       sodipodi:type="star"
+       style="fill:#ffffff;stroke-width:0.26458332"
+       id="path30"
+       sodipodi:sides="4"
+       sodipodi:cx="32.676765"
+       sodipodi:cy="262.69937"
+       sodipodi:r1="19.787439"
+       sodipodi:r2="9.8937197"
+       sodipodi:arg1="2.0943951"
+       sodipodi:arg2="2.8797933"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.04"
+       inkscape:randomized="0"
+       d="m 22.783046,279.8358 c -0.969383,-0.55968 -7.802379,-26.06077 -7.242706,-27.03015 0.559674,-0.96938 26.060762,-7.80238 27.030145,-7.2427 0.969383,0.55967 7.802379,26.06076 7.242706,27.03014 -0.559674,0.96938 -26.060763,7.80238 -27.030145,7.24271 z"
+       inkscape:transform-center-x="-2.1742093"
+       transform="matrix(0.48298146,0.12941449,-0.12941449,0.48298146,35.756769,148.35029)"
+       inkscape:transform-center-y="0.58258066" />
+  </g>
+</svg>

--- a/mycroft/res/ui/images/media-unmute.svg
+++ b/mycroft/res/ui/images/media-unmute.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="123.409"
+   height="123.409"
+   viewBox="0 0 32.651966 32.651966"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="simple-audio-on.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.2809755"
+     inkscape:cx="23.131927"
+     inkscape:cy="121.25706"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     width="256px"
+     inkscape:window-width="1920"
+     inkscape:window-height="985"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0" />
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(-1.2159538,-263.13209)">
+    <circle
+       style="fill:#1a1a1a;stroke-width:0.13229674"
+       id="path12"
+       cx="17.541937"
+       cy="279.45807"
+       r="16.325983" />
+    <path
+       sodipodi:type="star"
+       style="fill:#ffffff;stroke-width:0.26458332"
+       id="path30"
+       sodipodi:sides="3"
+       sodipodi:cx="32.676765"
+       sodipodi:cy="262.69937"
+       sodipodi:r1="19.787439"
+       sodipodi:r2="9.8937197"
+       sodipodi:arg1="2.0943951"
+       sodipodi:arg2="3.1415927"
+       inkscape:flatsided="true"
+       inkscape:rounded="0.04"
+       inkscape:randomized="0"
+       d="m 22.783046,279.8358 c -1.187247,-0.68546 -1.187247,-33.5874 0,-34.27285 1.187246,-0.68546 29.681159,15.76551 29.681159,17.13642 0,1.37092 -28.493913,17.82188 -29.681159,17.13643 z"
+       inkscape:transform-center-x="0.2329236"
+       transform="matrix(0.2500096,-0.43302932,0.43302932,0.2500096,-107.64087,227.9307)"
+       inkscape:transform-center-y="-0.40343842" />
+    <rect
+       style="fill:#1a1a1a;stroke-width:0.19363759"
+       id="rect226"
+       width="3.9917119"
+       height="13.514797"
+       x="6.9604759"
+       y="272.44635" />
+    <rect
+       y="275.1265"
+       x="3.7078028"
+       height="7.9263997"
+       width="4.3338585"
+       id="rect228"
+       style="fill:#1a1a1a;stroke-width:0.15451857" />
+    <rect
+       style="fill:#ffffff;stroke-width:0.13229674"
+       id="rect232"
+       width="2.8877196"
+       height="8.6631584"
+       x="7.7770677"
+       y="275.1265"
+       rx="0.5"
+       ry="0.5" />
+    <rect
+       style="fill:#ccff00;stroke-width:0.07797045"
+       id="rect236"
+       width="0.28225666"
+       height="5.3222041"
+       x="20.608721"
+       y="276.79697"
+       rx="0.49999899"
+       ry="0.49999899" />
+    <rect
+       style="fill:#ccff00;stroke-width:0.10858617"
+       id="rect236-7"
+       width="0.28225666"
+       height="10.322395"
+       x="22.608799"
+       y="274.29684"
+       rx="0.49999902"
+       ry="0.49999905" />
+    <rect
+       ry="0.49999902"
+       rx="0.49999902"
+       y="271.79681"
+       x="24.608875"
+       height="15.322504"
+       width="0.28225666"
+       id="rect257"
+       style="fill:#ccff00;stroke-width:0.13229674" />
+  </g>
+</svg>


### PR DESCRIPTION
## Description

Simple standalone implementation of enabling video playback by skills inside Mycroft-GUI without Common Play Framework integration. This PR is being opened because the previous PR for play video https://github.com/MycroftAI/mycroft-core/pull/2683  is blocked on Common Play Service implementation.

Skills should be allowed to display videos embedded in GUI and not be opened in external applications as the GUI is fully capable of playing Videos via inbuilt Video QML type regardless of Common Play Service Implementation. 

## How to test
Sample Test Skill To Test PR:
[testshowvideo.tar.gz](https://github.com/MycroftAI/mycroft-core/files/6596041/testshowvideo.tar.gz)

- "hey mycroft test streaming video"
- "hey mycroft test local video"

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
