### PR TITLE
Sj201r5

### DIFF
--- a/mycroft/enclosure/hardware/Mark2.py
+++ b/mycroft/enclosure/hardware/Mark2.py
@@ -19,6 +19,13 @@ from mycroft.configuration import Configuration
 
 class Capabilities:
     capabilities = {
+        "sj201r5": {
+            "Led": {"name": "led_dummy", "type": "MycroftLed"},
+            "Switch": {"name": "switch_gpio", "type": "MycroftSwitch"},
+            "Volume": {"name": "volume_sj201r4", "type": "MycroftVolume"},
+            "Fan": {"name": "fan_sj201r5", "type": "MycroftFan"},
+            "Palette": {"name": "default_palette", "type": "MycroftPalette"},
+        },
         "sj201r4": {
             "Led": {"name": "led_sj201r4", "type": "MycroftLed"},
             "Switch": {"name": "switch_gpio", "type": "MycroftSwitch"},
@@ -59,4 +66,4 @@ class Capabilities:
         },
     }
 
-    default_board_type = "sj201r4"
+    default_board_type = "sj201r5"

--- a/mycroft/enclosure/hardware/MycroftFan/fan_sj201r5.py
+++ b/mycroft/enclosure/hardware/MycroftFan/fan_sj201r5.py
@@ -1,0 +1,69 @@
+import os
+import subprocess
+import RPi.GPIO as GPIO
+from time import sleep
+from mycroft.util.log import LOG
+
+class FanControl:
+    # hardware speed range is appx 30-255
+    # we convert from 0 to 100
+    HDW_MIN = 100
+    HDW_MAX = 0
+    SFW_MIN = 0
+    SFW_MAX = 100
+
+    def __init__(self):
+        self.fan_speed = 0
+        ledpin = 13                             # PWM pin connected to LED
+        GPIO.setwarnings(False)                 # disable warnings
+        GPIO.setmode(GPIO.BCM)                  # set pin numbering system
+        GPIO.setup(ledpin,GPIO.OUT)             # set direction
+        self.pi_pwm = GPIO.PWM(ledpin,1000)     # create PWM instance with frequency
+        self.pi_pwm.start(0)                    # start PWM of required Duty Cycle 
+        self.set_fan_speed(self.fan_speed)
+
+    def execute_cmd(self, cmd):
+        process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        out, err = process.communicate()
+
+        try:
+            out = out.decode("utf8")
+        except Exception:
+            pass
+
+        try:
+            err = err.decode("utf8")
+        except Exception:
+            pass
+
+        return out, err
+
+    def cToF(self, temp):
+        return (temp * 1.8) + 32
+
+    def speed_to_hdw_val(self, speed):
+        return float( 100.0 - (speed % 101) )
+
+    def hdw_val_to_speed(self, hdw_val):
+        return abs( float( hdw_val - 100.0 ) )
+
+    def hdw_set_speed(self, hdw_speed):
+        self.pi_pwm.ChangeDutyCycle(hdw_speed)        # provide duty cycle in the range 0-100
+
+    def set_fan_speed(self, speed):
+        self.fan_speed = self.speed_to_hdw_val(speed)
+        self.hdw_set_speed(self.fan_speed)
+
+    def get_fan_speed(self):
+        return self.hdw_val_to_speed(self.fan_speed)
+
+    def get_cpu_temp(self):
+        cmd = ["cat", "/sys/class/thermal/thermal_zone0/temp"]
+        out, err = self.execute_cmd(cmd)
+        return float(out.strip()) / 1000
+

--- a/mycroft/enclosure/hardware/MycroftLed/led_sj201r5.py
+++ b/mycroft/enclosure/hardware/MycroftLed/led_sj201r5.py
@@ -23,7 +23,6 @@ class Led(MycroftLed):
     black = (0, 0, 0)  # TODO pull from pallette
 
     def __init__(self):
-        LOG.error("SJ201R5!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!INIT")
         pixel_pin = board.D12
         ORDER = neopixel.GRB
         self.brightness = 0.2

--- a/mycroft/enclosure/hardware/MycroftLed/led_sj201r5.py
+++ b/mycroft/enclosure/hardware/MycroftLed/led_sj201r5.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Mycroft AI Inc.
+# Copyright 2020 Mycroft AI Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,21 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mycroft.enclosure.hardware.MockSMBus import MockSMBus
+import board
+import neopixel
 from mycroft.enclosure.hardware.MycroftLed.MycroftLed import MycroftLed
 from mycroft.util.log import LOG
 
 class Led(MycroftLed):
-    """A dummy LED control class used for testing.
-    """
     real_num_leds = 12  # physical
     num_leds = 10  # logical
     black = (0, 0, 0)  # TODO pull from pallette
-    device_addr = 0x04
 
     def __init__(self):
-        self.bus = MockSMBus()
-        self.brightness = 0.5
+        LOG.error("SJ201R5!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!INIT")
+        pixel_pin = board.D12
+        ORDER = neopixel.GRB
+        self.brightness = 0.2
+
+        self.pixels = neopixel.NeoPixel(
+            pixel_pin,
+            real_num_leds,
+            brightness=self.brightness,
+            auto_write=False,
+            pixel_order=ORDER
+        )
+
         self.capabilities = {
             "num_leds": self.num_leds,
             "brightness": "(0.0-1.0)",
@@ -47,6 +56,8 @@ class Led(MycroftLed):
         red_val = int(color[0])
         green_val = int(color[1])
         blue_val = int(color[2])
+        self.pixels[pixel] = (red_val, green_val, blue_val)
+        self.pixels.show()
 
     def _set_led_with_brightness(self, pixel, color, blevel):
         self._set_led(pixel, list(map(self.adjust_brightness, color, (blevel,) * 3)))
@@ -67,6 +78,8 @@ class Led(MycroftLed):
     def fill(self, color):
         """fill all leds with the same color"""
         rgb = [int(self.adjust_brightness(c, self.brightness)) for c in color[:3]]
+        self.pixels.fill(rgb)
+
 
     def set_leds(self, new_leds):
         """set leds from tuple array"""


### PR DESCRIPTION
## Description
Adds support for the sj201r5 board. this device reverts to neopixels for LEDs and pwm GPIO for fan.

## How to test
Install an sj201r5 board. Change the config file board type to sj201r5

## Contributor license agreement signed?
CLA [Y ]