### PR TITLE
[RFC] speech: Add mycroft.mic.stop_record message

### DIFF
--- a/mycroft/audio/speech.py
+++ b/mycroft/audio/speech.py
@@ -81,7 +81,8 @@ def handle_speak(event):
             for chunk, listen in chunks:
                 # Check if somthing has aborted the speech
                 if (_last_stop_signal > start or
-                        check_for_signal('buttonPress')):
+                        check_for_signal('buttonPress') or
+                        check_for_signal('stopRecord')):
                     # Clear any newly queued speech
                     tts.playback.clear()
                     break

--- a/mycroft/client/speech/__main__.py
+++ b/mycroft/client/speech/__main__.py
@@ -29,6 +29,7 @@ from mycroft.util import (
 )
 from mycroft.util.log import LOG
 from mycroft.util.process_utils import ProcessStatus, StatusCallbackMap
+from mycroft.util.signal import create_signal
 
 bus = None  # Mycroft messagebus connection
 lock = Lock()
@@ -169,6 +170,11 @@ def handle_stop(event):
     loop.force_unmute()
 
 
+def handle_stop_record(event):
+    """Send a signal to stop recording."""
+    create_signal('stopRecord')
+
+
 def handle_open():
     # TODO: Move this into the Enclosure (not speech client)
     # Reset the UI to indicate ready for speech processing
@@ -212,6 +218,7 @@ def connect_bus_events(bus):
     bus.on('recognizer_loop:audio_output_start', handle_audio_start)
     bus.on('recognizer_loop:audio_output_end', handle_audio_end)
     bus.on('mycroft.stop', handle_stop)
+    bus.on('mycroft.mic.stop_record', handle_stop_record)
 
 
 def main(ready_hook=on_ready, error_hook=on_error, stopping_hook=on_stopping,

--- a/mycroft/client/speech/mic.py
+++ b/mycroft/client/speech/mic.py
@@ -460,7 +460,8 @@ class ResponsiveRecognizer(speech_recognition.Recognizer):
             # The phrase is complete if the noise_tracker end of sentence
             # criteria is met or if the  top-button is pressed
             phrase_complete = (noise_tracker.recording_complete() or
-                               check_for_signal('buttonPress'))
+                               check_for_signal('buttonPress') or
+                               check_for_signal('stopRecord'))
 
             # Periodically write the energy level to the mic level file.
             if num_chunks % 10 == 0:


### PR DESCRIPTION
If there's anything I forgot to add support for this message to (especially if it's in another component), please let me know.

## Description
Adds a new message, `mycroft.mic.stop_record`, which can be used by clients to force-stop recording from the mic, without having to use the buttonPressed signal.

## How to test
Send the `mycroft.mic.stop_record` signal

## Contributor license agreement signed?
CLA [X]
