### PR TITLE
Add method to remove any entries from a .voc file from a string.

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -669,6 +669,33 @@ class MycroftSkill:
         else:
             return False
 
+    def remove_voc(self, utterance, voc_filename, lang=None):
+        """Removes any entries in a .voc file from the provided string.
+
+        The vocab matching is not case sensitive.
+
+        Args:
+            utterance (str): String to remove entries from
+            voc_filename (str): Name of vocabulary file (e.g. 'yes' for
+                                'res/text/en-us/yes.voc')
+            lang (str): Language code, defaults to self.lang
+        Returns:
+            str: utterance with .voc entries removed
+        """
+        lang = lang or self.lang
+        cache_key = lang + voc_filename
+
+        if cache_key not in self.voc_match_cache:
+            self.voc_match(utterance, voc_filename, lang)
+
+        if utterance:
+            # Check for matches against complete words
+            for entry in self.voc_match_cache.get(cache_key) or []:
+                # Substitute only whole words matching the token
+                utterance = re.sub(r'\b' + entry + r"\b", "", utterance,
+                                   flags=re.IGNORECASE)
+        return utterance
+
     def report_metric(self, name, data):
         """Report a skill metric to the Mycroft servers.
 

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -563,6 +563,18 @@ class TestMycroftSkill(unittest.TestCase):
         self.assertFalse(s.voc_match("would you please turn off the lights",
                                      "turn_off_test", exact=True))
 
+    def test_remove_voc(self):
+        s = SimpleSkill1()
+        s.root_dir = abspath(dirname(__file__))
+        self.assertEqual(s.remove_voc("yes", "yes"), "")
+        self.assertEqual(s.remove_voc("yes please", "yes"), " ")
+        self.assertEqual(s.remove_voc("yes thank you", "yes"), " thank you")
+        self.assertEqual(s.remove_voc("I would like the last option", "last"),
+                         "I would like the ")
+        self.assertEqual(s.remove_voc("Never forget that",
+                         "cancel"), "Never forget that")
+        self.assertEqual(s.remove_voc("Never Forget it", "cancel"), "Never ")
+
     def test_translate_locations(self):
         """Assert that the a translatable list can be loaded from dialog and
         locale.

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -567,13 +567,13 @@ class TestMycroftSkill(unittest.TestCase):
         s = SimpleSkill1()
         s.root_dir = abspath(dirname(__file__))
         self.assertEqual(s.remove_voc("yes", "yes"), "")
-        self.assertEqual(s.remove_voc("yes please", "yes"), " ")
-        self.assertEqual(s.remove_voc("yes thank you", "yes"), " thank you")
+        self.assertEqual(s.remove_voc("yes please", "yes"), "")
+        self.assertEqual(s.remove_voc("yes thank you", "yes"), "thank you")
         self.assertEqual(s.remove_voc("I would like the last option", "last"),
-                         "I would like the ")
+                         "I would like the")
         self.assertEqual(s.remove_voc("Never forget that",
                          "cancel"), "Never forget that")
-        self.assertEqual(s.remove_voc("Never Forget it", "cancel"), "Never ")
+        self.assertEqual(s.remove_voc("Never Forget it", "cancel"), "Never")
 
     def test_translate_locations(self):
         """Assert that the a translatable list can be loaded from dialog and


### PR DESCRIPTION
## Description
The `remove_voc` method complements the existing vocab matching tools.

It is useful to clean utterances of common articles or other noise when parsing for specific information. 

This method is not case sensitive unlike the other vocab matching methods. Is the case sensitivity intentional? Should we make all methods case insensitive?

Context: I was needing this type of method today, then saw the same need had been identified in https://github.com/MycroftAI/mycroft-core/pull/2986 and an existing method to do it [already existed in OVOS](https://github.com/OpenVoiceOS/OVOS-workshop/blob/8d2b274084520154ab9c36dc6c78ed6f7cf13b44/ovos_workshop/patches/base_skill.py#L165)

## How to test
Unit tests included

## Contributor license agreement signed?
- [x] CLA
