### PR TITLE
Bump requests to remove GPL from dependency tree

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-requests>=2.20.0,<2.26.0
+requests~=2.26.0
 gTTS>=2.2.2,<2.3.0
 PyAudio==0.2.11
 pyee==8.1.0


### PR DESCRIPTION

## Description
`requests` versions prior to 2.26.0 used a GPL licensed package Chardet.
This has been replaced with charset_normalizer (MIT license).

Thanks to the OVOS crew for spotting this:
https://github.com/OpenVoiceOS/ovos-core/pull/52

## How to test
- Automated tests pass

## Contributor license agreement signed?
- [x] CLA
