### PR TITLE
Update pyxdg to ensure Python3.8 compatibility

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -25,4 +25,4 @@ fann2==1.0.7
 padaos==0.1.9
 precise-runner==0.2.1
 petact==0.1.2
-pyxdg==0.26
+pyxdg==0.27


### PR DESCRIPTION
## Description
pyxdg v0.27 contains fixes for Python3.8.4+ compatibility.

Release notes: https://freedesktop.org/wiki/Software/pyxdg/

## How to test
No functional changes. Tests should pass.

## Contributor license agreement signed?
- [x] CLA
