### PR TITLE
Use shellcheck directive instead of excludes

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -74,6 +74,6 @@ jobs:
     - name: Shell check mycroft tools
       uses: ludeeus/action-shellcheck@ceeca77f6538b97991ca2c2a2ebe1ab64e573b5e
       env:
-        SHELLCHECK_OPTS: -x --exclude SC2034 --exclude SC2012 --exclude SC1091
+        SHELLCHECK_OPTS: -x --exclude SC1091
       with:
         scandir: ./bin

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -74,6 +74,6 @@ jobs:
     - name: Shell check mycroft tools
       uses: ludeeus/action-shellcheck@ceeca77f6538b97991ca2c2a2ebe1ab64e573b5e
       env:
-        SHELLCHECK_OPTS: -x --exclude SC1091
+        SHELLCHECK_OPTS: -x
       with:
         scandir: ./bin

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,3 @@
+# Disable sourcing errors
+disable=SC1090
+disable=SC1091

--- a/bin/mycroft-config
+++ b/bin/mycroft-config
@@ -65,11 +65,17 @@ function found_exe() {
 }
 
 if found_exe tput ; then
+    # shellcheck disable=SC2034
     GREEN="$(tput setaf 2)"
+    # shellcheck disable=SC2034
     BLUE="$(tput setaf 4)"
+    # shellcheck disable=SC2034
     CYAN="$(tput setaf 6)"
+    # shellcheck disable=SC2034
     YELLOW="$(tput setaf 3)"
+    # shellcheck disable=SC2034
     RESET="$(tput sgr0)"
+    # shellcheck disable=SC2034
     HIGHLIGHT=${YELLOW}
 fi
 

--- a/bin/mycroft-help
+++ b/bin/mycroft-help
@@ -18,7 +18,7 @@ SOURCE="${BASH_SOURCE[0]}"
 cd -P "$( dirname "$SOURCE" )"/.. || exit
 DIR="$( pwd )"
 
-echo -e "\e[36mMycroft\e[0m is your open source voice assistant.  Full source"
+echo -e "\\e[36mMycroft\\e[0m is your open source voice assistant.  Full source"
 echo "can be found at: ${DIR}"
 echo
 echo "Mycroft-specific commands you can use from the Linux command prompt:"

--- a/bin/mycroft-say-to
+++ b/bin/mycroft-say-to
@@ -26,4 +26,4 @@ set -- "${1:-$(</dev/stdin)}" "${@:2}"
 
 # Send a message to be spoken
 data="$*"
-output=$(python -m mycroft.messagebus.send "recognizer_loop:utterance"  "{\"utterances\": [\"$data\"], \"lang\": \"en-us\"}")
+python -m mycroft.messagebus.send "recognizer_loop:utterance"  "{\"utterances\": [\"$data\"], \"lang\": \"en-us\"}" >> /dev/null

--- a/bin/mycroft-skill-testrunner
+++ b/bin/mycroft-skill-testrunner
@@ -20,9 +20,14 @@ DIR="$( dirname "$SOURCE" )"
 # Enter the Mycroft venv
 source "$DIR/../venv-activate.sh" -q
 
+function count-files() {
+    # shellcheck disable=SC2012
+    ls "$1" | wc -l
+}
+
 function vktest-clear() {
     FEATURES_DIR="$DIR/../test/integrationtests/voight_kampff/features"
-    num_feature_files=$(ls "$FEATURES_DIR" | wc -l) 
+    num_feature_files=$(count-files "$FEATURES_DIR")
     # A clean directory will have `steps/` and `environment.py`
     if [ "$num_feature_files" -gt "2" ] ; then
         echo "Removing Feature files..."
@@ -30,7 +35,7 @@ function vktest-clear() {
         rm "${DIR}"/../test/integrationtests/voight_kampff/features/*.config.json
     fi
     STEPS_DIR="$FEATURES_DIR/steps"
-    num_steps_files=$(ls "$STEPS_DIR" | wc -l)
+    num_steps_files=$(count-files "$STEPS_DIR")
     if [ "$num_steps_files" -gt "2" ] ; then
         echo "Removing Custom Step files..."
         TMP_DIR="$STEPS_DIR/tmp"

--- a/bin/mycroft-speak
+++ b/bin/mycroft-speak
@@ -24,4 +24,4 @@ source "$DIR/../venv-activate.sh" -q
 
 # Send a message to be spoken
 data="$*"
-output=$(python -m mycroft.messagebus.send "speak"  "{\"utterance\": \"$data\"}")
+python -m mycroft.messagebus.send "speak"  "{\"utterance\": \"$data\"}" >> /dev/null


### PR DESCRIPTION
## Description
This uses shellcheck directives instead of excludes only available in CICD as suggested by @PureTryOut.

This leaves SC1090/1091 as a general excludes, these are set in the .shellcheckrc to make sure the developer gets the same checks as the CI does.

## How to test
Ensure the CICD approves.

## Contributor license agreement signed?
CLA [ Yes ]