### PR TITLE
Fix loading of audioservice plugins

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -111,6 +111,7 @@ def setup_service(service_module, config, bus):
         except Exception as e:
             LOG.error('Failed to load service. ' + repr(e))
     else:
+        LOG.error('Failed to load service. loading function not found')
         return None
 
 
@@ -160,9 +161,10 @@ def load_plugins(config, bus):
         List of started services
     """
     plugin_services = []
-    plugins = find_plugins('mycroft.plugin.audioservice')
-    for plug in plugins:
-        service = setup_service(plug, config, bus)
+    found_plugins = find_plugins('mycroft.plugin.audioservice')
+    for plugin_name, plugin_module in found_plugins.items():
+        LOG.info(f'Loading audio service plugin: {plugin_name}')
+        service = setup_service(plugin_module, config, bus)
         if service:
             plugin_services += service
     return plugin_services


### PR DESCRIPTION
## Description
At some point the return from the `find_plugins()`-function was changed from a list to a dict, the change wasn't reflected in the audioservice. This adds @jarbasal's fix for the issue from HolmesV. I've tested it with the ovos-vlc-plugin as he suggested in #2952 and it works as described.

## How to test
Install the https://github.com/OpenVoiceOS/ovos-vlc-plugin (You may need to manually install the python package `phoneme_guesser` and the system package `VLC` to ensure that it'll work) and check that there is no load failure logged for the plugin. 

## Contributor license agreement signed?
CLA [ Yes ]