### PR TITLE
Handle multiple intents with the same name

### DIFF
--- a/mycroft/skills/intent_service_interface.py
+++ b/mycroft/skills/intent_service_interface.py
@@ -104,6 +104,21 @@ class IntentServiceInterface:
             self.registered_intents = [pair for pair in self.registered_intents
                                        if pair[0] != name]
 
+    def intent_is_detached(self, intent_name):
+        """Determine if an intent is detached.
+
+        Args:
+            intent_name(str): Intent reference
+
+        Returns:
+            (bool) True if intent is found, else False.
+        """
+        for (name, _) in self.detached_intents:
+            if name == intent_name:
+                return True
+
+        return False
+
     def set_adapt_context(self, context, word, origin):
         """Set an Adapt context.
 

--- a/mycroft/skills/intent_service_interface.py
+++ b/mycroft/skills/intent_service_interface.py
@@ -35,6 +35,7 @@ class IntentServiceInterface:
     def __init__(self, bus=None):
         self.bus = bus
         self.registered_intents = []
+        self.detached_intents = []
 
     def set_bus(self, bus):
         self.bus = bus
@@ -83,14 +84,25 @@ class IntentServiceInterface:
         """
         self.bus.emit(Message("register_intent", intent_parser.__dict__))
         self.registered_intents.append((name, intent_parser))
+        self.detached_intents = [detached for detached in self.detached_intents
+                                 if detached[0] != name]
 
     def detach_intent(self, intent_name):
         """Remove an intent from the intent service.
 
+        The intent is saved in the list of detached intents for use when
+        re-enabling an intent.
+
         Args:
             intent_name(str): Intent reference
         """
-        self.bus.emit(Message("detach_intent", {"intent_name": intent_name}))
+        name = intent_name.split(':')[1]
+        if name in self:
+            self.bus.emit(Message("detach_intent",
+                                  {"intent_name": intent_name}))
+            self.detached_intents.append((name, self.get_intent(name)))
+            self.registered_intents = [pair for pair in self.registered_intents
+                                       if pair[0] != name]
 
     def set_adapt_context(self, context, word, origin):
         """Set an Adapt context.
@@ -161,6 +173,8 @@ class IntentServiceInterface:
     def get_intent(self, intent_name):
         """Get intent from intent_name.
 
+        This will find both enabled and disabled intents.
+
         Args:
             intent_name (str): name to find.
 
@@ -170,8 +184,10 @@ class IntentServiceInterface:
         for name, intent in self:
             if name == intent_name:
                 return intent
-        else:
-            return None
+        for name, intent in self.detached_intents:
+            if name == intent_name:
+                return intent
+        return None
 
 
 class IntentQueryApi:

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1066,7 +1066,7 @@ class MycroftSkill:
         """Listener to enable a registered intent if it belongs to this skill.
         """
         intent_name = message.data['intent_name']
-        for (name, _) in self.intent_service:
+        for (name, _) in self.intent_service.detached_intents:
             if name == intent_name:
                 return self.enable_intent(intent_name)
 
@@ -1088,7 +1088,7 @@ class MycroftSkill:
                 bool: True if disabled, False if it wasn't registered
         """
         if intent_name in self.intent_service:
-            LOG.debug('Disabling intent ' + intent_name)
+            LOG.info('Disabling intent ' + intent_name)
             name = '{}:{}'.format(self.skill_id, intent_name)
             self.intent_service.detach_intent(name)
             return True

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -958,12 +958,25 @@ class MycroftSkill:
     def _register_adapt_intent(self, intent_parser, handler):
         """Register an adapt intent.
 
+        Will handle registration of anonymous
         Args:
             intent_parser: Intent object to parse utterance for the handler.
             handler (func): function to register with intent
         """
         # Default to the handler's function name if none given
+        is_anonymous = not intent_parser.name
         name = intent_parser.name or handler.__name__
+        if is_anonymous:
+            # Find a good name
+            original_name = name
+            nbr = 0
+            while name in self.intent_service:
+                nbr += 1
+                name = f'{original_name}{nbr}'
+        else:
+            if name in self.intent_service:
+                raise ValueError(f'The intent name {name} is already taken')
+
         munge_intent_parser(intent_parser, name, self.skill_id)
         self.intent_service.register_adapt_intent(name, intent_parser)
         if handler:

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1066,9 +1066,7 @@ class MycroftSkill:
         """Listener to enable a registered intent if it belongs to this skill.
         """
         intent_name = message.data['intent_name']
-        for (name, _) in self.intent_service.detached_intents:
-            if name == intent_name:
-                return self.enable_intent(intent_name)
+        return self.enable_intent(intent_name)
 
     def handle_disable_intent(self, message):
         """Listener to disable a registered intent if it belongs to this skill.
@@ -1107,7 +1105,7 @@ class MycroftSkill:
             bool: True if enabled, False if it wasn't registered
         """
         intent = self.intent_service.get_intent(intent_name)
-        if intent:
+        if intent and self.intent_service.intent_is_detached(intent_name):
             if ".intent" in intent_name:
                 self.register_intent_file(intent_name, None)
             else:
@@ -1115,10 +1113,13 @@ class MycroftSkill:
                 self.register_intent(intent, None)
             LOG.debug('Enabling intent {}'.format(intent_name))
             return True
+        elif intent:
+            LOG.error(f'Could not enable {intent_name}, '
+                      'it\'s not detached')
         else:
             LOG.error('Could not enable '
                       '{}, it hasn\'t been registered.'.format(intent_name))
-            return False
+        return False
 
     def set_context(self, context, word='', origin=''):
         """Add context to intent service


### PR DESCRIPTION
## Description
This implements Alternative 1 from #2920 

- It will raise a `ValueError` if two named `IntentBuilder`s with the same name is registered
- If anonymous `IntentBuilder`s are used they will be automatically given an unique name

The handling for enable-disable intent was updated to make sure that the intent was removed from the list of `registered_intents`, for re-enabling it's moved to a list of `detached_intents`

## How to test
Add a second `@intent_handler()` decorator to a method ensure both can be used to trigger the handler and that the handler is triggered exactly once.

## Contributor license agreement signed?
CLA [ Yes ]