### PR TITLE
Replace / by _ in name to avoid issue when writing the cache file.

### DIFF
--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -23,6 +23,7 @@ from os import walk
 from os.path import join, abspath, dirname, basename, exists
 from pathlib import Path
 from threading import Event, Timer
+from hashlib import md5
 
 from xdg import BaseDirectory
 
@@ -1046,7 +1047,8 @@ class MycroftSkill:
         if not filename:
             raise FileNotFoundError('Unable to find "{}"'.format(entity_file))
 
-        name = '{}:{}_{}'.format(self.skill_id, basename(entity_file), str(hex(abs(hash(entity_file))))[2:])
+        name = '{}:{}_{}'.format(self.skill_id, basename(entity_file),
+            str(md5(entity_file.encode('utf-8')).hexdigest()))
         self.intent_service.register_padatious_entity(name, filename)
 
     def handle_enable_intent(self, message):

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1046,7 +1046,7 @@ class MycroftSkill:
         if not filename:
             raise FileNotFoundError('Unable to find "{}"'.format(entity_file))
 
-        name = '{}:{}'.format(self.skill_id, entity_file.replace("/", "_"))
+        name = '{}:{}_{}'.format(self.skill_id, basename(entity_file), str(hex(abs(hash(entity_file))))[2:])
         self.intent_service.register_padatious_entity(name, filename)
 
     def handle_enable_intent(self, message):

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1046,7 +1046,7 @@ class MycroftSkill:
         if not filename:
             raise FileNotFoundError('Unable to find "{}"'.format(entity_file))
 
-        name = '{}:{}'.format(self.skill_id, entity_file)
+        name = '{}:{}'.format(self.skill_id, entity_file.replace("/", "_"))
         self.intent_service.register_padatious_entity(name, filename)
 
     def handle_enable_intent(self, message):

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1048,7 +1048,7 @@ class MycroftSkill:
             raise FileNotFoundError('Unable to find "{}"'.format(entity_file))
 
         name = '{}:{}_{}'.format(self.skill_id, basename(entity_file),
-            str(md5(entity_file.encode('utf-8')).hexdigest()))
+                                 str(md5(entity_file.encode('utf-8')).hexdigest()))
         self.intent_service.register_padatious_entity(name, filename)
 
     def handle_enable_intent(self, message):

--- a/mycroft/skills/mycroft_skill/mycroft_skill.py
+++ b/mycroft/skills/mycroft_skill/mycroft_skill.py
@@ -1048,7 +1048,8 @@ class MycroftSkill:
             raise FileNotFoundError('Unable to find "{}"'.format(entity_file))
 
         name = '{}:{}_{}'.format(self.skill_id, basename(entity_file),
-                                 str(md5(entity_file.encode('utf-8')).hexdigest()))
+                                 str(md5(entity_file.encode('utf-8'))
+                                 .hexdigest()))
         self.intent_service.register_padatious_entity(name, filename)
 
     def handle_enable_intent(self, message):

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -352,7 +352,7 @@ class TestMycroftSkill(unittest.TestCase):
             {
                 'file_name': join(dirname(__file__), 'intent_file',
                                   'vocab', 'en-us', 'test_ent.entity'),
-                'name': str(s.skill_id) + ':test_ent'
+                'name': str(s.skill_id) + ':test_ent_87af9db6c8402bcfaa8ebc719ae4427c'
             }
         ]
         self.check_register_object_file(expected_types, expected_results)

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -111,7 +111,7 @@ class TestMycroftSkill(unittest.TestCase):
                          json.dumps(d2, sort_keys=True))
 
     def check_read_vocab_file(self, path, result_list=None):
-        resultlist = result_list or []
+        result_list = result_list or []
         self.assertEqual(sorted(read_vocab_file(path)), sorted(result_list))
 
     def check_regex(self, path, result_list=None):

--- a/test/unittests/skills/test_mycroft_skill.py
+++ b/test/unittests/skills/test_mycroft_skill.py
@@ -352,7 +352,8 @@ class TestMycroftSkill(unittest.TestCase):
             {
                 'file_name': join(dirname(__file__), 'intent_file',
                                   'vocab', 'en-us', 'test_ent.entity'),
-                'name': str(s.skill_id) + ':test_ent_87af9db6c8402bcfaa8ebc719ae4427c'
+                'name': str(s.skill_id) +
+                ':test_ent_87af9db6c8402bcfaa8ebc719ae4427c'
             }
         ]
         self.check_register_object_file(expected_types, expected_results)


### PR DESCRIPTION
## Description
The latest version of homeassistant skills builds an intent file and tries to register it.
However this fails with the following error message :

```
FANN Error 2: Unable to open configuration file "/home/mycroft/.local/share/mycroft/intent_cache/homeassistant.mycroftai:{/tmp/mycroft/cache/HomeAssistantSkill/tracker}.intent.net" for writing.
```

## How to test
Install the latest homeassitant skill (HEAD).

## Contributor license agreement signed?
CLA (7-23-2017)