### PR TITLE
Add pause and resume capability to TTS playback thread

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -124,7 +124,7 @@ def mute_and_speak(utterance, ident, listen=False):
         tts.init(bus)
         tts_hash = hash(str(config.get('tts', '')))
 
-    LOG.info("Speak: " + utterance)
+    LOG.debug("Listen=%s, Speak:%s" % (listen, utterance))
     try:
         tts.execute(utterance, ident, listen)
     except RemoteTTSException as e:
@@ -174,6 +174,14 @@ def handle_stop(event):
         bus.emit(Message("mycroft.stop.handled", {"by": "TTS"}))
 
 
+def handle_pause(event):
+    tts.playback.pause()
+
+
+def handle_resume(event):
+    tts.playback.resume()
+
+
 def init(messagebus):
     """Start speech related handlers.
 
@@ -191,6 +199,8 @@ def init(messagebus):
     config = Configuration.get()
     bus.on('mycroft.stop', handle_stop)
     bus.on('mycroft.audio.speech.stop', handle_stop)
+    bus.on('mycroft.audio.speech.pause', handle_pause)
+    bus.on('mycroft.audio.speech.resume', handle_resume)
     bus.on('speak', handle_speak)
 
     tts = TTSFactory.create()

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -41,6 +41,7 @@ def handle_record_begin():
     LOG.info("Begin Recording...")
     context = {'client_name': 'mycroft_listener',
                'source': 'audio'}
+    bus.emit(Message('mycroft.audio.speech.pause'))
     bus.emit(Message('recognizer_loop:record_begin', context=context))
 
 
@@ -50,6 +51,7 @@ def handle_record_end():
     context = {'client_name': 'mycroft_listener',
                'source': 'audio'}
     bus.emit(Message('recognizer_loop:record_end', context=context))
+    bus.emit(Message('mycroft.audio.speech.resume'))
 
 
 def handle_no_internet():


### PR DESCRIPTION
## Description
This adds pause and resume functionality to the TTS playback thread for use in barge in.

From Ken:

> Barge-In is not an issue for Precise, however, core has some issues. When a wave file is speaking the recognizer confuses the wav file for the mic. Ducking helps a bit with this but its more useful as an audible confirmation as the recognizer still favors this over the mic input. The proper solution is to pause the audio output until the recognizer has consumed the utterance.
> 
> The root problem arises from the tts module which does not use the audio service but it wants to act like one. It has start and stop method and a queue but no pause or resume. This PR corrects that. It also contains the code which uses this new functionality to help with the barge-in process.

Replication of #2939 against the dev branch so it doesn't get lost.

## How to test
Unit tests need to be added.

> Enable your barge-in config flag and use a long playing dialog skill like the new duck duck go or wiki skill (these return an abstract rather than a single sentence) and then say 'stop'. Without this PR this will not work 90% of the time.

## Contributor license agreement signed?
- [x] CLA
