### PR TITLE
VK: Only stop Mycroft services if running in CI

### DIFF
--- a/test/integrationtests/voight_kampff/run_test_suite.sh
+++ b/test/integrationtests/voight_kampff/run_test_suite.sh
@@ -18,8 +18,10 @@ ${SCRIPT_DIR}/../../../start-mycroft.sh all
 echo "Running behave with the arguments \"$@\""
 behave $@
 RESULT=$?
-# Stop all mycroft core services.
-${SCRIPT_DIR}/../../../stop-mycroft.sh all
+if [[ -v CI ]]; then
+    # Stop all mycroft core services if running in CI environment.
+    ${SCRIPT_DIR}/../../../stop-mycroft.sh all
+fi
 
 # Reort the result of the behave test as exit status
 exit $RESULT


### PR DESCRIPTION
## Description
When running tests locally, a reasonable amount of time is spent starting and stopping Mycroft services. Rapidly doing this can also cause broader issues. Shutting down services at the end of a Voight Kampff test run in the CI makes sense, but it doesn't make sense for me personally when running locally. 

This is the simplest implementation which provides one behaviour for CI, and the other behaviour for "not-CI". Is this sufficient or do we need to add in one or more arguments? eg: 
```shell
# assume shutdown by default on all systems
mycroft-start vktest --no-stop-on-finish -t my-skill
```
or
```shell
# shutdown by default on CI, do not shutdown by default on non-CI but provide the option
mycroft-start vktest --stop-on-finish -t my-skill
```

## How to test
Run some VK tests locally and see that Mycroft is still running after the tests complete. 
You can now run the tests repeatedly, much faster than you could previously.

## Contributor license agreement signed?
- [x] CLA
