### PR TITLE
Use event handler to capture messages in then_wait()

### DIFF
--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -111,13 +111,11 @@ def after_all(context):
 def after_feature(context, feature):
     context.log.info('Result: {} ({:.2f}s)'.format(str(feature.status.name),
                                                    feature.duration))
-    sleep(1)
 
 
 def after_scenario(context, scenario):
     """Wait for mycroft completion and reset any changed state."""
     # TODO wait for skill handler complete
-    sleep(0.5)
     wait_while_speaking()
     context.bus.clear_messages()
     context.matched_message = None

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -30,10 +30,6 @@ from test.integrationtests.voight_kampff import (mycroft_responses, then_wait,
                                                  then_wait_fail)
 
 
-TIMEOUT = 10
-SLEEP_LENGTH = 0.25
-
-
 def find_dialog(skill_path, dialog, lang):
     """Check the usual location for dialogs.
 
@@ -253,13 +249,10 @@ def then_user_follow_up(context, text):
 
 @then('mycroft should send the message "{message_type}"')
 def then_messagebus_message(context, message_type):
-    """Set a timeout for the current Scenario."""
-    cnt = 0
-    while context.bus.get_messages(message_type) == []:
-        if cnt > int(TIMEOUT * (1.0 / SLEEP_LENGTH)):
-            assert False, "Message not found"
-            break
-        else:
-            cnt += 1
+    """Verify a specific message is sent."""
+    def check_dummy(message):
+        """We are just interested in the message data, just the type."""
+        return True, ""
 
-        time.sleep(SLEEP_LENGTH)
+    message_found, _ = then_wait(message_type, check_dummy, context)
+    assert message_found, "No matching message received."


### PR DESCRIPTION
## Description
A restructure on how waiting for events work in VK based on comments from @chrisveilleux in #2946.

This removes the handling of every single event by polling the new_message event, instead it sets up a temporary event handler handling the capture of events.

A check of the already captured messages are also made to avoid certain race conditions when messages are sent after the "when" but before the "then" is set up.

## How to test
Make sure the VK tests still passes.

## Contributor license agreement signed?
CLA [ Yes ]