### PR TITLE
Do not create identity folder when trying to read the identity file

### DIFF
--- a/mycroft/identity/__init__.py
+++ b/mycroft/identity/__init__.py
@@ -43,8 +43,12 @@ class IdentityManager:
     def _load():
         LOG.debug('Loading identity')
         try:
-            with FileSystemAccess('identity').open('identity2.json', 'r') as f:
-                IdentityManager.__identity = DeviceIdentity(**json.load(f))
+            identity_dir = FileSystemAccess('identity')
+            if identity_dir.exists('identity2.json'):
+                with identity_dir.open('identity2.json', 'r') as f:
+                    IdentityManager.__identity = DeviceIdentity(**json.load(f))
+            else:
+                IdentityManager.__identity = DeviceIdentity()
         except Exception:
             IdentityManager.__identity = DeviceIdentity()
 

--- a/mycroft/identity/__init__.py
+++ b/mycroft/identity/__init__.py
@@ -49,7 +49,8 @@ class IdentityManager:
                     IdentityManager.__identity = DeviceIdentity(**json.load(f))
             else:
                 IdentityManager.__identity = DeviceIdentity()
-        except Exception:
+        except Exception as e:
+            LOG.exception(f'Failed to load identity file: {repr(e)}')
             IdentityManager.__identity = DeviceIdentity()
 
     @staticmethod


### PR DESCRIPTION
## Description
This is a followup PR on #3045 ensuring that the identity2.json isn't created until the file is actually written. This is not as big an issue as the things handled in the previous PR since the access is generally locked using the ComboLock but this makes it less surprising to see the new folder.

## How to test
- remove the `.config/mycroft` folder
- start up mycroft
- let the pairing process start and check that the `.config/mycroft/identity` folder hasn't been created.
- Finish the pairing
- Check that the folder and identity2.json exists
- Ask mycroft about the weather and ensure it is fetched correctly 

## Contributor license agreement signed?
CLA [ Yes ]