### PR TITLE
Remove skills dir symlink on --clean

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -28,7 +28,11 @@ TOP=$(pwd -L)
 function clean_mycroft_files() {
     echo '
 This will completely remove any files installed by mycroft (including pairing
-information).
+information). 
+
+NOTE: This will not remove Mimic (if you chose to compile it), or other files
+generated within the mycroft-core directory.
+
 Do you wish to continue? (y/n)'
     while true; do
         read -N1 -s key

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -38,6 +38,7 @@ Do you wish to continue? (y/n)'
             rm -f /var/tmp/mycroft_web_cache.json
             rm -rf "${TMPDIR:-/tmp}/mycroft"
             rm -rf "$HOME/.mycroft"
+            rm -f "skills"  # The Skills directory symlink
             sudo rm -rf "/opt/mycroft"
             exit 0
             ;;


### PR DESCRIPTION
## Description
Delete the `skills` symlink when `dev_setup.sh --clean` is executed.

Added note regarding files that won't be cleaned - this is anything in the mycroft-core directory eg mimic and .installed. However I still think it's worth removing the skills symlink as the target directory no longer exists.

Fixes #3084 

## How to test
run `--clean` and the skills directory symlink should be removed

## Contributor license agreement signed?
- [x] CLA
