### PR TITLE
Fix pulseaudio daemon failing to start in CI

### DIFF
--- a/test/integrationtests/voight_kampff/run_test_suite.sh
+++ b/test/integrationtests/voight_kampff/run_test_suite.sh
@@ -9,6 +9,10 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Start pulseaudio if running in CI environment
 if [[ -v CI ]]; then
+    # Ensure pulseaudio is stateless on start up
+    # This stops the daemon from randomly failing on startup
+    # See https://superuser.com/a/1545361 for more info
+    rm -rf /root/.config/pulse
     pulseaudio -D
 fi
 # Start all mycroft core services.


### PR DESCRIPTION
## Description
This fixes an issue in the CI runs of Voight Kampff where the pulseaudio daemon would fail on load. 

This failure would result in the Volume Skill always failing it's tests.

This change has been manually applied to the 21.2.1 VK Docker image to enable: https://github.com/MycroftAI/mycroft-skills/pull/1566

Fixes: https://github.com/MycroftAI/mycroft-skills/issues/1560

## How to test
See the [build history of Mycroft-Skill PR-1566](https://hudson.mycroft.team/blue/organizations/jenkins/mycroft-skills/detail/PR-1566/17/pipeline/). It was consistently failing to start the pulse daemon.
The failure can be found very close to the top of the `docker run` step, eg [here](https://hudson.mycroft.team/blue/organizations/jenkins/mycroft-skills/detail/PR-1566/12/pipeline/)

Fix has been applied to the latest run. The checks on this PR should also pass.

## Contributor license agreement signed?
- [x] CLA
