### PR TITLE
Remove docs encouraging Skill config via mycroft.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,27 +99,17 @@ If you do not wish to use the Mycroft Home service, before starting Mycroft for 
 }
 ```
 
-Mycroft will then be unable to perform speech-to-text conversion, so you'll need to set that up as well, using one of the [STT engines Mycroft supports](https://mycroft-ai.gitbook.io/docs/using-mycroft-ai/customizations/stt-engine).
-
-You may insert your own API keys into the configuration files listed above in <b>Configuration</b>.  For example, to insert the API key for the Weather skill, create a new JSON key in the configuration file like so:
-
-```
-{
-  // other configuration settings...
-  //
-  "WeatherSkill": {
-    "api_key": "<insert your API key here>"
-  }
-}
-```
-
 ### API Key Services
 
-These are the keys currently used in Mycroft Core:
+The Mycroft backend provides access to a range of API keys for specific services. Without pairing with the Mycroft backend, you will need to add your own API keys, install a different Skill or Plugin to perform that function, or not have access to that functionality.
+
+These are the keys currently used in Mycroft Core through the Mycroft backend:
 
 - [STT API, Google STT, Google Cloud Speech](http://www.chromium.org/developers/how-tos/api-keys)
+  - [A range of STT services](https://mycroft-ai.gitbook.io/docs/using-mycroft-ai/customizations/stt-engine) are available for use with Mycroft.
 - [Weather Skill API, OpenWeatherMap](http://openweathermap.org/api)
 - [Wolfram-Alpha Skill](http://products.wolframalpha.com/api/)
+
 
 ### Using Mycroft behind a proxy
 


### PR DESCRIPTION
## Description
Removes an outdated section of the main README that encouraged the use of mycroft.conf for Skill configuration.

The example used was also outdated as you cannot currently configure the mycroft-weather Skill to use a local API key.

Raised in https://github.com/MycroftAI/skill-weather/issues/170

## How to test
Markdown only

## Contributor license agreement signed?
- [x] CLA
