### PR TITLE
Relax pyyaml version requirement

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,7 +12,7 @@ pocketsphinx==0.1.0
 pillow==8.3.2
 python-dateutil==2.6.0
 fasteners==0.14.1
-PyYAML==5.4
+PyYAML~=5.4
 
 lingua-franca==0.4.2
 msm==0.8.9


### PR DESCRIPTION
## Description
This specific version was failing on Debian Bullseye installs.
Using the `~=` operator allows for point release updates to this package.

Fixes #3117 

## How to test
Install mycroft-core on Debian Bullseye.

## Contributor license agreement signed?
- [x] CLA
