### PR TITLE
Issue-3026 - Update Gentoo libffi dependency reference

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -398,7 +398,7 @@ function redhat_install() {
 }
 
 function gentoo_install() {
-    $SUDO emerge --noreplace dev-vcs/git dev-lang/python dev-python/setuptools dev-python/pygobject dev-python/requests sys-devel/libtool virtual/libffi virtual/jpeg dev-libs/openssl sys-devel/autoconf sys-devel/bison dev-lang/swig dev-libs/glib media-libs/portaudio media-sound/mpg123 media-libs/flac net-misc/curl sci-mathematics/fann sys-devel/gcc app-misc/jq media-libs/alsa-lib dev-libs/icu
+    $SUDO emerge --noreplace dev-vcs/git dev-lang/python dev-python/setuptools dev-python/pygobject dev-python/requests sys-devel/libtool dev-libs/libffi virtual/jpeg dev-libs/openssl sys-devel/autoconf sys-devel/bison dev-lang/swig dev-libs/glib media-libs/portaudio media-sound/mpg123 media-libs/flac net-misc/curl sci-mathematics/fann sys-devel/gcc app-misc/jq media-libs/alsa-lib dev-libs/icu
 }
 
 function alpine_install() {


### PR DESCRIPTION
## Description
Updates the `libffi` package reference as it has been changed in Gentoo's package index:
https://bugs.gentoo.org/699796

Fixes # 3026

## How to test
1. Install current gentoo os
2. Execute `bash dev_setup.sh`

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
