### PR TITLE
Fix PWD directory of start script

### DIFF
--- a/start-mycroft.sh
+++ b/start-mycroft.sh
@@ -14,12 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SOURCE="$0"
-
 script=${0}
 script=${script##*/}
-cd -P "$( dirname "$SOURCE" )" || exit 1 # Enter scripts folder or fail!
-DIR="$( pwd )"
+
+DIR="$(realpath -- "$PWD")"
 VIRTUALENV_ROOT=${VIRTUALENV_ROOT:-"${DIR}/.venv"}
 
 help() {


### PR DESCRIPTION
## Description
Hi, I'm proposing a fix for issue #3137. 

For getting directory use `$PWD` and for getting directory of script which was caller use `$0`.

## How to test
Try to start Mycroft by calling `mycroft-start debug` and `sh start-mycroft.sh debug`

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
