### PR TITLE
Fix inconsistent hotwords configuration reference

### DIFF
--- a/mycroft/client/speech/hotword_factory.py
+++ b/mycroft/client/speech/hotword_factory.py
@@ -77,7 +77,7 @@ class HotWordEngine:
         self.key_phrase = str(key_phrase).lower()
 
         if config is None:
-            config = Configuration.get().get("hot_words", {})
+            config = Configuration.get().get("hotwords", {})
             config = config.get(self.key_phrase, {})
         self.config = config
 


### PR DESCRIPTION
## Description
Fixes Issue-3006 by correctly looking up phoneme_duration setting

## How to test
Set hotwords.{myword}.phoneme_duration to a larger value than 120 and see the recording of the wake word change length

## Contributor license agreement signed?
CLA [ x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
