### PR TITLE
Patch dependencies that use the deprecated use_2to3

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,7 +5,8 @@ pytest-cov==2.8.1
 cov-core==1.15.0
 sphinx==2.2.1
 sphinx-rtd-theme==0.4.3
-git+https://github.com/behave/behave@v1.2.7.dev1
+https://github.com/krisgesling/tag-expressions-python/tarball/master/
+https://github.com/krisgesling/behave/tarball/master/
 allure-behave==2.8.10
 
 python-vlc==1.1.2


### PR DESCRIPTION
## Description
Setuptools deprecated use of `use_2to3` from v58 (see [changelog](https://setuptools.readthedocs.io/en/latest/history.html#v58-0-0))

This is still included in the behave and cucumber-tag-expressions packages. The problem has been reported upstream to both packages. The simplest short term fix while waiting for upstream seems to be using forked versions and removing Python2 support. It's more difficult to pin setuptools as this is installed via system packages in dev_setup.sh

The reason this is a problem, is that the pip install of behave and cucumber-tag-expressions are currently failing when using the pip git install method in Github Actions. See: 
https://github.com/MycroftAI/mycroft-core/runs/3530814664?check_suite_focus=true#step:7:407

This change means these two packages will instead be installed from a patched fork of each package. These could be moved into the Mycroft org, but I expect them to be temporary patches until upstream releases a new version. 

Alternatively we could enforce a specific version of setuptools < v58.

## How to test
Run `dev_setup.sh` and ensure it installs cleanly.
Run unit and VK tests to ensure they succeed.

## Contributor license agreement signed?
- [x] CLA
