### PR TITLE
Remove incorrectly added args in GUIWebsocketHandler methods

### DIFF
--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -493,7 +493,7 @@ class GUIWebsocketHandler(WebSocketHandler):
         LOG.info('New Connection opened!')
         self.synchronize()
 
-    def on_close(self, _):
+    def on_close(self, _=None):
         LOG.info('Closing {}'.format(id(self)))
         GUIWebsocketHandler.clients.remove(self)
 

--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -525,8 +525,10 @@ class GUIWebsocketHandler(WebSocketHandler):
                            })
             namespace_pos += 1
 
-    def on_message(self, _, message):
+    def on_message(self, _=None, message=None):
         LOG.info("Received: {}".format(message))
+        if message is None:
+            return
         msg = json.loads(message)
         if (msg.get('type') == "mycroft.events.triggered" and
                 (msg.get('event_name') == 'page_gained_focus' or

--- a/mycroft/client/enclosure/base.py
+++ b/mycroft/client/enclosure/base.py
@@ -493,7 +493,7 @@ class GUIWebsocketHandler(WebSocketHandler):
         LOG.info('New Connection opened!')
         self.synchronize()
 
-    def on_close(self, _=None):
+    def on_close(self):
         LOG.info('Closing {}'.format(id(self)))
         GUIWebsocketHandler.clients.remove(self)
 
@@ -525,10 +525,8 @@ class GUIWebsocketHandler(WebSocketHandler):
                            })
             namespace_pos += 1
 
-    def on_message(self, _=None, message=None):
+    def on_message(self, message):
         LOG.info("Received: {}".format(message))
-        if message is None:
-            return
         msg = json.loads(message)
         if (msg.get('type') == "mycroft.events.triggered" and
                 (msg.get('event_name') == 'page_gained_focus' or


### PR DESCRIPTION
## Description
PR #2879 updated the websocket-client and changed function signatures to account for API changes in that package. The instances in this PR were falsely changed as the GUI bus does not use the websocket-client.

Consistency would be good however modifying these for the GUI bus would require significant work. For now we have two slightly different bus interfaces.

This was causing the GUI to crash on click events and on close.

Thanks to @AIIX for help getting to the right answer on this one!

## How to test
Test 1:
- Launch Mycroft
- Launch GUI from terminal
- Kill the GUI (ctrl+c)
- See `TypeError: on_close() missing 1 required positional argument: '_'`
- Apply commit, rinse and repeat.

Test 2:
- Launch Mycroft
- Launch GUI from terminal
- trigger some GUI skill
- click on it

## Contributor license agreement signed?
- [x] CLA
