### PR TITLE
WIP: Add per TTS config for free disk space

### DIFF
--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -304,9 +304,13 @@
       "lang": "en-us",
       "url": "https://mimic-api.mycroft.ai/synthesize?text=",
       "preloaded_cache": "/opt/mycroft/preloaded_cache/Mimic2",
-      // Temp cache will be curated if insufficient disk space is available
-      "min_free_disk_space": 1024,
-      "min_free_disk_percent": 20
+      "cache_limits": {
+        // Temp cache will be curated if any criteria cannot be met
+        "min_free_disk_percent": 20.0,
+        "min_free_disk_space": 1024.0,
+        "max_usage_disk_percent": 90.0
+        "max_usage_disk_space": 100.0,
+      }
     },
     "espeak": {
       "lang": "english-us",

--- a/mycroft/configuration/mycroft.conf
+++ b/mycroft/configuration/mycroft.conf
@@ -303,7 +303,10 @@
     "mimic2": {
       "lang": "en-us",
       "url": "https://mimic-api.mycroft.ai/synthesize?text=",
-      "preloaded_cache": "/opt/mycroft/preloaded_cache/Mimic2"
+      "preloaded_cache": "/opt/mycroft/preloaded_cache/Mimic2",
+      // Temp cache will be curated if insufficient disk space is available
+      "min_free_disk_space": 1024,
+      "min_free_disk_percent": 20
     },
     "espeak": {
       "lang": "english-us",

--- a/mycroft/tts/cache.py
+++ b/mycroft/tts/cache.py
@@ -142,6 +142,7 @@ class PhonemeFile:
 
 class TextToSpeechCache:
     """Class for all persistent and temporary caching operations."""
+
     def __init__(self, tts_config, tts_name, audio_file_type):
         self.config = tts_config
         self.tts_name = tts_name
@@ -161,6 +162,10 @@ class TextToSpeechCache:
         ensure_directory_exists(
             str(self.temporary_cache_dir), permissions=0o755
         )
+        self.min_free_disk_percent = self.config.get(
+            "min_free_disk_percent", 20)
+        self.min_free_disk_space = self.config.get(
+            "min_free_disk_space", 1024)
 
     def __contains__(self, sha):
         """The cache contains a SHA if it knows of it and it exists on disk."""
@@ -311,8 +316,10 @@ class TextToSpeechCache:
 
     def curate(self):
         """Remove cache data if disk space is running low."""
-        files_removed = curate_cache(self.temporary_cache_dir,
-                                     min_free_percent=100)
+        files_removed = curate_cache(
+            self.temporary_cache_dir,
+            min_free_percent=self.min_free_disk_percent,
+            min_free_disk=self.min_free_disk_space)
 
         hashes = set([hash_from_path(Path(path)) for path in files_removed])
         for sentence_hash in hashes:


### PR DESCRIPTION
## Description
This adds configurable values for required free disk space per TTS service.
If free disk space falls below these values, the temporary TTS cache will be curated.

Split from #2930 

**Problem # 1 - tests failing**
This seems to be working in practice but I haven't got the tests to work.
At first I thought it was because the cached files didn't exist, hence didn't take up any space and so the calculation in curate_cache would have seen them as irrelevant. However populating them with some data didn't fix this.

Assuming this is a simple fix and just needs a fresh set of eyes on it to find my mistake...

**Problem # 2 - Are we curating caches properly**
It also raises a question for me as to whether the `curate_cache` should actually use an "OR" eg
```python
if percent_free < min_free_percent or space.free < min_free_disk:
```
rather than the current "AND"
```python
if percent_free < min_free_percent and space.free < min_free_disk:
```

This I think is partially how this issue arose. We currently have a call to the method that only includes the `min_free_percent` argument. It would be assumed that this would then be the factor on whether curation happened or not. However it must also fall below the default disk space argument. So even passing in 99% free disk percentage required, the cache will not be curated unless you also have <50MB of disk space as well.


## How to test
- wait until unit tests work

## Contributor license agreement signed?
- [x] CLA (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
