### PR TITLE
Add pipewire check for Arch

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -377,7 +377,14 @@ function fedora_install() {
 
 
 function arch_install() {
-    $SUDO pacman -S --needed --noconfirm git python python-pip python-setuptools python-virtualenv python-gobject libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq pulseaudio pulseaudio-alsa
+        pkgs="git python python-pip python-setuptools python-virtualenv python-gobject libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq"
+
+    if ! pacman -Qs pipewire-pulse > /dev/null
+    then
+        pkgs="{pkgs} pulseaudio pulseaudio-alsa"
+    fi
+
+    $SUDO pacman -S --needed --noconfirm $pkgs
 
     pacman -Qs '^fann$' &> /dev/null || (
         git clone  https://aur.archlinux.org/fann.git


### PR DESCRIPTION
## Description
Fixes #2980 by running `pacman -Qs` to verify installation of pulseaudio -> pipewire compat layer.

## How to test
Run installation on Arch Linux install with and without `pipewire-pulse`, the script will print the list of packages being installed. `pulseaudio` and `pulseaudio-alma` should only exist when `pipewire-pulse` is not installed.

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
