### PR TITLE
Install pulseaudio-utils on Fedora

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -366,7 +366,7 @@ function open_suse_install() {
 
 
 function fedora_install() {
-    $SUDO dnf install -y git python3 python3-devel python3-pip python3-setuptools python3-virtualenv pygobject3-devel libtool libffi-devel openssl-devel autoconf bison swig glib2-devel portaudio-devel mpg123 mpg123-plugins-pulseaudio screen curl pkgconfig libicu-devel automake libjpeg-turbo-devel fann-devel gcc-c++ redhat-rpm-config jq make
+    $SUDO dnf install -y git python3 python3-devel python3-pip python3-setuptools python3-virtualenv pygobject3-devel libtool libffi-devel openssl-devel autoconf bison swig glib2-devel portaudio-devel mpg123 mpg123-plugins-pulseaudio screen curl pkgconfig libicu-devel automake libjpeg-turbo-devel fann-devel gcc-c++ redhat-rpm-config jq make pulseaudio-utils
 }
 
 


### PR DESCRIPTION
## Description

Install `pulseaudio-utils` on Fedora to make sure we have the `paplay` command.

## How to test

Remove `pulseaudio-utils` package (this is not present by default on Fedora Toolbox containers), then re-run `dev-setup.sh`

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
