### PR TITLE
Add initial value for shell variable

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -70,6 +70,7 @@ opt_forcemimicbuild=false
 opt_allowroot=false
 opt_skipmimicbuild=false
 opt_python=python3
+disable_precise_later=false
 param=''
 
 for var in "$@" ; do


### PR DESCRIPTION
Condition

    if [ $disable_precise_later == true ]; 

gives a syntax error if variable is not initialized

## Contributor license agreement signed?
Yes
