### PR TITLE
dev_setup: Give packages in separate args to pacman

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -380,14 +380,15 @@ function fedora_install() {
 
 
 function arch_install() {
-        pkgs="git python python-pip python-setuptools python-virtualenv python-gobject libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq"
+    pkgs=( git python python-pip python-setuptools python-virtualenv python-gobject libffi swig portaudio mpg123 screen flac curl icu libjpeg-turbo base-devel jq )
 
     if ! pacman -Qs pipewire-pulse > /dev/null
     then
-        pkgs="{pkgs} pulseaudio pulseaudio-alsa"
+        pulse_pkgs=( pulseaudio pulseaudio-alsa )
+        pkgs=( "${pkgs[@]}" "${pulse_pkgs[@]}" )
     fi
 
-    $SUDO pacman -S --needed --noconfirm "$pkgs"
+    $SUDO pacman -S --needed --noconfirm "${pkgs[@]}"
 
     pacman -Qs '^fann$' &> /dev/null || (
         git clone  https://aur.archlinux.org/fann.git


### PR DESCRIPTION
## Description
This makes sure the packages aren't clumped together into a single argument when using pacman to install packages for arch linux. Perhaps pacman handles this correctly (apt does not) but generally it's better to use an array instead of a string when sending arguments.

## Contributor license agreement signed?
CLA [ x ]