### PR TITLE
Requirements: remove pychromecast

### DIFF
--- a/requirements/extra-audiobackend.txt
+++ b/requirements/extra-audiobackend.txt
@@ -1,2 +1,1 @@
-pychromecast==3.2.2
 python-vlc==1.1.2


### PR DESCRIPTION
## Description
Removes the now unused pychromecast requirement. Thanks to @j1nx for flagging that I missed removing it in #3097.

## Contributor license agreement signed?
CLA [ x ]