### PR TITLE
Adapt intent matches not returned to core in confidence order.

### DIFF
--- a/mycroft/skills/intent_services/adapt_service.py
+++ b/mycroft/skills/intent_services/adapt_service.py
@@ -167,11 +167,11 @@ class ContextManager:
 
 
 class AdaptService:
-    """Intent service wrapping the Apdapt intent Parser."""
+    """Intent service wrapping the Adapt intent Parser."""
     def __init__(self, config):
         self.config = config
         self.engine = IntentDeterminationEngine()
-        # Context related intializations
+        # Context related initialization
         self.context_keywords = self.config.get('keywords', [])
         self.context_max_frames = self.config.get('max_frames', 3)
         self.context_timeout = self.config.get('timeout', 2)
@@ -202,8 +202,12 @@ class AdaptService:
         """Run the Adapt engine to search for an matching intent.
 
         Args:
-            utterances (iterable): iterable of utterances, expected order
-                                   [raw, normalized, other]
+            utterances (iterable): utterances for consideration in intent
+                matching. As a practical matter, a single utterance will be
+                passed in most cases.  But there are instances, such as
+                streaming STT that could pass multiple.  Each utterance
+                is represented as a tuple containing the raw, normalized, and
+                possibly other variations of the utterance.
 
         Returns:
             Intent structure, or None if no match was found.
@@ -227,7 +231,11 @@ class AdaptService:
                         include_tags=True,
                         context_manager=self.context_manager)]
                     if intents:
-                        take_best(intents[0], utt_tup[0])
+                        intents_with_best_confidence = max(
+                            intents,
+                            key=lambda intent: intent.get('confidence', 0.0)
+                        )
+                        take_best(intents_with_best_confidence, utt_tup[0])
 
                 except Exception as err:
                     LOG.exception(err)


### PR DESCRIPTION
## Description
The AdaptService in core assumes that the highest confidence intent match will be the first result returned from Adapt. This is not always the case. It is possible that Adapt should be ordering the return value instead. But that would be a bigger change to Adapt.

NOTE: this replaces [PR2915](https://github.com/MycroftAI/mycroft-core/pull/2915)

## How to test
*  Remove the future time Padatious intent from the date/time skill
* Ask "what time will it be in ten minutes"; current time will be returned.
* Apply the change in this PR
* Make same request as before, future time will be returned.

## Contributor license agreement signed?
CLA [Y]
