### PR TITLE
Move CLA check to GitHub Action

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,42 @@
+name: Contributor License Agreement
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - master
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: CLA
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+    - name: Cache pip packages
+      uses: actions/cache@v2
+      env:
+        cache-name: cache-pypi-modules
+      with:
+        # pip cache files are stored in `~/.cache/pip` on Linux
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('requirements/requirements.txt', 'requirements/tests.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+    - name: Install CLA check script
+      run: |
+          git clone https://github.com/forslund/github-repo-cla
+          cd github-repo-cla
+          git checkout cd85a2f
+          pip install -r requirements.txt
+    - name: Check CLA
+      env:
+        GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+          cd github-repo-cla
+          python3 cla_script.py -b dev MycroftAI/mycroft-core

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,21 +8,6 @@ pipeline {
     }
     stages {
         // Run the build in the against the dev branch to check for compile errors
-        stage('Add CLA label to PR') {
-            options {
-                lock(resource: "lock_${env.JOB_NAME}")
-            }
-            environment {
-                //spawns GITHUB_USR and GITHUB_PSW environment variables
-                GITHUB=credentials('38b2e4a6-167a-40b2-be6f-d69be42c8190')
-            }
-            steps {
-                // Using an install of Github repo CLA tagger
-                // (https://github.com/forslund/github-repo-cla)
-                sh '~/github-repo-cla/mycroft-core-cla-check.sh'
-            }
-        }
-
         stage('Run Integration Tests') {
             when {
                 anyOf {


### PR DESCRIPTION
## Description
This runs the CLA check as a github action instead of as a stage in the Jenkins integration test pipeline. The benefit is that the authentication is much simpler to handle.

This can probably be improved somewhat but should hopefully keep the current functionality while allowing the Voight Kampff test suite to run.

## Contributor license agreement signed?
CLA [ x ]