### PR TITLE
Bugfix/issue 3011

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -189,7 +189,7 @@ in mycroft.conf.
             if [[ ! -f /etc/mycroft/mycroft.conf ]]; then
                 $SUDO mkdir -p /etc/mycroft
                 $SUDO touch /etc/mycroft/mycroft.conf
-                $SUDO bash -c 'echo "{ \"use_precise\": true }" > /etc/mycroft/mycroft.conf'
+                $SUDO bash -c 'echo "{ \"use_precise\": false }" > /etc/mycroft/mycroft.conf'
             else
                 # Ensure dependency installed to merge configs
                 disable_precise_later=true
@@ -469,7 +469,7 @@ install_deps
 
 # It's later. Update existing config with jq.
 if [ $disable_precise_later == true ]; then
-    $SUDO bash -c 'jq ". + { \"use_precise\": true }" /etc/mycroft/mycroft.conf > tmp.mycroft.conf' 
+    $SUDO bash -c 'jq ". + { \"use_precise\": false }" /etc/mycroft/mycroft.conf > tmp.mycroft.conf' 
                     $SUDO mv -f tmp.mycroft.conf /etc/mycroft/mycroft.conf
 fi
 


### PR DESCRIPTION
## Description
Added a 'do later' flag in place of command that sets `use_precise` to false if Precise is unavailable, since the command relied on a dependency installed later in the script. After dependencies are installed, if flag is set, run the original update command. Also fixed `use_precise` wrongly being set to 'true' instead of 'false' after failing the AVX check.

## How to test
Run Mycroft dev_setup.sh on an Intel/AMD machine with no AVX support.
Installer should complete without `jq: command not found` error.
After install check `{ "use_precise": false }` in _/etc/mycroft/mycroft.conf_, and not 'true'.

## Contributor license agreement signed?
CLA [ ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
