### PR TITLE
VK: Remove mycroft-stock from install list

### DIFF
--- a/test/integrationtests/voight_kampff/default.yml
+++ b/test/integrationtests/voight_kampff/default.yml
@@ -12,7 +12,6 @@ test_skills:
 - mycroft-npr-news
 - mycroft-installer
 - mycroft-singing
-- mycroft-stock
 - mycroft-mark-1
 - fallback-unknown
 - fallback-query


### PR DESCRIPTION
## Description
Remove mycroft-stock from list of skills to include in test-runs, the skill was removed from mycroft-skills so VK tests here stopped working see https://hudson.mycroft.team/blue/organizations/jenkins/mycroft-core/detail/PR-2951/2/pipeline

## How to test
Ensure the VK test passes

## Contributor license agreement signed?
CLA [ Yes ]