### PR TITLE
fix(sec): upgrade psutil to 5.6.7

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ tornado~=6.1
 websocket-client~=1.2.1
 requests-futures==0.9.5
 pyserial==3.0
-psutil==5.6.6
+psutil==5.6.7
 pocketsphinx==0.1.0
 pillow==8.3.2
 python-dateutil==2.6.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in psutil 5.6.6
- [CVE-2019-18874](https://www.oscs1024.com/hd/CVE-2019-18874)


### What did I do？
Upgrade psutil from 5.6.6 to 5.6.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS