### PR TITLE
stop passing lang=None to Lingua Franca

### DIFF
--- a/mycroft/util/format.py
+++ b/mycroft/util/format.py
@@ -31,6 +31,7 @@ from calendar import leapdays
 from enum import Enum
 
 # These are the main functions we are using lingua franca to provide
+from lingua_franca import get_default_loc
 # TODO 21.08 - move nice_duration methods to Lingua Franca.
 from lingua_franca.format import (
     join_list,
@@ -104,6 +105,7 @@ def _duration_handler(time1, lang=None, speech=True, *, time2=None,
     Returns:
         str: timespan as a string
     """
+    lang = lang or get_default_loc()
     _leapdays = 0
     _input_resolution = resolution
     milliseconds = 0

--- a/mycroft/util/parse.py
+++ b/mycroft/util/parse.py
@@ -30,6 +30,7 @@ use in Mycroft Skills.
 from difflib import SequenceMatcher
 from warnings import warn
 
+from lingua_franca import get_default_loc
 from lingua_franca.parse import (
     extract_duration,
     extract_number,
@@ -115,4 +116,7 @@ def extract_datetime(text, anchorDate="DEFAULT", lang=None,
                                 "deprecated. This parameter can be omitted."))
     if anchorDate is None or anchorDate == "DEFAULT":
         anchorDate = now_local()
-    return _extract_datetime(text, anchorDate, lang, default_time)
+    return _extract_datetime(text,
+                             anchorDate,
+                             lang or get_default_loc(),
+                             default_time)


### PR DESCRIPTION
LF's only breaking change over the past two versions has been the
deprecation of `lang=None` as a valid parameter. This is because the new
language loading paradigm wants to load certain functions on the fly,
which it cannot do when it is explicitly told to look for a null lang.

I've addressed this by passing `lingua_franca.get_default_lang()` where
the `lang=None` call remained.

Bonus: Gets rid of over 200 DeprecationWarnings in unit tests!