### PR TITLE
Use response method for track_info handler

### DIFF
--- a/mycroft/audio/audioservice.py
+++ b/mycroft/audio/audioservice.py
@@ -484,8 +484,7 @@ class AudioService:
             track_info = self.current.track_info()
         else:
             track_info = {}
-        self.bus.emit(Message('mycroft.audio.service.track_info_reply',
-                              data=track_info))
+        self.bus.emit(message.response(track_info))
 
     def _list_backends(self, message):
         """ Return a dict of available backends. """

--- a/mycroft/skills/audioservice.py
+++ b/mycroft/skills/audioservice.py
@@ -148,7 +148,6 @@ class AudioService:
         """
         info = self.bus.wait_for_response(
             Message('mycroft.audio.service.track_info'),
-            reply_type='mycroft.audio.service.track_info_reply',
             timeout=1)
         return info.data if info else {}
 


### PR DESCRIPTION
## Description
The `audioservice.track_info` handler was using a custom reply message, which is an older form of replying to a message.

This required you to know what the `reply_type` is eg:
```
response = self.bus.wait_for_response(
            Message('mycroft.audio.service.track_info'),
            reply_type='mycroft.audio.service.track_info_reply')
```

The new format is automatic:
```
response = self.bus.wait_for_response(
            Message('mycroft.audio.service.track_info'))
```

This is a breaking change as any calls expecting the custom reply_type will break. Creating the PR now so that we can switch it over in the next major release.

## How to test
Using the new standard format of `wait_for_response` as above will currently result in no response being received. With this change, the reply conforms to the new standard and will be returned correctly.