### PR TITLE
Padatious doesn't need to run 3 times

### DIFF
--- a/mycroft/skills/intent_service.py
+++ b/mycroft/skills/intent_service.py
@@ -21,7 +21,10 @@ from mycroft.util.log import LOG
 from mycroft.util.parse import normalize
 from mycroft.metrics import report_timing, Stopwatch
 from .intent_services import (
-    AdaptService, AdaptIntent, FallbackService, PadatiousService, IntentMatch
+    AdaptService, AdaptIntent,
+    FallbackService,
+    PadatiousService, PadatiousMatcher,
+    IntentMatch
 )
 from .intent_service_interface import open_intent_envelope
 
@@ -280,13 +283,16 @@ class IntentService:
 
             stopwatch = Stopwatch()
 
+            # Create matchers
+            padatious_matcher = PadatiousMatcher(self.padatious_service)
+
             # List of functions to use to match the utterance with intent.
             # These are listed in priority order.
             match_funcs = [
-                self._converse, self.padatious_service.match_high,
+                self._converse, padatious_matcher.match_high,
                 self.adapt_service.match_intent, self.fallback.high_prio,
-                self.padatious_service.match_medium, self.fallback.medium_prio,
-                self.padatious_service.match_low, self.fallback.low_prio
+                padatious_matcher.match_medium, self.fallback.medium_prio,
+                padatious_matcher.match_low, self.fallback.low_prio
             ]
 
             match = None
@@ -438,17 +444,20 @@ class IntentService:
         lang = message.data.get("lang", "en-us")
         combined = _normalize_all_utterances([utterance])
 
+        # Create matchers
+        padatious_matcher = PadatiousMatcher(self.padatious_service)
+
         # List of functions to use to match the utterance with intent.
         # These are listed in priority order.
         # TODO once we have a mechanism for checking if a fallback will
         #  trigger without actually triggering it, those should be added here
         match_funcs = [
-            self.padatious_service.match_high,
+            padatious_matcher.match_high,
             self.adapt_service.match_intent,
             # self.fallback.high_prio,
-            self.padatious_service.match_medium,
+            padatious_matcher.match_medium,
             # self.fallback.medium_prio,
-            self.padatious_service.match_low,
+            padatious_matcher.match_low,
             # self.fallback.low_prio
         ]
         # Loop through the matching functions until a match is found.

--- a/mycroft/skills/intent_services/__init__.py
+++ b/mycroft/skills/intent_services/__init__.py
@@ -1,4 +1,4 @@
 from .adapt_service import AdaptService, AdaptIntent
 from .base import IntentMatch
 from .fallback_service import FallbackService
-from .padatious_service import PadatiousService
+from .padatious_service import PadatiousService, PadatiousMatcher

--- a/mycroft/skills/intent_services/padatious_service.py
+++ b/mycroft/skills/intent_services/padatious_service.py
@@ -26,6 +26,76 @@ from mycroft.util.log import LOG
 from .base import IntentMatch
 
 
+class PadatiousMatcher:
+    """Matcher class to avoid redundancy in padatious intent matching."""
+    def __init__(self, service):
+        self.service = service
+        self.has_result = False
+        self.ret = None
+        self.conf = None
+
+    def _match_level(self, utterances, limit):
+        """Match intent and make sure a certain level of confidence is reached.
+
+        Args:
+            utterances (list of tuples): Utterances to parse, originals paired
+                                         with optional normalized version.
+            limit (float): required confidence level.
+        """
+        if not self.has_result:
+            padatious_intent = None
+            LOG.debug('Padatious Matching confidence > {}'.format(limit))
+            for utt in utterances:
+                for variant in utt:
+                    intent = self.service.calc_intent(variant)
+                    if intent:
+                        best = padatious_intent.conf \
+                            if padatious_intent else 0.0
+                        if best < intent.conf:
+                            padatious_intent = intent
+                            padatious_intent.matches['utterance'] = utt[0]
+
+            if padatious_intent:
+                skill_id = padatious_intent.name.split(':')[0]
+                self.ret = IntentMatch(
+                    'Padatious', padatious_intent.name,
+                    padatious_intent.matches, skill_id
+                )
+                self.conf = padatious_intent.conf
+            self.has_result = True
+
+        if self.conf and self.conf > limit:
+            return self.ret
+        return None
+
+    def match_high(self, utterances, _=None, __=None):
+        """Intent matcher for high confidence.
+
+        Args:
+            utterances (list of tuples): Utterances to parse, originals paired
+                                         with optional normalized version.
+        """
+        return self._match_level(utterances, 0.95)
+
+    def match_medium(self, utterances, _=None, __=None):
+        """Intent matcher for medium confidence.
+
+        Args:
+            utterances (list of tuples): Utterances to parse, originals paired
+                                         with optional normalized version.
+        """
+        return self._match_level(utterances, 0.8)
+
+    def match_low(self, utterances, _=None, __=None):
+        """Intent matcher for low confidence.
+
+        Args:
+            utterances (list of tuples): Utterances to parse, originals paired
+                                         with optional normalized version.
+        """
+        return self._match_level(utterances, 0.5)
+
+
 class PadatiousService:
     """Service class for padatious intent matching."""
     def __init__(self, bus, config):
@@ -166,62 +236,6 @@ class PadatiousService:
         """
         self.registered_entities.append(message.data)
         self._register_object(message, 'entity', self.container.load_entity)
-
-    def _match_level(self, utterances, limit):
-        """Match intent and make sure a certain level of confidence is reached.
-
-        Args:
-            utterances (list of tuples): Utterances to parse, originals paired
-                                         with optional normalized version.
-            limit (float): required confidence level.
-        """
-        padatious_intent = None
-        LOG.debug('Padatious Matching confidence > {}'.format(limit))
-        for utt in utterances:
-            for variant in utt:
-                intent = self.calc_intent(variant)
-                if intent:
-                    best = padatious_intent.conf if padatious_intent else 0.0
-                    if best < intent.conf:
-                        padatious_intent = intent
-                        padatious_intent.matches['utterance'] = utt[0]
-
-        if padatious_intent and padatious_intent.conf > limit:
-            skill_id = padatious_intent.name.split(':')[0]
-            ret = IntentMatch(
-                'Padatious', padatious_intent.name, padatious_intent.matches,
-                skill_id
-            )
-        else:
-            ret = None
-        return ret
-
-    def match_high(self, utterances, _=None, __=None):
-        """Intent matcher for high confidence.
-
-        Args:
-            utterances (list of tuples): Utterances to parse, originals paired
-                                         with optional normalized version.
-        """
-        return self._match_level(utterances, 0.95)
-
-    def match_medium(self, utterances, _=None, __=None):
-        """Intent matcher for medium confidence.
-
-        Args:
-            utterances (list of tuples): Utterances to parse, originals paired
-                                         with optional normalized version.
-        """
-        return self._match_level(utterances, 0.8)
-
-    def match_low(self, utterances, _=None, __=None):
-        """Intent matcher for low confidence.
-
-        Args:
-            utterances (list of tuples): Utterances to parse, originals paired
-                                         with optional normalized version.
-        """
-        return self._match_level(utterances, 0.5)
 
     @lru_cache(maxsize=2)  # 2 catches both raw and normalized utts in cache
     def calc_intent(self, utt):


### PR DESCRIPTION
## Description
New class PadatiousMatcher created to avoid running Padatious intent service 3 times when a low priority callback happens.
Instead, the new class stores the result from the first call and uses it on subsequent calls with different match priority.

## How to test
There's no new feature, the way to see its impact is by getting faster low priority fallbacks.
So just say something to Mycroft that it shouldn't understand and see that it takes shorter for it to reply.