### PR TITLE
Upgrade PIP to 21.3.1

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -469,7 +469,7 @@ function install_venv() {
     # Force version of pip for reproducability, but there is nothing special
     # about this version.  Update whenever a new version is released and
     # verified functional.
-    curl "${GET_PIP_URL}" | "${VIRTUALENV_ROOT}/bin/${opt_python}" - 'pip==22.0.3'
+    curl "${GET_PIP_URL}" | "${VIRTUALENV_ROOT}/bin/${opt_python}" - 'pip==21.3.1'
     # Function status depending on if pip exists
     [[ -x ${VIRTUALENV_ROOT}/bin/pip ]]
 }

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -469,7 +469,7 @@ function install_venv() {
     # Force version of pip for reproducability, but there is nothing special
     # about this version.  Update whenever a new version is released and
     # verified functional.
-    curl "${GET_PIP_URL}" | "${VIRTUALENV_ROOT}/bin/${opt_python}" - 'pip==20.0.2'
+    curl "${GET_PIP_URL}" | "${VIRTUALENV_ROOT}/bin/${opt_python}" - 'pip==22.0.3'
     # Function status depending on if pip exists
     [[ -x ${VIRTUALENV_ROOT}/bin/pip ]]
 }


### PR DESCRIPTION
## Description
Upgrade PIP to latest version.

There have been an extensive number of bugfixes, improvements and deprecations. Nothing that I've seen that should really impact us.

@forslund I remember hearing about issues with a previous PIP update - are there specific things you can remember that we should be on the lookout for?

## Tested on:
- [x] Ubuntu 20.04 VM
- [x] Upgrading pip on an existing Mark II
- [x] Build of new Mark II image
- [ ] Upgrading pip on an existing Mark 1

## Contributor license agreement signed?
- [x] CLA

