### PR TITLE
Fix TTS using the returned path

### DIFF
--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -17,6 +17,7 @@ import os
 import random
 import re
 from abc import ABCMeta, abstractmethod
+from pathlib import Path
 from threading import Thread
 from time import time
 from warnings import warn
@@ -374,7 +375,9 @@ class TTS(metaclass=ABCMeta):
                 # TODO 21.08: remove mutation of audio_file.path.
                 returned_file, phonemes = self.get_tts(
                     sentence, str(audio_file.path))
-                if returned_file.path != audio_file.path:
+                # Convert to Path as needed
+                returned_file = Path(returned_file)
+                if returned_file != audio_file.path:
                     warn(
                         DeprecationWarning(
                             f"{self.tts_name} is saving files "
@@ -382,7 +385,7 @@ class TTS(metaclass=ABCMeta):
                             "the maintainer of this plugin, please adhere to "
                             "the file path argument provided. Modified paths "
                             "will be ignored in a future release."))
-                    audio_file = returned_file
+                    audio_file.path = returned_file
                 if phonemes:
                     phoneme_file = self.cache.define_phoneme_file(
                         sentence_hash

--- a/test/unittests/tts/test_tts.py
+++ b/test/unittests/tts/test_tts.py
@@ -8,7 +8,7 @@ from unittest import mock
 import mycroft.tts
 
 mock_phoneme = mock.Mock(name='phoneme')
-mock_audio = mock.Mock(name='audio')
+mock_audio = "/tmp/mock_path"
 mock_viseme = mock.Mock(name='viseme')
 
 
@@ -103,7 +103,32 @@ class TestTTS(unittest.TestCase):
         tts.queue.put.assert_called_with(
             (
                 'wav',
-                str(mock_audio.path),
+                mock_audio,
+                mock_viseme,
+                42,
+                False
+            )
+        )
+
+    def test_execute_path_returned(self, mock_playback_thread):
+        tts = MockTTS("en-US", {}, MockTTSValidator(None))
+        tts.get_tts.return_value = (Path(mock_audio), mock_viseme)
+        bus_mock = mock.Mock()
+        tts.init(bus_mock)
+        self.assertTrue(tts.bus is bus_mock)
+
+        tts.queue = mock.Mock()
+        with mock.patch('mycroft.tts.tts.open') as mock_open:
+            tts.cache.temporary_cache_dir = Path('/tmp/dummy')
+            tts.execute('Oh no, not again', 42)
+        tts.get_tts.assert_called_with(
+            'Oh no, not again',
+            '/tmp/dummy/8da7f22aeb16bc3846ad07b644d59359.wav'
+        )
+        tts.queue.put.assert_called_with(
+            (
+                'wav',
+                mock_audio,
                 mock_viseme,
                 42,
                 False


### PR DESCRIPTION
## Description
Fixes issues with retuned file as reported and suggested by @JarbasAI 

Ensures that the returned file from get_tts() is a `Path` object and fixes the comparisons. This means that a get_tts can also return a Path object instead of a str and all should  be well,

## How to test
Run branch ensure that audio is heard and the lookups works.

## Contributor license agreement signed?
CLA [ Yes ]