### PR TITLE
Mycroft-config: Fix deprecated --tempfile in nano

### DIFF
--- a/bin/mycroft-config
+++ b/bin/mycroft-config
@@ -52,7 +52,8 @@ if [ -z "$EDITOR" ] ; then
     if which sensible-editor > /dev/null ; then
         EDITOR="sensible-editor"
     else
-        EDITOR="nano --syntax=json --tempfile"
+        # -t mean --saveonexit (--tempfile in pre 5.0 version)
+        EDITOR="nano --syntax=json -t"
     fi
 fi
 


### PR DESCRIPTION
## Description
As described in Issue #3124, `--tempfile` was deprecated in Nano version 5.0.

Switching to `--saveonexit` would break function on older versions (Ubuntu 20.04 LTS use 4.8 version).

Thankfully, the short version of those two is still the same `-t`. Using it will preserve function on older systems and fix function on newer ones. 

## How to test
Try to edit config.

## Contributor license agreement signed?
CLA [x] (Whether you have signed a [CLA - Contributor Licensing Agreement](https://mycroft.ai/cla/)
