### PR TITLE
Intent service support for multiple languages

### DIFF
--- a/mycroft/skills/__main__.py
+++ b/mycroft/skills/__main__.py
@@ -199,8 +199,11 @@ def main(alive_hook=on_alive, started_hook=on_started, ready_hook=on_ready,
     # Create PID file, prevent multiple instances of this service
     mycroft.lock.Lock('skills')
     config = Configuration.get()
-    lang_code = config.get("lang", "en-us")
-    load_languages([lang_code, "en-us"])
+    lang = config.get("lang", "en-us")
+    supported_langs = config.get('supported_langs', [lang])
+    if lang not in supported_langs:
+        supported_langs.append(lang)
+    load_languages([*supported_langs, "en-us"])
 
     # Connect this process to the Mycroft message bus
     bus = start_message_bus_client("SKILLS")

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -304,6 +304,8 @@ class IntentService:
 
                 # Launch skill if not handled by the match function
                 if match.intent_type:
+                    if 'lang' not in match.intent_data:
+                        match.intent_data['lang'] = lang
                     reply = message.reply(match.intent_type, match.intent_data)
                     self.bus.emit(reply)
 
@@ -358,8 +360,9 @@ class IntentService:
         end_concept = message.data.get('end')
         regex_str = message.data.get('regex')
         alias_of = message.data.get('alias_of')
+        lang = message.data.get('lang')
         self.adapt_service.register_vocab(start_concept, end_concept,
-                                          alias_of, regex_str)
+                                          alias_of, regex_str, lang)
         self.registered_vocab.append(message.data)
 
     def handle_register_intent(self, message):

--- a/mycroft/skills/intent_service_interface.py
+++ b/mycroft/skills/intent_service_interface.py
@@ -39,7 +39,8 @@ class IntentServiceInterface:
     def set_bus(self, bus):
         self.bus = bus
 
-    def register_adapt_keyword(self, vocab_type, entity, aliases=None):
+    def register_adapt_keyword(self, vocab_type, entity,
+                               aliases=None, lang=None):
         """Send a message to the intent service to add an Adapt keyword.
 
             vocab_type(str): Keyword reference
@@ -48,20 +49,26 @@ class IntentServiceInterface:
         """
         aliases = aliases or []
         self.bus.emit(Message("register_vocab",
-                              {'start': entity, 'end': vocab_type}))
+                              {'start': entity,
+                               'end': vocab_type,
+                               'lang': lang}))
         for alias in aliases:
             self.bus.emit(Message("register_vocab", {
-                'start': alias, 'end': vocab_type, 'alias_of': entity
+                'start': alias,
+                'end': vocab_type,
+                'alias_of': entity,
+                'lang': lang
             }))
 
-    def register_adapt_regex(self, regex):
+    def register_adapt_regex(self, regex, lang):
         """Register a regex with the intent service.
 
         Args:
             regex (str): Regex to be registered, (Adapt extracts keyword
                          reference from named match group.
         """
-        self.bus.emit(Message("register_vocab", {'regex': regex}))
+        self.bus.emit(Message("register_vocab",
+                      {'regex': regex, 'lang': lang}))
 
     def register_adapt_intent(self, name, intent_parser):
         """Register an Adapt intent parser object.
@@ -363,8 +370,10 @@ class IntentQueryApi:
                     lines = f.read().replace("(", "").replace(")", "").split(
                         "\n")
                 samples = []
-                for l in lines:
-                    samples += [a.strip() for a in l.split("|") if a.strip()]
+                for line in lines:
+                    samples += [a.strip()
+                                for a in line.split("|")
+                                if a.strip()]
                 entities.append({"name": ent["name"], "samples": samples})
         return entities
 

--- a/mycroft/skills/intent_service_interface.py
+++ b/mycroft/skills/intent_service_interface.py
@@ -107,7 +107,7 @@ class IntentServiceInterface:
         """
         self.bus.emit(Message('remove_context', {'context': context}))
 
-    def register_padatious_intent(self, intent_name, filename):
+    def register_padatious_intent(self, intent_name, filename, lang):
         """Register a padatious intent file with Padatious.
 
         Args:
@@ -120,11 +120,12 @@ class IntentServiceInterface:
             raise FileNotFoundError('Unable to find "{}"'.format(filename))
 
         data = {"file_name": filename,
-                "name": intent_name}
+                "name": intent_name,
+                "lang": lang}
         self.bus.emit(Message("padatious:register_intent", data))
         self.registered_intents.append((intent_name.split(':')[-1], data))
 
-    def register_padatious_entity(self, entity_name, filename):
+    def register_padatious_entity(self, entity_name, filename, lang):
         """Register a padatious entity file with Padatious.
 
         Args:
@@ -138,7 +139,8 @@ class IntentServiceInterface:
 
         self.bus.emit(Message('padatious:register_entity', {
             'file_name': filename,
-            'name': entity_name
+            'name': entity_name,
+            "lang": lang
         }))
 
     def __iter__(self):

--- a/mycroft/skills/intent_services/padatious_service.py
+++ b/mycroft/skills/intent_services/padatious_service.py
@@ -137,11 +137,6 @@ class PadatiousService:
         for i in remove_list:
             self.__detach_intent(i)
 
-    def get_file_lang(self, file_name):
-        _path, _ = path.split(file_name)
-        _, _name = path.split(_path)
-        return _name
-
     def _register_object(self, message, object_name, register_func):
         """Generic method for registering a padatious object.
 
@@ -168,7 +163,7 @@ class PadatiousService:
         Args:
             message (Message): message triggering action
         """
-        lang = self.get_file_lang(message.data['file_name'])
+        lang = message.data['lang']
         if lang in self.supported_langs:
             if message.data['name'] not in self.registered_intents:
                 self.registered_intents.append(message.data['name'])
@@ -181,7 +176,7 @@ class PadatiousService:
         Args:
             message (Message): message triggering action
         """
-        lang = self.get_file_lang(message.data['file_name'])
+        lang = message.data['lang']
         if lang in self.supported_langs:
             self.registered_entities.append(message.data)
             self._register_object(

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1040,7 +1040,8 @@ class MycroftSkill:
                 LOG.Error(
                     'Unable to find "{}" ("{}")'.format(intent_file, lang))
             else:
-                self.intent_service.register_padatious_intent(name, filename)
+                self.intent_service.register_padatious_intent(
+                    name, filename, lang)
                 found = True
         if handler and found:
             self.add_event(name, handler, 'mycroft.skill.handler')
@@ -1071,7 +1072,8 @@ class MycroftSkill:
             if not filename:
                 LOG.Error('Unable to find "{}"'.format(entity_file))
             else:
-                self.intent_service.register_padatious_entity(name, filename)
+                self.intent_service.register_padatious_entity(
+                    name, filename, lang)
 
     def handle_enable_intent(self, message):
         """Listener to enable a registered intent if it belongs to this skill.
@@ -1193,7 +1195,9 @@ class MycroftSkill:
             entity_type:    Intent handler entity to tie the word to
         """
         self.bus.emit(Message('register_vocab', {
-            'start': entity, 'end': to_alnum(self.skill_id) + entity_type
+            'start': entity,
+            'end': to_alnum(self.skill_id) + entity_type,
+            'lang': self.lang
         }))
 
     def register_regex(self, regex_str):

--- a/mycroft/skills/skill_data.py
+++ b/mycroft/skills/skill_data.py
@@ -65,8 +65,12 @@ def load_regex_from_file(path, skill_id):
                 regex = munge_regex(line.strip(), skill_id)
                 LOG.debug('regex post-munge: ' + regex)
                 # Raise error if regex can't be compiled
-                re.compile(regex)
-                regexes.append(regex)
+                try:
+                    re.compile(regex)
+                    regexes.append(regex)
+                except Exception as e:
+                    LOG.warning('failed to compile regex {}: {}'.format(
+                        regex, e))
 
     return regexes
 


### PR DESCRIPTION
## Description
New (optional) parameter in Mycroft config file: "supported_langs" consisting on an array of languages, for example {"supported_langs": ["en-us", "es-es"]}

Based in this parameter Mycroft will:
-Create multiple language dialog renders
-Create multiple adapt and padatious containers that will be used to match the intent based on the message's language
-Each adapt and padatious container is trained using only the language is set to.
-Skills self.lang property is temporarily modified to match the intent language.
-Language is included in skill's speak bus messages for future multi-language TTS support.

This PR is meant for future development and for current usage with [HiveMind-core](https://github.com/JarbasHiveMind/skill-hivemind) as there are some clients such as [this fork of the voice satellite](https://github.com/Joanguitar/HiveMind-voice-sat) that already support multiple language support.

After this PR gets approved I will work on multi-language TTS support.

## How to test
Easiest way to test is to configure multiple languages including the supported_langs parameter in Mycroft's config file and then inject a message in the messagebus in any of the supported languages. For example:
```
from mycroft_bus_client import MessageBusClient, Message

print('Setting up client to connect to a local mycroft instance')
client = MessageBusClient()
client.run_in_thread()

print('Sending speak message...')
client.emit(Message(
    'recognizer_loop:utterance',
    data={'utterances': ['que hora es'], 'lang': 'es-es'},
    context={
        'client_name': 'mycroft_cli',
        'source': 'debug_cli',
        'destination': ['skills']}
    ))
```
The code above will inject a message in Spanish pretending to be the debug cli, therefore printing the answer in the debug_cli if this one is open.

## Contributor license agreement signed?
CLA [x]
Yes, I have already signed the CLA.