### PR TITLE
Fix pip url for Python > 3.6

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -460,10 +460,10 @@ function install_venv() {
     $opt_python -m venv "${VIRTUALENV_ROOT}/" --without-pip
 
     # Check if old script for python 3.6 is needed
-    if "${VIRTUALENV_ROOT}/bin/${opt_python}" --version > /dev/null | grep " 3.6"; then
+    if "${VIRTUALENV_ROOT}/bin/${opt_python}" --version | grep " 3.6"; then
         GET_PIP_URL="https://bootstrap.pypa.io/pip/3.6/get-pip.py"
     else
-        GET_PIP_URL="https://bootstrap.pypa.io/pip/3.6/get-pip.py"
+        GET_PIP_URL="https://bootstrap.pypa.io/get-pip.py"
     fi
 
     # Force version of pip for reproducability, but there is nothing special


### PR DESCRIPTION
## Description
Fixes the url to fetch pip from on versions of Python > 3.6

## How to test
Ensure all Github Actions complete showing it installs correctly.

## Contributor license agreement signed?
- [x] CLA
