### PR TITLE
Fix #2929: use returned TTS audio file path

### DIFF
--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -19,6 +19,7 @@ import re
 from abc import ABCMeta, abstractmethod
 from threading import Thread
 from time import time
+from warnings import warn
 
 import os.path
 from os.path import dirname, exists, isdir, join
@@ -370,7 +371,18 @@ class TTS(metaclass=ABCMeta):
                 #  of the TTS cache.  But this requires changing the public
                 #  API of the get_tts method in each engine.
                 audio_file = self.cache.define_audio_file(sentence_hash)
-                _, phonemes = self.get_tts(sentence, str(audio_file.path))
+                # TODO 21.08: remove mutation of audio_file.path.
+                returned_file, phonemes = self.get_tts(
+                    sentence, str(audio_file.path))
+                if returned_file.path != audio_file.path:
+                    warn(
+                        DeprecationWarning(
+                            f"{self.tts_name} is saving files "
+                            "to a different path than requested. If you are "
+                            "the maintainer of this plugin, please adhere to "
+                            "the file path argument provided. Modified paths "
+                            "will be ignored in a future release."))
+                    audio_file = returned_file
                 if phonemes:
                     phoneme_file = self.cache.define_phoneme_file(
                         sentence_hash

--- a/test/unittests/tts/test_tts.py
+++ b/test/unittests/tts/test_tts.py
@@ -96,11 +96,14 @@ class TestTTS(unittest.TestCase):
         with mock.patch('mycroft.tts.tts.open') as mock_open:
             tts.cache.temporary_cache_dir = Path('/tmp/dummy')
             tts.execute('Oh no, not again', 42)
-        self.assertTrue(tts.get_tts.called)
+        tts.get_tts.assert_called_with(
+            'Oh no, not again',
+            '/tmp/dummy/8da7f22aeb16bc3846ad07b644d59359.wav'
+        )
         tts.queue.put.assert_called_with(
             (
                 'wav',
-                '/tmp/dummy/8da7f22aeb16bc3846ad07b644d59359.wav',
+                str(mock_audio.path),
                 mock_viseme,
                 42,
                 False


### PR DESCRIPTION
## Description
This reverts an unintentional breaking change.

A TTS engine may return a different file path than was requested. This again uses the returned path but adds a deprecation warning that this behaviour will no longer be supported in an upcoming release.

Unless there are reasons why a TTS engine may need to save the files in an alternative location?

Fixes #2929

## How to test
Updated unit test. 
Test also throws the DeprecationWarning as the mocked value returned differs from the path requested.

## Contributor license agreement signed?
- [x] CLA
