### PR TITLE
Add phonetic spellings for IP and Wikipedia

### DIFF
--- a/mycroft/res/text/en-us/phonetic_spellings.txt
+++ b/mycroft/res/text/en-us/phonetic_spellings.txt
@@ -3,3 +3,5 @@ ai: A.I.
 mycroftai: mycroft A.I.
 spotify: spot-ify
 corgi: core-gee
+ip: eye pea
+wikipedia: wickee-peedia


### PR DESCRIPTION
## Description
Add phonetic spellings for IP and Wikipedia so that different TTS engines say them correctly.

Not a problem with Mimic2 but it is in a range of other TTS engines and they're very commonly spoken terms.

## How to test
Set up Coqui TTS or another service and have Mycroft say "wikipedia" and "IP"

## Contributor license agreement signed?
- [x] CLA
