### PR TITLE
Fix VK race condition in MycroftSkill.get_response()

### DIFF
--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -235,8 +235,8 @@ def then_contains(context, text):
 @then('the user replies "{text}"')
 @then('the user says "{text}"')
 def then_user_follow_up(context, text):
-    time.sleep(2)
     wait_while_speaking()
+    time.sleep(2)
     context.bus.emit(Message('recognizer_loop:utterance',
                              data={'utterances': [text],
                                    'lang': context.lang,


### PR DESCRIPTION
## Description
Running the VK tests for the timer skill, I noticed that some of the tests with conversational logic were failing sporadically.  After researching the issue, I found that the user reply portion of the conversational logic was experiencing a race condition.  The race condition is not seen in regular device use because the computer running VK is faster than human interaction.

The logic in MycroftSkill.__get_response() that reassigns the converse method to a nested function to handle the user response portion of the conversation was happening AFTER the utterance event generated by VK had already been swallowed by the intent parser.  In other words, the utterance method was generated faster than the logic in get_response() could handle it.  For example, when the timer skill was asked to "set a timer", it responds with "how long of a timer?".  The response, in this case "one minute" made its way to the intent parser before the converse methods were switched, resulting in a "I don't know what that means" response from the intent system.

The function this PR changes seemed odd to me in that it was sleeping before the wait_while_speaking() function was called.  So if the dialog being spoken took 4 seconds to speak, this code would wait for four seconds (two second sleep plus two seconds remaining in speak). The sleep() was essentially a no-op.  Switching the order of these statements added two seconds to the end of the four second speaking for a total of six seconds.  This gave the skill the time necessary to flip the converse methods before the user response hit the intent parsers.

## How to test
This is very difficult to test.  The race condition occurred intermittently.  So you would have to find a way to force the race condition with the old version of this code, then run it again with the code in this PR.  The only real way to test it works is to run some VK tests that check for conversational logic and ensure they pass without failing.  The timer skill is an example of a skill that has these types of tests.

## Contributor license agreement signed?
CLA [Y]
