### PR TITLE
Add `supported_languages` parameter to STT and TTS base classes

### DIFF
--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -37,6 +37,18 @@ class STT(metaclass=ABCMeta):
         self.recognizer = Recognizer()
         self.can_stream = False
 
+    @property
+    def supported_languages(self) -> set:
+        """Return languages supported by this STT implementation
+
+        This property should be overridden by the derived class to advertise
+        what languages that engine supports.
+
+        Returns:
+            set: supported languages
+        """
+        return set()
+
     @staticmethod
     def init_language(config_core):
         """Helper method to get language code from Mycroft config."""

--- a/mycroft/stt/__init__.py
+++ b/mycroft/stt/__init__.py
@@ -38,8 +38,8 @@ class STT(metaclass=ABCMeta):
         self.can_stream = False
 
     @property
-    def supported_languages(self) -> set:
-        """Return languages supported by this STT implementation
+    def available_languages(self) -> set:
+        """Return languages supported by this STT implementation in this state
 
         This property should be overridden by the derived class to advertise
         what languages that engine supports.

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -194,8 +194,8 @@ class TTS(metaclass=ABCMeta):
         self.cache.clear()
 
     @property
-    def supported_languages(self) -> set:
-        """Return languages supported by this TTS implementation
+    def available_languages(self) -> set:
+        """Return languages supported by this TTS implementation in this state
 
         This property should be overridden by the derived class to advertise
         what languages that engine supports.

--- a/mycroft/tts/tts.py
+++ b/mycroft/tts/tts.py
@@ -193,6 +193,18 @@ class TTS(metaclass=ABCMeta):
         )
         self.cache.clear()
 
+    @property
+    def supported_languages(self) -> set:
+        """Return languages supported by this TTS implementation
+
+        This property should be overridden by the derived class to advertise
+        what languages that engine supports.
+
+        Returns:
+            set: supported languages
+        """
+        return set()
+
     def load_spellings(self):
         """Load phonetic spellings of words as dictionary."""
         path = join('text', self.lang.lower(), 'phonetic_spellings.txt')


### PR DESCRIPTION
## Description
This PR adds a property to the base STT and TTS classes that a plugin can override to specify what languages it supports.
#3058

## How to test
This change should not affect behavior. The added property should always return `set()` currently.

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
