### PR TITLE
Issue-3041 - Install pip for python version specified by argument in …

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -460,7 +460,7 @@ function install_venv() {
     # Force version of pip for reproducability, but there is nothing special
     # about this version.  Update whenever a new version is released and
     # verified functional.
-    curl https://bootstrap.pypa.io/get-pip.py | "${VIRTUALENV_ROOT}/bin/python" - 'pip==20.0.2'
+    curl https://bootstrap.pypa.io/get-pip.py | "${VIRTUALENV_ROOT}/bin/${opt_python}" - 'pip==20.0.2'
     # Function status depending on if pip exists
     [[ -x ${VIRTUALENV_ROOT}/bin/pip ]]
 }


### PR DESCRIPTION
…dev_setup

## Description
fixes #3041

It is possible to provide a python version as an argument to the dev_setup.sh script. I suggest that the provided version should also be used to install the correct pip. This would make it easier to install mycroft on systems such as respeaker core 2.


## How to test
/

## Contributor license agreement signed?
CLA [x ] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
