### PR TITLE
Release GUI on Skill shutdown or reload

### DIFF
--- a/mycroft/enclosure/gui.py
+++ b/mycroft/enclosure/gui.py
@@ -373,5 +373,5 @@ class SkillGUI:
         Clear pages loaded through this interface and remove the skill
         reference to make ref counting warning more precise.
         """
-        self.clear()
+        self.release()
         self.skill = None


### PR DESCRIPTION
## Description
When a Skill shuts down, the GUI data is cleared but not released. This removes the Skill reference on shutdown.

## Contributor license agreement signed?
- [x] CLA
