### PR TITLE
Voigt kampff: Bugfix dialogfile from sentence

### DIFF
--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -17,7 +17,7 @@ Predefined step definitions for handling dialog interaction with Mycroft for
 use with behave.
 """
 from os.path import join, exists, basename
-from glob import glob
+from pathlib import Path
 import re
 import time
 
@@ -65,6 +65,26 @@ def load_dialog_list(skill_path, dialog):
     return load_dialog_file(dialog_path), debug
 
 
+def _get_dialog_files(skill_path, lang):
+    """Generator expression returning all dialog files.
+
+    This includes both the 'locale' and the older style 'dialog' folder.
+
+    Args:
+        skill_path (str): skill root folder
+        lang (str): language code to check
+
+    yields:
+        (Path) path of each found dialog file
+    """
+    in_dialog_dir = Path(skill_path, 'dialog', lang).rglob('*.dialog')
+    for dialog_path in in_dialog_dir:
+        yield dialog_path
+    in_locale_dir = Path(skill_path, 'locale', lang).rglob('*.dialog')
+    for dialog_path in in_locale_dir:
+        yield dialog_path
+
+
 def dialog_from_sentence(sentence, skill_path, lang):
     """Find dialog file from example sentence.
 
@@ -75,9 +95,8 @@ def dialog_from_sentence(sentence, skill_path, lang):
 
     Returns (str): Dialog file best matching the sentence.
     """
-    dialog_paths = join(skill_path, 'dialog', lang, '*.dialog')
     best = (None, 0)
-    for path in glob(dialog_paths):
+    for path in _get_dialog_files(skill_path, lang):
         patterns = load_dialog_file(path)
         match, _ = _match_dialog_patterns(patterns, sentence.lower())
         if match is not False:

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -25,6 +25,7 @@ from behave import given, when, then
 
 from mycroft.messagebus import Message
 from mycroft.audio import wait_while_speaking
+from mycroft.util.format import expand_options
 
 from test.integrationtests.voight_kampff import (mycroft_responses, then_wait,
                                                  then_wait_fail)
@@ -45,8 +46,14 @@ def load_dialog_file(dialog_path):
     """Load dialog files and get the contents."""
     with open(dialog_path) as f:
         lines = f.readlines()
-    return [l.strip().lower() for l in lines
-            if l.strip() != '' and l.strip()[0] != '#']
+
+    # Expand parentheses in lines
+    expanded_lines = []
+    for line in lines:
+        expanded_lines += expand_options(line)
+
+    return [line.strip().lower() for line in expanded_lines
+            if line.strip() != '' and line.strip()[0] != '#']
 
 
 def load_dialog_list(skill_path, dialog):

--- a/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
+++ b/test/integrationtests/voight_kampff/features/steps/utterance_responses.py
@@ -117,7 +117,6 @@ def _match_dialog_patterns(dialogs, sentence):
     dialogs = [re.sub(r'{.*?\}', r'.*', dia) for dia in dialogs]
     # Remove left over '}'
     dialogs = [re.sub(r'\}', r'', dia) for dia in dialogs]
-    dialogs = [re.sub(r' .* ', r' .*', dia) for dia in dialogs]
     # Merge consequtive .*'s into a single .*
     dialogs = [re.sub(r'\.\*( \.\*)+', r'.*', dia) for dia in dialogs]
     # Remove double whitespaces


### PR DESCRIPTION
## Description
Fix two issues with `"skill" should reply with "sentence"` behave step.

- locale folder was not checked for dialog files
- A redundant (?) regex step caused issues if there were no keywords

Should resolve #3067

## How to test
Ensure VK tests still works, see test case in #3067 for previously failing test.

## Contributor license agreement signed?
CLA [ x ]