### PR TITLE
Fixed formatting error in skill loader log message

### DIFF
--- a/mycroft/skills/skill_loader.py
+++ b/mycroft/skills/skill_loader.py
@@ -41,7 +41,7 @@ def remove_submodule_refs(module_name):
         module_name: name of skill module.
     """
     submodules = []
-    LOG.debug('Skill module'.format(module_name))
+    LOG.debug('Skill module: {}'.format(module_name))
     # Collect found submodules
     for m in sys.modules:
         if m.startswith(module_name + '.'):


### PR DESCRIPTION
## Description
There were no curly braces in a log message to mark where the module name should go in the message.

## How to test
Restart Mycroft with debug logging turned on.  Look for a log message that starts with "Skill module:"  the name of the module should appear after the colon

## Contributor license agreement signed?
CLA [X] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
