### PR TITLE
Fix race condition in GUI namespace insertion

### DIFF
--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -264,7 +264,7 @@ class Enclosure:
 
         # Load any already stored Data
         data = self.datastore.get(namespace, {})
-        for key in data:
+        for key in dict(data):
             msg = {"type": "mycroft.session.set",
                    "namespace": namespace,
                    "data": {key: data[key]}}


### PR DESCRIPTION
## Description
When inserting a new namespace for the GUI, bus events could cause the dict to change while it is being iterated over.

## How to test
Unsure - saw it in OVOS and can see how that could happen.
Change shouldn't have a negative impact.

## Contributor license agreement signed?
- [x] CLA


Thanks to @JarbasAI for identifying and fixing it
