### PR TITLE
Provide AdaptIntent from mycroft.skills

### DIFF
--- a/mycroft/skills/__init__.py
+++ b/mycroft/skills/__init__.py
@@ -20,6 +20,7 @@ These classes, decorators and functions are used to build skills for Mycroft.
 
 from .mycroft_skill import (MycroftSkill, intent_handler, intent_file_handler,
                             resting_screen_handler, skill_api_method)
+from .intent_service import AdaptIntent
 from .fallback_skill import FallbackSkill
 from .common_iot_skill import CommonIoTSkill
 from .common_play_skill import CommonPlaySkill, CPSMatchLevel


### PR DESCRIPTION
## Description
This is convenience addition for Skill developers who can now import all standard items for both Adapt and Padatious from a single level.

```
from mycroft.skills import MycroftSkill, intent_handler, AdaptIntent
```

Currently you need to have:

```
from mycroft.skills import MycroftSkill, intent_handler
from mycroft.skills.intent_service import AdaptIntent
```

## How to test
Replace current imports in Hello World Skill with the above and run VK.

## Contributor license agreement signed?
- [x] CLA
