### PR TITLE
Stop creation of 'None' cache directory

### DIFF
--- a/mycroft/tts/cache.py
+++ b/mycroft/tts/cache.py
@@ -147,20 +147,20 @@ class TextToSpeechCache:
         self.tts_name = tts_name
         if "preloaded_cache" in self.config:
             self.persistent_cache_dir = Path(self.config["preloaded_cache"])
+            ensure_directory_exists(
+                str(self.persistent_cache_dir), permissions=0o755
+            )
         else:
             self.persistent_cache_dir = None
         self.temporary_cache_dir = Path(
             get_cache_directory("tts/" + tts_name)
         )
-        self.audio_file_type = audio_file_type
-        self.resource_dir = Path(__file__).parent.parent.joinpath("res")
-        self.cached_sentences = dict()
-        ensure_directory_exists(
-            str(self.persistent_cache_dir), permissions=0o755
-        )
         ensure_directory_exists(
             str(self.temporary_cache_dir), permissions=0o755
         )
+        self.audio_file_type = audio_file_type
+        self.resource_dir = Path(__file__).parent.parent.joinpath("res")
+        self.cached_sentences = dict()
 
     def __contains__(self, sha):
         """The cache contains a SHA if it knows of it and it exists on disk."""


### PR DESCRIPTION
## Description
The `persistent_cache_dir` is assigned `None` if no `preloaded_cache` exists.
`None` was then created as a directory when it's clearly not needed.

Re-ordered slightly to keep all the directory setting and checking together.

Fixes #2930 
Thanks to @JarbasAI for the fix

## How to test
1. Set TTS.module to mimic which has no default preloaded cache directory
2. Launch Mycroft
3. See that a `mycroft-core/None` directory is created.
4. Delete this directory, then apply this PR and repeat.

## Contributor license agreement signed?
- [x] CLA
