### PR TITLE
Add 'utterances' to message emitted to skill intent handler

### DIFF
--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -305,7 +305,8 @@ class IntentService:
                 # Launch skill if not handled by the match function
                 if match.intent_type:
                     reply = message.reply(match.intent_type, match.intent_data)
-                    reply.data["utterances"] = utterances  # Add back original utterances for intent handlers
+                    # Add back original utterances for intent handlers
+                    reply.data["utterances"] = utterances
                     self.bus.emit(reply)
 
             else:

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -305,6 +305,7 @@ class IntentService:
                 # Launch skill if not handled by the match function
                 if match.intent_type:
                     reply = message.reply(match.intent_type, match.intent_data)
+                    reply.data["utterances"] = utterances  # Add back original utterances for intent handlers
                     self.bus.emit(reply)
 
             else:

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -305,8 +305,9 @@ class IntentService:
                 # Launch skill if not handled by the match function
                 if match.intent_type:
                     reply = message.reply(match.intent_type, match.intent_data)
-                    # Add back original utterances for intent handlers
-                    # match.intent_data only includes the utterance with the highest confidence
+                    # Add back original list of utterances for intent handlers
+                    # match.intent_data only includes the utterance with the
+                    # highest confidence.
                     reply.data["utterances"] = utterances
                     self.bus.emit(reply)
 

--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -306,6 +306,7 @@ class IntentService:
                 if match.intent_type:
                     reply = message.reply(match.intent_type, match.intent_data)
                     # Add back original utterances for intent handlers
+                    # match.intent_data only includes the utterance with the highest confidence
                     reply.data["utterances"] = utterances
                     self.bus.emit(reply)
 


### PR DESCRIPTION
## Description
Adds `utterances` to message.data that is passed to skill intent handlers. This allows intent handlers to use all transcriptions for STT modules that return alternative transcriptions which may be useful if extracting numbers or other entities that may be present in alternate transcriptions. This also lets intent handlers utilize the same data that is now passed to `converse()` (as of #2813 ).

## How to test
This PR should have no breaking changes or affect behavior in any existing skills. Intent handler methods should now be able to reference the list `message.data["utterances"]` which will contain `message.data["utterance"]`

## Contributor license agreement signed?
CLA [X] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
