### PR TITLE
fixed an error with message formatting in a ValueError message

### DIFF
--- a/test/integrationtests/voight_kampff/features/environment.py
+++ b/test/integrationtests/voight_kampff/features/environment.py
@@ -82,7 +82,7 @@ class InterceptAllBusClient(MessageBusClient):
         """
         with self.message_lock:
             if msg not in self.messages:
-                raise ValueError(f'{msg} was not found in '
+                raise ValueError(f'{msg.msg_type} was not found in '
                                  'the list of messages.')
             # Update processed message count if a read message was removed
             if self.messages.index(msg) < self._processed_messages:


### PR DESCRIPTION
## Description
There is a bug in formatting the message passed to the ValueError raised when the InterceptAllBusClient attempts to remove a message that no longer in the client's buffer.

## How to test
Run a Voight-Kampff test that tries to remove a message from the bus that has already been removed.

## Contributor license agreement signed?
CLA [Y] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
