### PR TITLE
Use unique paths for temp file storage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -107,13 +107,20 @@ pipeline {
                     sh 'rmdir $HOME/core/$BRANCH_ALIAS'
                     sh (
                         label: 'Publish Report to Web Server',
-                        script: '''scp allure-report.zip root@157.245.127.234:~;
-                            ssh root@157.245.127.234 "unzip -o ~/allure-report.zip";
+                        script: '''
+                            ssh root@157.245.127.234 "mkdir -p ~/allure-reports/core/${BRANCH_ALIAS}";
+                            scp allure-report.zip root@157.245.127.234:~/allure-reports/core/${BRANCH_ALIAS};
+                            ssh root@157.245.127.234 "unzip -o ~/allure-reports/core/${BRANCH_ALIAS}/allure-report.zip -d ~/allure-reports/core/${BRANCH_ALIAS}/";
                             ssh root@157.245.127.234 "rm -rf /var/www/voight-kampff/core/${BRANCH_ALIAS}";
-                            ssh root@157.245.127.234 "mv allure-report /var/www/voight-kampff/core/${BRANCH_ALIAS}"
-                            scp mycroft-logs.zip root@157.245.127.234:~;
+                            ssh root@157.245.127.234 "mv ~/allure-reports/core/${BRANCH_ALIAS}/allure-report /var/www/voight-kampff/core/${BRANCH_ALIAS}"
+                            ssh root@157.245.127.234 "rm ~/allure-reports/core/${BRANCH_ALIAS}/allure-report.zip";
+                            ssh root@157.245.127.234 "rmdir ~/allure-reports/core/${BRANCH_ALIAS}";
+                            ssh root@157.245.127.234 "mkdir -p ~/mycroft-logs/core/${BRANCH_ALIAS}";
+                            scp mycroft-logs.zip root@157.245.127.234:~/mycroft-logs/core/${BRANCH_ALIAS}/;
                             ssh root@157.245.127.234 "mkdir -p /var/www/voight-kampff/core/${BRANCH_ALIAS}/logs"
-                            ssh root@157.245.127.234 "unzip -oj ~/mycroft-logs.zip -d /var/www/voight-kampff/core/${BRANCH_ALIAS}/logs/";
+                            ssh root@157.245.127.234 "unzip -oj ~/mycroft-logs/core/${BRANCH_ALIAS}/mycroft-logs.zip -d /var/www/voight-kampff/core/${BRANCH_ALIAS}/logs/";
+                            ssh root@157.245.127.234 "rm ~/mycroft-logs/core/${BRANCH_ALIAS}/mycroft-logs.zip";
+                            ssh root@157.245.127.234 "rmdir ~/mycroft-logs/core/${BRANCH_ALIAS}";
                         '''
                     )
                     echo 'Report Published'


### PR DESCRIPTION
## Description
When transferring the Allure report and the Mycroft logs to the report host, the zip files were being written to a common directory. In the event that multiple jobs were writing to or reading from this directory at the same time, conflicts could occur.

This ensures that both zip files are written to unique paths and cleaned up afterward.

Companion PR to https://github.com/MycroftAI/mycroft-skills/pull/1516

## How to test
CI should pass - then verify that both the Allure report and the mycroft-logs are accessible using the links in the comment.
Should also replay it on some other PR's using this modified Jenkins file, particularly ones that expected to fail.

## Contributor license agreement signed?
- [x] CLA
