### PR TITLE
scripts: Support busybox chown

### DIFF
--- a/scripts/mycroft-use.sh
+++ b/scripts/mycroft-use.sh
@@ -88,10 +88,10 @@ function restore_init_scripts() {
     sudo sh -c 'cat /etc/init.d/mycroft-admin-service.original > /etc/init.d/mycroft-admin-service'
     sudo rm /etc/init.d/*.original
     chown mycroft:mycroft /home/mycroft/.mycroft/identity/identity2.json
-    sudo chown -Rvf mycroft:mycroft /var/log/mycroft*
-    sudo chown -Rvf mycroft:mycroft /tmp/mycroft
-    sudo chown -Rvf mycroft:mycroft /var/run/mycroft*
-    sudo chown -Rvf mycroft:mycroft /opt/mycroft
+    sudo chown -R mycroft:mycroft /var/log/mycroft*
+    sudo chown -R mycroft:mycroft /tmp/mycroft
+    sudo chown -R mycroft:mycroft /var/run/mycroft*
+    sudo chown -R mycroft:mycroft /opt/mycroft
     sudo chown mycroft:mycroft /var/tmp/mycroft_web_cache.json
 
     # reload daemon scripts
@@ -144,10 +144,10 @@ function github_init_scripts() {
             sudo ln -s /home/mycroft/.mycroft/identity ${HOME}/.mycroft/
         fi
 
-        sudo chown -Rvf ${user}:${user} /var/log/mycroft*
-        sudo chown -Rvf ${user}:${user} /var/run/mycroft*
-        sudo chown -Rvf ${user}:${user} /tmp/mycroft
-        sudo chown -Rvf ${user}:${user} /var/tmp/mycroft_web_cache.json
+        sudo chown -R ${user}:${user} /var/log/mycroft*
+        sudo chown -R ${user}:${user} /var/run/mycroft*
+        sudo chown -R ${user}:${user} /tmp/mycroft
+        sudo chown -R ${user}:${user} /var/tmp/mycroft_web_cache.json
 
         # reload daemon scripts
         sudo systemctl daemon-reload


### PR DESCRIPTION
Those extra options are not enabled in busybox
(at least not the configured version in poky yocto distribution)

This will also help to support systems without coreutils,

Relate-to: https://github.com/MycroftAI/mycroft-core/pull/2686
Signed-off-by: Philippe Coval <philippe.coval@astrolabe.coop>

## Description
(Description of what the PR does, such as fixes # {issue number})

## How to test
(Description of how to validate or test this PR)

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
