### PR TITLE
Voight Kampff: No skill updates at runtime

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -96,7 +96,7 @@ FROM core_builder as voight_kampff_builder
 ARG platform
 # Setup a dummy TTS backend for the audio process
 RUN mkdir /etc/mycroft
-RUN echo '{"tts": {"module": "dummy"}}' > /etc/mycroft/mycroft.conf
+RUN echo '{"tts": {"module": "dummy"}, "skills": {"auto_update": false}}' > /etc/mycroft/mycroft.conf
 RUN mkdir ~/.mycroft/allure-result
 
 # The behave feature files for a skill are defined within the skill's


### PR DESCRIPTION
## Description
A lot of the skill logs are covered in msm update messages, the updates should generally not make any changes in VK and can't be verified so they are superfluous.

## How to test
Ensure there are no msm update logs in the VK output.

## Contributor license agreement signed?
CLA [ Yes ]