### PR TITLE
Don't install pulseaudio-dev on Alpine Linux systems

### DIFF
--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -419,7 +419,7 @@ function gentoo_install() {
 }
 
 function alpine_install() {
-    $SUDO apk add --virtual makedeps-mycroft-core alpine-sdk git python3 py3-pip py3-setuptools py3-virtualenv mpg123 vorbis-tools pulseaudio-utils fann-dev automake autoconf libtool pcre2-dev pulseaudio-dev alsa-lib-dev swig python3-dev portaudio-dev libjpeg-turbo-dev
+    $SUDO apk add --virtual .makedeps-mycroft-core alpine-sdk git python3 py3-pip py3-setuptools py3-virtualenv mpg123 vorbis-tools pulseaudio-utils fann-dev automake autoconf libtool pcre2-dev pulseaudio-dev alsa-lib-dev swig python3-dev portaudio-dev libjpeg-turbo-dev
 }
 
 function install_deps() {

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -431,7 +431,6 @@ function alpine_install() {
 		mpg123 \
 		pcre2-dev \
 		portaudio-dev \
-		pulseaudio-dev \
 		pulseaudio-utils \
 		py3-pip \
 		py3-setuptools \

--- a/dev_setup.sh
+++ b/dev_setup.sh
@@ -419,7 +419,27 @@ function gentoo_install() {
 }
 
 function alpine_install() {
-    $SUDO apk add --virtual .makedeps-mycroft-core alpine-sdk git python3 py3-pip py3-setuptools py3-virtualenv mpg123 vorbis-tools pulseaudio-utils fann-dev automake autoconf libtool pcre2-dev pulseaudio-dev alsa-lib-dev swig python3-dev portaudio-dev libjpeg-turbo-dev
+    $SUDO apk add --virtual .makedeps-mycroft-core \
+		alpine-sdk \
+		alsa-lib-dev \
+		autoconf \
+		automake \
+		fann-dev \
+		git \
+		libjpeg-turbo-dev \
+		libtool \
+		mpg123 \
+		pcre2-dev \
+		portaudio-dev \
+		pulseaudio-dev \
+		pulseaudio-utils \
+		py3-pip \
+		py3-setuptools \
+		py3-virtualenv \
+		python3 \
+		python3-dev \
+		swig \
+		vorbis-tools
 }
 
 function install_deps() {


### PR DESCRIPTION
## Description
Don't install pulseaudio-dev on Alpine Linux systems as it doesn't actually seem to be required by any of the PyPi deps.

## How to test
Run `./dev_setup.sh` on an Alpine Linux system.

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
