### PR TITLE
Fix config priority

### DIFF
--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -236,12 +236,12 @@ class Configuration:
                 _log_old_location_deprecation()
                 configs.append(LocalConf(OLD_USER_CONFIG))
 
+            # Then use the system config (/etc/mycroft/mycroft.conf)
+            configs.append(LocalConf(SYSTEM_CONFIG))
+
             # Then use remote config
             if remote:
                 configs.append(RemoteConf())
-
-            # Then use the system config (/etc/mycroft/mycroft.conf)
-            configs.append(LocalConf(SYSTEM_CONFIG))
 
             # Then use the config that comes with the package
             configs.append(LocalConf(DEFAULT_CONFIG))

--- a/mycroft/util/log.py
+++ b/mycroft/util/log.py
@@ -86,7 +86,8 @@ class LOG:
         cls.handler = logging.StreamHandler(sys.stdout)
         cls.handler.setFormatter(formatter)
 
-        config = mycroft.configuration.Configuration.get(remote=False)
+        config = mycroft.configuration.Configuration.get(cache=False,
+                                                         remote=False)
         if config.get('log_format'):
             formatter = logging.Formatter(config.get('log_format'), style='{')
             cls.handler.setFormatter(formatter)


### PR DESCRIPTION
## Description
This resolves #3029 as well as a bug masking the issue by not loading remote config at startup.

## How to test
- Remove all local configs setting "tts"->"module"
- Set the voice to American Male on the web
- Start Mycroft `./start-mycroft.sh all`
- Wait for everything to be up
- Restart the audio service `./start-mycroft.sh audio restart`
- Verify that the Mimic2 voice used
- Add config for the voice used in `/etc/mycroft/mycroft.conf`
```json
{
  "tts" {
    "module": "mimic"
  }
}
``` 
- Restart the audio service again `./start-mycroft.sh audio restart`
- Verify that the mimic voice is used

## Contributor license agreement signed?
CLA [ Yes ]