### PR TITLE
Update key names in adapt keyword registration message

### DIFF
--- a/mycroft/skills/intent_service_interface.py
+++ b/mycroft/skills/intent_service_interface.py
@@ -44,15 +44,27 @@ class IntentServiceInterface:
 
             vocab_type(str): Keyword reference
             entity (str): Primary keyword
-            aliases (list): List of alternative kewords
+            aliases (list): List of alternative keywords
         """
+        # TODO 22.02: Remove compatibility data
         aliases = aliases or []
-        self.bus.emit(Message("register_vocab",
-                              {'start': entity, 'end': vocab_type}))
+        entity_data = {'entity_value': entity, 'entity_type': vocab_type}
+        compatibility_data = {'start': entity, 'end': vocab_type}
+
+        self.bus.emit(
+            Message("register_vocab",
+                    {**entity_data, **compatibility_data})
+        )
         for alias in aliases:
-            self.bus.emit(Message("register_vocab", {
-                'start': alias, 'end': vocab_type, 'alias_of': entity
-            }))
+            alias_data = {
+                'entity_value': alias,
+                'entity_type': vocab_type,
+                'alias_of': entity}
+            compatibility_data = {'start': alias, 'end': vocab_type}
+            self.bus.emit(
+                Message("register_vocab",
+                        {**alias_data, **compatibility_data})
+            )
 
     def register_adapt_regex(self, regex):
         """Register a regex with the intent service.

--- a/mycroft/skills/intent_services/adapt_service.py
+++ b/mycroft/skills/intent_services/adapt_service.py
@@ -249,14 +249,35 @@ class AdaptService:
             ret = None
         return ret
 
+    # TODO 22.02: Remove this deprecated method
     def register_vocab(self, start_concept, end_concept, alias_of, regex_str):
-        """Register vocabulary."""
+        """Register Vocabulary. DEPRECATED
+
+        This method should not be used, it has been replaced by
+        register_vocabulary().
+        """
+        self.register_vocabulary(start_concept, end_concept,
+                                 alias_of, regex_str)
+
+    def register_vocabulary(self, entity_value, entity_type,
+                            alias_of, regex_str):
+        """Register skill vocabulary as adapt entity.
+
+        This will handle both regex registration and registration of normal
+        keywords. if the "regex_str" argument is set all other arguments will
+        be ignored.
+
+        Argument:
+            entity_value: the natural langauge word
+            entity_type: the type/tag of an entity instance
+            alias_of: entity this is an alternative for
+        """
         with self.lock:
             if regex_str:
                 self.engine.register_regex_entity(regex_str)
             else:
                 self.engine.register_entity(
-                    start_concept, end_concept, alias_of=alias_of)
+                    entity_value, entity_type, alias_of=alias_of)
 
     def register_intent(self, intent):
         """Register new intent with adapt engine.

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1168,9 +1168,8 @@ class MycroftSkill:
             entity:         word to register
             entity_type:    Intent handler entity to tie the word to
         """
-        self.bus.emit(Message('register_vocab', {
-            'start': entity, 'end': to_alnum(self.skill_id) + entity_type
-        }))
+        keyword_type = to_alnum(self.skill_id) + entity_type
+        self.intent_service.register_adapt_keyword(keyword_type, entity)
 
     def register_regex(self, regex_str):
         """Register a new regex.

--- a/test/unittests/skills/test_intent_service_interface.py
+++ b/test/unittests/skills/test_intent_service_interface.py
@@ -25,13 +25,15 @@ class MockEmitter:
         self.results = []
 
 
-class FunctionTest(unittest.TestCase):
-    def check_emitter(self, result_list):
-        for type in self.emitter.get_types():
-            self.assertEqual(type, 'register_vocab')
-        self.assertEqual(sorted(self.emitter.get_results(),
-                                key=lambda d: sorted(d.items())),
-                         sorted(result_list, key=lambda d: sorted(d.items())))
+class KeywordRegistrationTest(unittest.TestCase):
+    def check_emitter(self, expected_message_data):
+        """Verify that the registration messages matches the expected."""
+        for msg_type in self.emitter.get_types():
+            self.assertEqual(msg_type, 'register_vocab')
+        self.assertEqual(
+            sorted(self.emitter.get_results(),
+                   key=lambda d: sorted(d.items())),
+            sorted(expected_message_data, key=lambda d: sorted(d.items())))
         self.emitter.reset()
 
     def setUp(self):

--- a/test/unittests/skills/test_intent_service_interface.py
+++ b/test/unittests/skills/test_intent_service_interface.py
@@ -40,18 +40,40 @@ class FunctionTest(unittest.TestCase):
     def test_register_keyword(self):
         intent_service = IntentServiceInterface(self.emitter)
         intent_service.register_adapt_keyword('test_intent', 'test')
-        self.check_emitter([{'start': 'test', 'end': 'test_intent'}])
+        entity_data = {'entity_value': 'test', 'entity_type': 'test_intent'}
+        compatibility_data = {'start': 'test', 'end': 'test_intent'}
+        expected_data = {**entity_data, **compatibility_data}
+        self.check_emitter([expected_data])
 
     def test_register_keyword_with_aliases(self):
+        # TODO 22.02: Remove compatibility data
         intent_service = IntentServiceInterface(self.emitter)
         intent_service.register_adapt_keyword('test_intent', 'test',
                                               ['test2', 'test3'])
-        self.check_emitter([{'start': 'test', 'end': 'test_intent'},
-                            {'start': 'test2', 'end': 'test_intent',
-                             'alias_of': 'test'},
-                            {'start': 'test3', 'end': 'test_intent',
-                             'alias_of': 'test'},
-                            ])
+
+        entity_data = {'entity_value': 'test', 'entity_type': 'test_intent'}
+        compatibility_data = {'start': 'test', 'end': 'test_intent'}
+        expected_initial_vocab = {**entity_data, **compatibility_data}
+
+        alias_data = {
+            'entity_value': 'test2',
+            'entity_type': 'test_intent',
+            'alias_of': 'test'
+        }
+        alias_compatibility = {'start': 'test2', 'end': 'test_intent'}
+        expected_alias1 = {**alias_data, **alias_compatibility}
+
+        alias_data2 = {
+            'entity_value': 'test3',
+            'entity_type': 'test_intent',
+            'alias_of': 'test'
+        }
+        alias_compatibility2 = {'start': 'test3', 'end': 'test_intent'}
+        expected_alias2 = {**alias_data2, **alias_compatibility2}
+
+        self.check_emitter([expected_initial_vocab,
+                            expected_alias1,
+                            expected_alias2])
 
     def test_register_regex(self):
         intent_service = IntentServiceInterface(self.emitter)

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -303,7 +303,14 @@ class TestMycroftSkill(unittest.TestCase):
 
         # Normal vocaubulary
         self.emitter.reset()
-        expected = [{'start': 'hello', 'end': 'AHelloKeyword'}]
+        expected = [
+            {
+                'start': 'hello',
+                'end': 'AHelloKeyword',
+                'entity_value': 'hello',
+                'entity_type': 'AHelloKeyword'
+            }
+        ]
         s.register_vocabulary('hello', 'HelloKeyword')
         self.check_register_vocabulary(expected)
         # Regex


### PR DESCRIPTION
## Description
This should resolve #2950. It matches the keyword entity terms in Mycroft with the ones used in Adapt. 

This changes the internally used names for entities and entity values when
sent on the messagebus and used internally in the intent service from start / end to entity_value and entity_type.

This makes the terminology easier to understand and follow across into Adapt.

The old terms are still included and usable for compatibility but should be
removed in an upcoming major release (22.02).

## How to test
Ensure VK tests works.

## Contributor license agreement signed?
CLA [ Yes ]