### PR TITLE
Backport/playback queue singleton

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -116,10 +116,9 @@ def mute_and_speak(utterance, ident, listen=False):
     # update TTS object if configuration has changed
     if tts_hash != hash(str(config.get('tts', ''))):
         global tts
-        # Stop tts playback thread
-        tts.playback.stop()
-        tts.playback.join()
         # Create new tts instance
+        if tts:
+            tts.playback.detach_tts(tts)
         tts = TTSFactory.create()
         tts.init(bus)
         tts_hash = hash(str(config.get('tts', '')))

--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -74,13 +74,7 @@ def handle_speak(event):
         # so we likely will want to get rid of this when not running on Mimic
         if (config.get('enclosure', {}).get('platform') != "picroft" and
                 len(re.findall('<[^>]*>', utterance)) == 0):
-            # Remove any whitespace present after the period,
-            # if a character (only alpha) ends with a period
-            # ex: A. Lincoln -> A.Lincoln
-            # so that we don't split at the period
-            utterance = re.sub(r'\b([A-za-z][\.])(\s+)', r'\g<1>', utterance)
-            chunks = re.split(r'(?<!\w\.\w.)(?<![A-Z][a-z]\.)(?<=\.|\;|\?)\s',
-                              utterance)
+            chunks = tts.preprocess_utterance(utterance)
             # Apply the listen flag to the last chunk, set the rest to False
             chunks = [(chunks[i], listen if i == len(chunks) - 1 else False)
                       for i in range(len(chunks))]

--- a/mycroft/tts/mimic_tts.py
+++ b/mycroft/tts/mimic_tts.py
@@ -130,8 +130,6 @@ class Mimic(TTS):
         )
         self.default_binary = get_mimic_binary()
 
-        self.clear_cache()
-
         # Download subscriber voices if needed
         self.subscriber_voices = get_subscriber_voices()
         self.is_subscriber = DeviceApi().is_subscriber

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -394,10 +394,7 @@ class TTS(metaclass=ABCMeta):
         sentence = self.validate_ssml(sentence)
 
         create_signal("isSpeaking")
-        try:
-            self._execute(sentence, ident, listen)
-        except Exception:
-            raise
+        self._execute(sentence, ident, listen)
 
     def _execute(self, sentence, ident, listen):
         if self.phonetic_spelling:

--- a/test/unittests/audio/test_speech.py
+++ b/test/unittests/audio/test_speech.py
@@ -23,6 +23,7 @@ from os.path import exists
 
 import mycroft.audio.speech as speech
 from mycroft.messagebus import Message
+from mycroft.tts.tts import default_preprocess_utterance
 from mycroft.tts.remote_tts import RemoteTTSTimeoutException
 
 """Tests for speech dispatch service."""
@@ -36,6 +37,8 @@ def setup_mocks(config_mock, tts_factory_mock):
     config_mock.get.return_value = {}
 
     tts_factory_mock.create.return_value = tts_mock
+
+    tts_mock.preprocess_utterance.side_effect = default_preprocess_utterance
     config_mock.reset_mock()
     tts_factory_mock.reset_mock()
     tts_mock.reset_mock()

--- a/test/unittests/tts/test_tts.py
+++ b/test/unittests/tts/test_tts.py
@@ -12,6 +12,14 @@ mock_audio = "/tmp/mock_path"
 mock_viseme = mock.Mock(name='viseme')
 
 
+class MsgTypeCheck:
+    def __init__(self, msg_type):
+        self.msg_type = msg_type
+
+    def __eq__(self, other):
+        return self.msg_type == other.msg_type
+
+
 class MockTTS(mycroft.tts.TTS):
     def __init__(self, lang, config, validator, audio_ext='wav',
                  phonetic_spelling=True, ssml_tags=None):
@@ -58,17 +66,20 @@ class TestPlaybackThread(unittest.TestCase):
             # Test wav data
             wav_mock = mock.Mock(name='wav_data')
             queue.put(('wav', wav_mock, None, 0, False))
-            time.sleep(0.2)
-            mock_tts.begin_audio.called_with()
+            time.sleep(0.3)
             mock_play_wav.assert_called_with(wav_mock, environment=None)
-            mock_tts.end_audio.assert_called_with(False)
+            mock_tts.bus.emit.assert_called_with(
+                    MsgTypeCheck('recognizer_loop:audio_output_end')
+            )
 
             # Test mp3 data and trigger listening True
             mp3_mock = mock.Mock(name='mp3_data')
             queue.put(('mp3', mp3_mock, None, 0, True))
             time.sleep(0.2)
             mock_play_mp3.assert_called_with(mp3_mock, environment=None)
-            mock_tts.end_audio.assert_called_with(True)
+            mock_tts.bus.emit.assert_called_with(
+                MsgTypeCheck('mycroft.mic.listen')
+            )
             self.assertFalse(playback.enclosure.get.called)
 
             # Test sending visemes
@@ -92,7 +103,7 @@ class TestTTS(unittest.TestCase):
         tts.init(bus_mock)
         self.assertTrue(tts.bus is bus_mock)
 
-        tts.queue = mock.Mock()
+        mycroft.tts.TTS.queue = mock.Mock()
         with mock.patch('mycroft.tts.tts.open') as mock_open:
             tts.cache.temporary_cache_dir = Path('/tmp/dummy')
             tts.execute('Oh no, not again', 42)
@@ -100,7 +111,7 @@ class TestTTS(unittest.TestCase):
             'Oh no, not again',
             '/tmp/dummy/8da7f22aeb16bc3846ad07b644d59359.wav'
         )
-        tts.queue.put.assert_called_with(
+        mycroft.tts.TTS.queue.put.assert_called_with(
             (
                 'wav',
                 mock_audio,
@@ -117,7 +128,7 @@ class TestTTS(unittest.TestCase):
         tts.init(bus_mock)
         self.assertTrue(tts.bus is bus_mock)
 
-        tts.queue = mock.Mock()
+        mycroft.tts.TTS.queue = mock.Mock()
         with mock.patch('mycroft.tts.tts.open') as mock_open:
             tts.cache.temporary_cache_dir = Path('/tmp/dummy')
             tts.execute('Oh no, not again', 42)
@@ -125,7 +136,7 @@ class TestTTS(unittest.TestCase):
             'Oh no, not again',
             '/tmp/dummy/8da7f22aeb16bc3846ad07b644d59359.wav'
         )
-        tts.queue.put.assert_called_with(
+        mycroft.tts.TTS.queue.put.assert_called_with(
             (
                 'wav',
                 mock_audio,


### PR DESCRIPTION
## Description
This backports the TTS Playback queue singleton PR to the dev branch.

This fixes some additional issues (existing on dev at least)
- Handle Mimic2 error on chunk without repetition
- some minor changes where self was used instead of TTS to refer to the singleton for consistency
- Curate cache for all attached TTS's
- Remove use of clear_cache in Mimic (1) TTS implementation, this caused all cache to be removed from Mimic2 when fallback tts was called.

## How to test
The game-zork skill triggers really bad issues when using Mimic2, (500 errors on almost empty utterances) and together with the listening=true it's really noticable. Playing that for a bit should give some idea if it works or not.

## Contributor license agreement signed?
CLA [x]