### PR TITLE
Do not overwrite new path if it already exists

### DIFF
--- a/mycroft/filesystem/__init__.py
+++ b/mycroft/filesystem/__init__.py
@@ -39,7 +39,7 @@ class FileSystemAccess:
 
         # Migrate from the old location if it still exists
         # TODO: remove in 22.02
-        if isdir(old_path):
+        if not isdir(path) and isdir(old_path):
             if isdir(path):
                 shutil.rmtree(path)
             shutil.move(old_path, path)


### PR DESCRIPTION
## Description
In the migration to XDG compatible paths, we move anything from the old path to the new path. However if for some reason both paths exist the old path would overwrite the new one. 

This should only really happen for devs who are switching back and forth between branches. So just an extra precaution. 

## How to test
With an existing install pre-paired but stopped:
```
mkdir ~/.mycroft/identity
mv ~/.config/mycroft/identity/* ~/.mycroft/identity/
touch ~/.config/mycroft/identity/test
mycroft-start all
```
Prior to this change - the test file will get wiped when the old path overwrites the new one.

## Contributor license agreement signed?
- [x] CLA
