### PR TITLE
Fix shellcheck error on Arch install command

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -387,7 +387,7 @@ function arch_install() {
         pkgs="{pkgs} pulseaudio pulseaudio-alsa"
     fi
 
-    $SUDO pacman -S --needed --noconfirm $pkgs
+    $SUDO pacman -S --needed --noconfirm "$pkgs"
 
     pacman -Qs '^fann$' &> /dev/null || (
         git clone  https://aur.archlinux.org/fann.git


### PR DESCRIPTION
## Description
Fixes shellcheck error from PR #3091 

## How to test
Shellcheck wasn't running on `dev_setup.sh` when those tests ran. It is now so automated tests should pass.

## Contributor license agreement signed?
- [x] Yes
