### PR TITLE
Do not create configs folders until writing

### DIFF
--- a/mycroft/client/enclosure/mark1/__init__.py
+++ b/mycroft/client/enclosure/mark1/__init__.py
@@ -15,6 +15,7 @@
 import subprocess
 import time
 from alsaaudio import Mixer
+from os.path import join
 from threading import Thread, Timer
 
 import serial
@@ -165,10 +166,11 @@ class EnclosureReader(Thread):
         if "unit.factory-reset" in data:
             self.bus.emit(Message("speak", {
                 'utterance': mycroft.dialog.get("reset to factory defaults")}))
-            subprocess.call(
-                (f'rm {xdg.BaseDirectory.save_config_path("mycroft")}'
-                 '/mycroft/identity/identity2.json'),
-                shell=True)
+            xdg_identity_path = join(xdg.BaseDirectory.xdg_config_home,
+                                     'mycroft',
+                                     'identity',
+                                     'identity2.json')
+            subprocess.call(f'rm {xdg_identity_path}', shell=True)
             subprocess.call(
                 'rm ~/.mycroft/identity/identity2.json',
                 shell=True)

--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -201,7 +201,7 @@ class PreciseHotword(HotWordEngine):
         # Make sure we pick the key we need from wherever it's located,
         # but save to a writeable location only
         local_conf = LocalConf(
-            join(xdg.BaseDirectory.save_config_path('mycroft'), 'mycroft.conf')
+            join(xdg.BaseDirectory.xdg_config_home, 'mycroft', 'mycroft.conf')
         )
 
         for conf_dir in xdg.BaseDirectory.load_config_paths('mycroft'):

--- a/mycroft/client/text/text_client.py
+++ b/mycroft/client/text/text_client.py
@@ -185,7 +185,7 @@ def load_settings():
         LOG.warning(" Note that this location is deprecated and will" +
                     " not be used in the future")
         LOG.warning(" Please move it to " +
-                    os.path.join(xdg.BaseDirectory.save_config_path('mycroft'),
+                    os.path.join(xdg.BaseDirectory.xdg_config_home, 'mycroft',
                                  filename))
         config_file = path
 

--- a/mycroft/configuration/config.py
+++ b/mycroft/configuration/config.py
@@ -16,12 +16,15 @@
 
 import inflection
 import json
-from os.path import exists, isfile, join
+import os
 import re
+from os.path import exists, isfile, join, dirname
 
 from requests import RequestException
 import xdg.BaseDirectory
 
+from mycroft.util.combo_lock import ComboLock
+from mycroft.util.file_utils import get_temp_path
 from mycroft.util.json_helper import load_commented_json, merge_dict
 from mycroft.util.log import LOG
 
@@ -85,6 +88,8 @@ def translate_list(config, values):
 
 class LocalConf(dict):
     """Config dictionary from file."""
+    _lock = ComboLock(get_temp_path('local-conf.lock'))
+
     def __init__(self, path):
         super(LocalConf, self).__init__()
         if path:
@@ -116,20 +121,26 @@ class LocalConf(dict):
         The cache will be used if the remote is unreachable to load settings
         that are as close to the user's as possible.
         """
-        path = path or self.path
-        with open(path, 'w') as f:
-            json.dump(self, f, indent=2)
+        with self._lock:
+            path = path or self.path
+            config_dir = dirname(path)
+            if not exists(config_dir):
+                os.makedirs(config_dir)
+
+            with open(path, 'w') as f:
+                json.dump(self, f, indent=2)
 
     def merge(self, conf):
         merge_dict(self, conf)
 
 
 class RemoteConf(LocalConf):
+    _lock = ComboLock(get_temp_path('remote-conf.lock'))
     """Config dictionary fetched from mycroft.ai."""
     def __init__(self, cache=None):
         super(RemoteConf, self).__init__(None)
 
-        cache = cache or join(xdg.BaseDirectory.save_cache_path('mycroft'),
+        cache = cache or join(xdg.BaseDirectory.xdg_cache_home, 'mycroft',
                               'web_cache.json')
         from mycroft.api import is_paired
         if not is_paired():
@@ -179,7 +190,7 @@ def _log_old_location_deprecation():
                 " Note that this location is deprecated and will"
                 " not be used in the future\n"
                 " Please move it to "
-                f"{xdg.BaseDirectory.save_config_path('mycroft')}")
+                f"{join(xdg.BaseDirectory.xdg_config_home, 'mycroft')}")
 
 
 class Configuration:

--- a/mycroft/configuration/locations.py
+++ b/mycroft/configuration/locations.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
-from os.path import join, dirname, expanduser, exists
+from os.path import join, dirname, expanduser
 
 import xdg.BaseDirectory
 
@@ -23,24 +23,11 @@ SYSTEM_CONFIG = os.environ.get('MYCROFT_SYSTEM_CONFIG',
 # Make sure we support the old location still
 # Deprecated and will be removed eventually
 OLD_USER_CONFIG = join(expanduser('~'), '.mycroft/mycroft.conf')
-USER_CONFIG = join(xdg.BaseDirectory.save_config_path('mycroft'),
-                   'mycroft.conf')
+USER_CONFIG = join(xdg.BaseDirectory.xdg_config_home,
+                   'mycroft',
+                   'mycroft.conf'
+                   )
 
 REMOTE_CONFIG = "mycroft.ai"
 WEB_CONFIG_CACHE = os.environ.get('MYCROFT_WEB_CACHE',
                                   '/var/tmp/mycroft_web_cache.json')
-
-
-def __ensure_folder_exists(path):
-    """ Make sure the directory for the specified path exists.
-
-        Args:
-            path (str): path to config file
-     """
-    directory = dirname(path)
-    if not exists(directory):
-        os.makedirs(directory)
-
-
-__ensure_folder_exists(WEB_CONFIG_CACHE)
-__ensure_folder_exists(USER_CONFIG)


### PR DESCRIPTION
## Description

This replaces save_*_path with usage of the xdg_*_home when handling
config files as suggested by @JarbasAI in #3044. This means the config system will not create folders unless
actually written.

The check for whether a directory needs to be created is handled behind
a lock to avoid race conditions.

It also changes some usages in strings where the 

The save_config_path() call still exists in the FileSystemAccess-class as a file is opened, which should probably be improved as well.


## Contributor license agreement signed?
CLA [ x ]