### PR TITLE
Fix bargein

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -124,7 +124,7 @@ def mute_and_speak(utterance, ident, listen=False):
         tts.init(bus)
         tts_hash = hash(str(config.get('tts', '')))
 
-    LOG.info("Speak: " + utterance)
+    LOG.debug("Listen=%s, Speak:%s" % (listen, utterance))
     try:
         tts.execute(utterance, ident, listen)
     except RemoteTTSException as e:
@@ -173,6 +173,11 @@ def handle_stop(event):
         tts.playback.clear()  # Clear here to get instant stop
         bus.emit(Message("mycroft.stop.handled", {"by": "TTS"}))
 
+def handle_pause(event):
+    tts.playback.pause()
+
+def handle_resume(event):
+    tts.playback.resume()
 
 def init(messagebus):
     """Start speech related handlers.
@@ -191,6 +196,8 @@ def init(messagebus):
     config = Configuration.get()
     bus.on('mycroft.stop', handle_stop)
     bus.on('mycroft.audio.speech.stop', handle_stop)
+    bus.on('mycroft.audio.speech.pause', handle_pause)
+    bus.on('mycroft.audio.speech.resume', handle_resume)
     bus.on('speak', handle_speak)
 
     tts = TTSFactory.create()

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -41,6 +41,7 @@ def handle_record_begin():
     LOG.info("Begin Recording...")
     context = {'client_name': 'mycroft_listener',
                'source': 'audio'}
+    bus.emit(Message('mycroft.audio.speech.pause'))
     bus.emit(Message('recognizer_loop:record_begin', context=context))
 
 
@@ -50,6 +51,7 @@ def handle_record_end():
     context = {'client_name': 'mycroft_listener',
                'source': 'audio'}
     bus.emit(Message('recognizer_loop:record_end', context=context))
+    bus.emit(Message('mycroft.audio.speech.resume'))
 
 
 def handle_no_internet():

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -18,7 +18,7 @@ import random
 import re
 from abc import ABCMeta, abstractmethod
 from threading import Thread
-from time import time
+from time import time, sleep
 
 import os.path
 from os.path import dirname, exists, isdir, join
@@ -53,6 +53,7 @@ class PlaybackThread(Thread):
     def __init__(self, queue):
         super(PlaybackThread, self).__init__()
         self.queue = queue
+        self._paused = False
         self._terminated = False
         self._processing_queue = False
         self.enclosure = None
@@ -92,6 +93,8 @@ class PlaybackThread(Thread):
         listening.
         """
         while not self._terminated:
+            while self._paused:
+                sleep(0.2)
             try:
                 (snd_type, data,
                  visemes, ident, listen) = self.queue.get(timeout=2)
@@ -106,11 +109,17 @@ class PlaybackThread(Thread):
                         self.p = play_wav(data, environment=self.pulse_env)
                     elif snd_type == 'mp3':
                         self.p = play_mp3(data, environment=self.pulse_env)
+
                     if visemes:
                         self.show_visemes(visemes)
+
                     if self.p:
-                        self.p.communicate()
-                        self.p.wait()
+                        while self.p.poll() is None:
+                            if self._paused:
+                                self.p.terminate()
+                                break
+                            sleep(0.1)
+
                 report_timing(ident, 'speech_playback', stopwatch)
 
                 if self.queue.empty():
@@ -145,6 +154,14 @@ class PlaybackThread(Thread):
         """Blink mycroft's eyes"""
         if self.enclosure and random.random() < rate:
             self.enclosure.eyes_blink("b")
+
+    def pause(self):
+        """pause thread"""
+        self._paused = True
+
+    def resume(self):
+        """resume thread"""
+        self._paused = False
 
     def stop(self):
         """Stop thread"""


### PR DESCRIPTION
## Description
Barge-In is not an issue for Precise, however, core has some issues. When a wave file is speaking the recognizer confuses the wav file for the mic. Ducking helps a bit with this but its more useful as an audible confirmation as the recognizer still favors this over the mic input. The proper solution is to pause the audio output until the recognizer has consumed the utterance. 

The root problem arises from the tts module which does not use the audio service but it wants to act like one. It has start and stop method and a queue but no pause or resume. This PR corrects that. It also contains the code which uses this new functionality to help with the barge-in process. 

## How to test
Enable your barge-in config flag and use a long playing dialog skill like the new duck duck go or wiki skill (these return an abstract rather than a single sentence) and then say 'stop'. Without this PR this will not work 90% of the time. 

## Contributor license agreement signed?
Yes
