### PR TITLE
Fix messages clearing in the InterceptAllBusClient

### DIFF
--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -93,7 +93,7 @@ class InterceptAllBusClient(MessageBusClient):
     def clear_messages(self):
         """Clear all messages that has been fetched atleast once."""
         with self.message_lock:
-            self.messages = self.messages[:self._processed_messages]
+            self.messages = self.messages[self._processed_messages:]
             self._processed_messages = 0
 
     def clear_all_messages(self):

--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -38,9 +38,9 @@ def create_voight_kampff_logger():
 
 
 class InterceptAllBusClient(MessageBusClient):
-    """Bus Client storing all messages recieved.
+    """Bus Client storing all messages received.
 
-    This allows readback of older messages and non-event-driven operation.
+    This allows read back of older messages and non-event-driven operation.
     """
     def __init__(self):
         super().__init__()
@@ -50,7 +50,7 @@ class InterceptAllBusClient(MessageBusClient):
         self._processed_messages = 0
 
     def on_message(self, message):
-        """Extends normal operation by storing the recieved message.
+        """Extends normal operation by storing the received message.
 
         Args:
             message (Message): message from the Mycroft bus
@@ -64,7 +64,7 @@ class InterceptAllBusClient(MessageBusClient):
         """Get messages from received list of messages.
 
         Args:
-            msg_type (None,str): string filter for messagetype to extract.
+            msg_type (None,str): string filter for the message type to extract.
                                  if None all messages will be returned.
         """
         with self.message_lock:
@@ -91,7 +91,7 @@ class InterceptAllBusClient(MessageBusClient):
             self.messages.remove(msg)
 
     def clear_messages(self):
-        """Clear all messages that has been fetched atleast once."""
+        """Clear all messages that has been fetched at least once."""
         with self.message_lock:
             self.messages = self.messages[self._processed_messages:]
             self._processed_messages = 0


### PR DESCRIPTION
## Description
The logic that is intended to clear processed messages was clearing messages that have not yet been read, not messages that have already been read.

## How to test
Run a test that uses the clear_messages function in the InterceptAllBusClient.

## Contributor license agreement signed?
CLA [X] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
