### PR TITLE
Added duration_to_bytes to FileMockMicrophone

### DIFF
--- a/test/wake_word/wake_word_test.py
+++ b/test/wake_word/wake_word_test.py
@@ -90,8 +90,9 @@ class FileMockMicrophone(AudioSource):
         self.stream.close()
 
     def duration_to_bytes(self, ww_duration):
-        return int(ww_duration*self.SAMPLE_RATE*self.SAMPLE_WIDTH)
+        return int(ww_duration * self.SAMPLE_RATE * self.SAMPLE_WIDTH)
 
+    
 class AudioTester:
     def __init__(self, samp_rate):
         print()  # Pad debug messages

--- a/test/wake_word/wake_word_test.py
+++ b/test/wake_word/wake_word_test.py
@@ -92,7 +92,7 @@ class FileMockMicrophone(AudioSource):
     def duration_to_bytes(self, ww_duration):
         return int(ww_duration * self.SAMPLE_RATE * self.SAMPLE_WIDTH)
 
-    
+
 class AudioTester:
     def __init__(self, samp_rate):
         print()  # Pad debug messages

--- a/test/wake_word/wake_word_test.py
+++ b/test/wake_word/wake_word_test.py
@@ -88,8 +88,10 @@ class FileMockMicrophone(AudioSource):
 
     def close(self):
         self.stream.close()
-
-
+        
+    def duration_to_bytes(self,ww_duration):
+        return int(ww_duration*self.SAMPLE_RATE*self.SAMPLE_WIDTH)
+    
 class AudioTester:
     def __init__(self, samp_rate):
         print()  # Pad debug messages

--- a/test/wake_word/wake_word_test.py
+++ b/test/wake_word/wake_word_test.py
@@ -88,10 +88,10 @@ class FileMockMicrophone(AudioSource):
 
     def close(self):
         self.stream.close()
-        
-    def duration_to_bytes(self,ww_duration):
+
+    def duration_to_bytes(self, ww_duration):
         return int(ww_duration*self.SAMPLE_RATE*self.SAMPLE_WIDTH)
-    
+
 class AudioTester:
     def __init__(self, samp_rate):
         print()  # Pad debug messages


### PR DESCRIPTION
## Description
Added duration_to_bytes to fix AttributeError: 'FileMockMicrophone' object has no attribute 'duration_to_bytes'
in call from mycroft-core/mycroft/client/speech/mic.py _wait_until_wake_word

## How to test
./start-mycroft.sh wakewordtest

## Contributor license agreement signed?
CLA [X] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
